### PR TITLE
Declare HPOS compatibility for WooCommerce

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-attribution.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-attribution.php
@@ -50,9 +50,11 @@ class WC_AI_Syndication_Attribution {
 		// Display AI attribution data in admin order view.
 		add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'display_attribution_in_admin' ], 20, 1 );
 
-		// Add AI agent column to orders list (optional, lightweight).
+		// Add AI agent column to orders list — support both HPOS and legacy post type.
 		add_filter( 'manage_woocommerce_page_wc-orders_columns', [ $this, 'add_order_list_column' ] );
 		add_action( 'manage_woocommerce_page_wc-orders_custom_column', [ $this, 'render_order_list_column' ], 10, 2 );
+		add_filter( 'manage_edit-shop_order_columns', [ $this, 'add_order_list_column' ] );
+		add_action( 'manage_shop_order_posts_custom_column', [ $this, 'render_order_list_column' ], 10, 2 );
 	}
 
 	/**

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -27,6 +27,20 @@ define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __F
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );
 
 /**
+ * Declare compatibility with WooCommerce features.
+ *
+ * HPOS (custom_order_tables): This plugin uses WC_Order methods and
+ * wc_get_orders() for all order access — no direct post meta queries
+ * on shop_order posts. The get_stats() SQL query supports both HPOS
+ * and legacy tables with a runtime check.
+ */
+add_action( 'before_woocommerce_init', function () {
+	if ( class_exists( \Automattic\WooCommerce\Utilities\FeaturesUtil::class ) ) {
+		\Automattic\WooCommerce\Utilities\FeaturesUtil::declare_compatibility( 'custom_order_tables', __FILE__, true );
+	}
+} );
+
+/**
  * Initialize the plugin after WooCommerce is loaded.
  */
 function wc_ai_syndication_init() {


### PR DESCRIPTION
## Summary

- Plugin was showing as incompatible in WooCommerce because it was missing the HPOS compatibility declaration
- Add `FeaturesUtil::declare_compatibility('custom_order_tables')` on `before_woocommerce_init` hook
- Add legacy `shop_order` post type column hooks alongside HPOS hooks so the AI Agent column works on both order list screens

## Test plan
- [ ] Activate plugin on a WooCommerce site with HPOS enabled — no "incompatible" warning
- [ ] Activate plugin on a WooCommerce site with HPOS disabled (legacy) — no warning
- [ ] Verify AI Agent column appears in WooCommerce > Orders on both HPOS and legacy screens

🤖 Generated with [Claude Code](https://claude.ai/claude-code)