### PR TITLE
1.4.3: actually wire the canonical-redirect filter (hotfix for 1.4.2)

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -23,34 +23,6 @@ class WC_AI_Syndication_Llms_Txt {
 	const CACHE_KEY = 'wc_ai_syndication_llms_txt';
 
 	/**
-	 * Initialize hooks.
-	 */
-	public function init() {
-		add_action( 'init', [ $this, 'add_rewrite_rules' ] );
-		add_action( 'template_redirect', [ $this, 'serve_llms_txt' ] );
-		add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
-
-		// Suppress WordPress's canonical-URL trailing-slash redirect
-		// for this endpoint. With permalink structures like
-		// `/%postname%/` (the default on WordPress.com and most sites),
-		// WP's `redirect_canonical()` 301s `/llms.txt` → `/llms.txt/`
-		// on `template_redirect` at priority 10 — running BEFORE our
-		// serve handler at the same priority. AI browsing tools then
-		// either don't follow the redirect, or follow it to a URL
-		// that no longer matches our `^llms\.txt$` rewrite rule and
-		// falls through to a WordPress 404 HTML page.
-		//
-		// Returning false from the filter tells WP "this URL is
-		// already canonical — don't touch it." The query var gate
-		// ensures we only intercept canonical checks for requests
-		// the rewrite rule has already matched; all other canonical
-		// behavior across the site is untouched.
-		// Declaring 1 accepted arg (not the 2 WP passes) — we gate on
-		// the query var, not on the requested-URL string.
-		add_filter( 'redirect_canonical', [ $this, 'suppress_canonical_redirect' ], 10, 1 );
-	}
-
-	/**
 	 * Short-circuit canonical-URL redirects for the llms.txt endpoint.
 	 *
 	 * @param string|false $redirect_url The candidate canonical URL

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -58,26 +58,6 @@ class WC_AI_Syndication_Ucp {
 	const CACHE_KEY = 'wc_ai_syndication_ucp';
 
 	/**
-	 * Initialize hooks.
-	 */
-	public function init() {
-		add_action( 'init', [ $this, 'add_rewrite_rules' ] );
-		add_action( 'template_redirect', [ $this, 'serve_manifest' ] );
-		add_filter( 'query_vars', [ $this, 'add_query_vars' ] );
-
-		// Defense-in-depth mirror of the canonical-redirect suppression
-		// applied to llms.txt (see the sibling class for the full
-		// rationale). `/.well-known/ucp` has been observed in the wild
-		// to be safe from `redirect_canonical()` on most permalink
-		// structures because the `.well-known` prefix is an unusual
-		// shape, but there's no harm in being explicit — especially
-		// on hosts with aggressive canonical enforcement like
-		// WordPress.com Atomic.
-		// See llms.txt sibling for the arg-count rationale.
-		add_filter( 'redirect_canonical', [ $this, 'suppress_canonical_redirect' ], 10, 1 );
-	}
-
-	/**
 	 * Short-circuit canonical-URL redirects for the manifest endpoint.
 	 *
 	 * @param string|false $redirect_url WP's candidate canonical URL.

--- a/includes/class-wc-ai-syndication.php
+++ b/includes/class-wc-ai-syndication.php
@@ -155,6 +155,19 @@ class WC_AI_Syndication {
 		add_action( 'template_redirect', [ $llms_txt, 'serve_llms_txt' ] );
 		add_action( 'template_redirect', [ $ucp, 'serve_manifest' ] );
 
+		// Suppress WordPress's trailing-slash canonical redirect for
+		// the discovery endpoints. On sites with trailing-slash
+		// permalink structures (the default on WordPress.com and
+		// most self-hosted installs), core would otherwise 301 the
+		// unslashed URL to a slashed variant that no longer matches
+		// our rewrite rule — the redirected request falls through to
+		// a 404 HTML page and AI browsing tools give up. The filter
+		// returns false only when the corresponding query var is
+		// set, so canonical behavior elsewhere on the site is
+		// untouched.
+		add_filter( 'redirect_canonical', [ $llms_txt, 'suppress_canonical_redirect' ], 10, 1 );
+		add_filter( 'redirect_canonical', [ $ucp, 'suppress_canonical_redirect' ], 10, 1 );
+
 		// Flush rewrite rules and bust content caches when needed:
 		//
 		// 1. After a plugin code update (stored version on disk differs

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.4.2
+Stable tag: 1.4.3
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,9 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.4.3 =
+* Fixed: 1.4.2's canonical-redirect fix didn't actually register, because the `redirect_canonical` filter was added inside the llms.txt/UCP classes' `init()` method — and those `init()` methods had been silently unused since an earlier refactor moved their hook registrations to the main plugin class. Production `curl -I` after the 1.4.2 deploy still showed `HTTP/2 301 location: .../llms.txt/` with `x-redirect-by: WordPress`, confirming the filter was never attached. Moved the filter registration to the main plugin class (`WC_AI_Syndication::register_rewrite_rules()`) alongside the other hooks for these two classes. Deleted the now-empty `init()` methods from both `WC_AI_Syndication_Llms_Txt` and `WC_AI_Syndication_Ucp` to prevent future changes to those methods from silently doing nothing.
 
 = 1.4.2 =
 * Fixed: llms.txt and UCP manifest were being 301-redirected by WordPress's `redirect_canonical()` function on sites with trailing-slash permalink structures (the default on WordPress.com and most self-hosted sites). `GET /llms.txt` would return `HTTP/2 301 location: /llms.txt/` with `content-type: text/html`, and then the trailing-slash URL didn't match the plugin's `^llms\.txt$` rewrite rule — the request fell through to a WordPress 404 HTML page. AI browsing tools either didn't follow the redirect or choked on the HTML response at the destination. Diagnosed via `curl -I` output from a production site on WordPress.com Atomic which showed the telltale `x-redirect-by: WordPress` header. Added a `redirect_canonical` filter on both the llms.txt and UCP manifest endpoints that returns `false` when the respective query var is present, short-circuiting WordPress's trailing-slash enforcement for exactly these two URLs while leaving canonical behavior on every other page of the site untouched.

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.4.2
+ * Version: 1.4.3
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.4.2' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.4.3' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## What happened

1.4.2 added a \`redirect_canonical\` filter inside \`WC_AI_Syndication_Llms_Txt::init()\` and \`WC_AI_Syndication_Ucp::init()\`.

**But those \`init()\` methods are dead code.** The main plugin class (\`WC_AI_Syndication::register_rewrite_rules()\`) registers every hook for these two classes directly — it never calls their \`init()\` methods. This has been true since an earlier refactor; the \`init()\` methods stuck around as cargo-culted scaffolding.

So the filter never attached. Production \`curl -I\` after 1.4.2 deploy confirmed:

\`\`\`
HTTP/2 301
location: https://pierorocca.com/llms.txt/
x-redirect-by: WordPress
\`\`\`

## Fix

1. Register the two filters in the main plugin class where all other hooks for these classes already live.
2. **Delete** the dead \`init()\` methods so future changes naturally go to the right place.

The filter callbacks themselves (\`suppress_canonical_redirect()\`) are correct and remain untouched.

## Why no test

The gap is integration wiring — "is this filter actually attached when the plugin boots?" Unit tests validate methods in isolation and can't catch "hook-registered-but-to-a-method-that-never-runs" bugs. The authoritative smoke test is \`curl -I\` after deploy.

## Test plan
- [x] PHPCS clean
- [x] PHPStan clean
- [x] PHPUnit: 293 tests / 818 assertions pass
- [ ] After merge, tag, release, and manual zip upload on pierorocca.com: \`curl -I https://pierorocca.com/llms.txt\` returns 200 + \`content-type: text/plain\` + CORS headers (not 301)
- [ ] After that succeeds: ask Gemini to read the file

🤖 Generated with [Claude Code](https://claude.com/claude-code)