### PR TITLE
1.4.2: suppress canonical-URL redirect on llms.txt + UCP manifest

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -29,6 +29,40 @@ class WC_AI_Syndication_Llms_Txt {
 		add_action( 'init', [ $this, 'add_rewrite_rules' ] );
 		add_action( 'template_redirect', [ $this, 'serve_llms_txt' ] );
 		add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
+
+		// Suppress WordPress's canonical-URL trailing-slash redirect
+		// for this endpoint. With permalink structures like
+		// `/%postname%/` (the default on WordPress.com and most sites),
+		// WP's `redirect_canonical()` 301s `/llms.txt` → `/llms.txt/`
+		// on `template_redirect` at priority 10 — running BEFORE our
+		// serve handler at the same priority. AI browsing tools then
+		// either don't follow the redirect, or follow it to a URL
+		// that no longer matches our `^llms\.txt$` rewrite rule and
+		// falls through to a WordPress 404 HTML page.
+		//
+		// Returning false from the filter tells WP "this URL is
+		// already canonical — don't touch it." The query var gate
+		// ensures we only intercept canonical checks for requests
+		// the rewrite rule has already matched; all other canonical
+		// behavior across the site is untouched.
+		// Declaring 1 accepted arg (not the 2 WP passes) — we gate on
+		// the query var, not on the requested-URL string.
+		add_filter( 'redirect_canonical', [ $this, 'suppress_canonical_redirect' ], 10, 1 );
+	}
+
+	/**
+	 * Short-circuit canonical-URL redirects for the llms.txt endpoint.
+	 *
+	 * @param string|false $redirect_url The candidate canonical URL
+	 *                                   WordPress wants to redirect to.
+	 * @return string|false               False disables the redirect;
+	 *                                   original value otherwise.
+	 */
+	public function suppress_canonical_redirect( $redirect_url ) {
+		if ( get_query_var( 'wc_ai_syndication_llms_txt' ) ) {
+			return false;
+		}
+		return $redirect_url;
 	}
 
 	/**

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -64,6 +64,31 @@ class WC_AI_Syndication_Ucp {
 		add_action( 'init', [ $this, 'add_rewrite_rules' ] );
 		add_action( 'template_redirect', [ $this, 'serve_manifest' ] );
 		add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
+
+		// Defense-in-depth mirror of the canonical-redirect suppression
+		// applied to llms.txt (see the sibling class for the full
+		// rationale). `/.well-known/ucp` has been observed in the wild
+		// to be safe from `redirect_canonical()` on most permalink
+		// structures because the `.well-known` prefix is an unusual
+		// shape, but there's no harm in being explicit — especially
+		// on hosts with aggressive canonical enforcement like
+		// WordPress.com Atomic.
+		// See llms.txt sibling for the arg-count rationale.
+		add_filter( 'redirect_canonical', [ $this, 'suppress_canonical_redirect' ], 10, 1 );
+	}
+
+	/**
+	 * Short-circuit canonical-URL redirects for the manifest endpoint.
+	 *
+	 * @param string|false $redirect_url WP's candidate canonical URL.
+	 * @return string|false               False disables the redirect;
+	 *                                   original value otherwise.
+	 */
+	public function suppress_canonical_redirect( $redirect_url ) {
+		if ( get_query_var( 'wc_ai_syndication_ucp' ) ) {
+			return false;
+		}
+		return $redirect_url;
 	}
 
 	/**

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.4.1
+Stable tag: 1.4.2
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,9 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.4.2 =
+* Fixed: llms.txt and UCP manifest were being 301-redirected by WordPress's `redirect_canonical()` function on sites with trailing-slash permalink structures (the default on WordPress.com and most self-hosted sites). `GET /llms.txt` would return `HTTP/2 301 location: /llms.txt/` with `content-type: text/html`, and then the trailing-slash URL didn't match the plugin's `^llms\.txt$` rewrite rule — the request fell through to a WordPress 404 HTML page. AI browsing tools either didn't follow the redirect or choked on the HTML response at the destination. Diagnosed via `curl -I` output from a production site on WordPress.com Atomic which showed the telltale `x-redirect-by: WordPress` header. Added a `redirect_canonical` filter on both the llms.txt and UCP manifest endpoints that returns `false` when the respective query var is present, short-circuiting WordPress's trailing-slash enforcement for exactly these two URLs while leaving canonical behavior on every other page of the site untouched.
 
 = 1.4.1 =
 * Fixed: llms.txt was unreachable from AI browsing tools running in Chromium-based headless contexts (Gemini's browsing tool, ChatGPT browse, Claude web-search), because the endpoint sent no CORS headers. The UCP manifest at `/.well-known/ucp` already set `Access-Control-Allow-Origin: *` and worked fine; llms.txt was the asymmetric missing piece. Reports from agents: "my browsing tool is still having trouble 'seeing' the raw text files despite the robots.txt update" — the tool's fetch was silently blocked by same-origin policy. Added `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: GET, OPTIONS`, and a 204 handler for CORS preflight OPTIONS requests so browsing tools that preflight (some do, some don't) don't interpret a non-2xx preflight as "resource unreachable."

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.4.1
+ * Version: 1.4.2
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.4.1' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.4.2' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## The real bug

The 1.4.1 CORS fix was correct but couldn't help, because the plugin's serve handler was **never reached**. Production \`curl -I\` from pierorocca.com exposed the actual flow:

\`\`\`
HTTP/2 301
location: https://pierorocca.com/llms.txt/    ← trailing slash!
x-redirect-by: WordPress                       ← core canonical redirect
content-type: text/html
\`\`\`

WordPress's \`redirect_canonical()\` fires on \`template_redirect\` at priority 10 and 301s \`/llms.txt\` → \`/llms.txt/\` on any site with trailing-slash permalinks (the default on WP.com and most self-hosted sites). The destination \`/llms.txt/\` doesn't match our \`^llms\.txt$\` rewrite rule, so WP falls through to a 404 HTML page.

Gemini's browsing tool (and presumably others) either didn't follow the redirect or followed it to the HTML 404 and gave up.

## Fix

Add a \`redirect_canonical\` filter on both endpoints that returns \`false\` when our query var is set, gating the suppression to exactly the URLs we own. Applied to both llms.txt and UCP manifest — the manifest hasn't been seen to hit this in the wild, but being explicit costs nothing.

## Verification path

After merge, tag, and release:

\`\`\`bash
# Should return HTTP/2 200 (not 301) with content-type: text/plain
curl -I https://pierorocca.com/llms.txt

# Should still work (manifest was independent)
curl -I https://pierorocca.com/.well-known/ucp
\`\`\`

## Test plan
- [x] PHPCS: 0 errors, 0 warnings
- [x] PHPStan: clean
- [x] PHPUnit: 293 tests / 818 assertions pass
- [ ] After release + manual upload on pierorocca.com: curl shows 200, not 301
- [ ] After release: ask Gemini to read llms.txt — should succeed on first try
- [ ] After release: UCP manifest still works (no regression from the defensive filter)

## Why stack on 1.4.1 rather than roll back

The CORS fix from 1.4.1 is still needed — once canonical redirect stops interfering and the handler actually runs, CORS is what lets headless-browser contexts read the response. These two fixes are complementary; 1.4.2 depends on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)