### PR TITLE
1.4.4: heal poisoned empty-string llms.txt cache + drop noindex

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -86,9 +86,15 @@ class WC_AI_Syndication_Llms_Txt {
 	 *   refresh on the same cadence, so the merchant never sees a stale
 	 *   file served while the internal cache has been rebuilt.
 	 *
-	 * - `X-Robots-Tag: noindex`: keeps the file out of search results.
-	 *   llms.txt is machine-readable guidance for AI agents, not a page
-	 *   that merchants or shoppers should land on via Google.
+	 * (No `X-Robots-Tag: noindex`): earlier revisions set noindex to
+	 * keep llms.txt out of human-facing search results, but 1.4.4
+	 * dropped it. Some AI browsing tools (notably Gemini) appear to
+	 * use Google's search index as a discovery layer — when they
+	 * find a URL in the index they'll fetch it; when the URL is
+	 * noindexed they never try. Because llms.txt exists specifically
+	 * to be discovered, noindex was working against the plugin's
+	 * own purpose. Agents that go direct to `/llms.txt` continue to
+	 * work either way; agents that search-first now work too.
 	 */
 	public function serve_llms_txt() {
 		if ( ! get_query_var( 'wc_ai_syndication_llms_txt' ) ) {
@@ -103,7 +109,6 @@ class WC_AI_Syndication_Llms_Txt {
 
 		header( 'Content-Type: text/plain; charset=utf-8' );
 		header( 'Cache-Control: public, max-age=3600' );
-		header( 'X-Robots-Tag: noindex' );
 		header( 'X-Content-Type-Options: nosniff' );
 		header( 'Access-Control-Allow-Origin: *' );
 		header( 'Access-Control-Allow-Methods: GET, OPTIONS' );
@@ -123,18 +128,41 @@ class WC_AI_Syndication_Llms_Txt {
 	/**
 	 * Get cached llms.txt content, regenerating if expired.
 	 *
+	 * Cache-hit detection must exclude both `false` (the transient
+	 * miss sentinel) AND empty strings. Before 1.4.4 the check was
+	 * `false !== $cached`, which treated an empty cached string as
+	 * a valid hit — a real bug that surfaced in production:
+	 * `generate()` had captured empty content during a transient
+	 * bad state (likely a handler that never ran because of the
+	 * 1.4.2 wiring bug), and the empty value stuck in the cache for
+	 * the full 1-hour TTL, serving blank responses even after every
+	 * upstream fix.
+	 *
+	 * Defensive matching pair: we also refuse to write empty content
+	 * into the cache in the first place, so a single bad
+	 * generate() call can't poison the next hour of responses.
+	 *
 	 * @return string Markdown content.
 	 */
 	private function get_cached_content() {
 		$cached = get_transient( self::CACHE_KEY );
-		if ( false !== $cached ) {
+		if ( false !== $cached && '' !== $cached ) {
 			WC_AI_Syndication_Logger::debug( 'llms.txt cache hit' );
 			return $cached;
 		}
 
 		WC_AI_Syndication_Logger::debug( 'llms.txt cache miss — regenerating' );
 		$content = $this->generate();
-		set_transient( self::CACHE_KEY, $content, HOUR_IN_SECONDS );
+
+		// Only cache non-empty content. Caching an empty string would
+		// re-create the poisoning scenario the cache-hit check above
+		// now defends against; belt + suspenders.
+		if ( '' !== $content ) {
+			set_transient( self::CACHE_KEY, $content, HOUR_IN_SECONDS );
+		} else {
+			WC_AI_Syndication_Logger::debug( 'llms.txt generate() returned empty — not caching' );
+		}
+
 		return $content;
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.4.3
+Stable tag: 1.4.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,10 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.4.4 =
+* Fixed: llms.txt served an empty body on sites whose transient cache had been poisoned with an empty string during an earlier broken state (most likely during the 1.4.2 wiring-bug window before 1.4.3 shipped). The cache-hit check was `if ( false !== $cached )`, which passed for `''` because empty-string !== false — so the poisoned value was served verbatim for the full 1-hour TTL even after every upstream fix was in place. Production `curl -I` showed 200 with all the right headers (CORS, text/plain, no 301), but `curl` (GET without -I) returned nothing. Fix hardens the cache path on both halves: treat empty/falsy cached values as a miss (forcing regeneration + a fresh cache write that heals the poison), and refuse to write empty generate() output back into the cache (prevents future poisoning from the same root cause). New unit tests lock in both halves so a partial refactor can't re-introduce the bug.
+* Changed: removed `X-Robots-Tag: noindex` from the llms.txt response. Earlier revisions set it defensively to keep the URL out of human-facing search results, but some AI browsing tools (Gemini reported this explicitly) use Google's search index as a discovery layer — they find URLs via search first, then fetch. A noindexed URL never enters the index, so those agents never try to fetch it. Since llms.txt exists specifically to be discovered by agents, nulling its search-indexability contradicts the plugin's own purpose. Agents that go direct to `/llms.txt` (the spec-canonical path) are unaffected; agents that search-first now work too. Merchants who want llms.txt kept out of search can reinstate the header via a `send_headers` filter in their own code.
 
 = 1.4.3 =
 * Fixed: 1.4.2's canonical-redirect fix didn't actually register, because the `redirect_canonical` filter was added inside the llms.txt/UCP classes' `init()` method — and those `init()` methods had been silently unused since an earlier refactor moved their hook registrations to the main plugin class. Production `curl -I` after the 1.4.2 deploy still showed `HTTP/2 301 location: .../llms.txt/` with `x-redirect-by: WordPress`, confirming the filter was never attached. Moved the filter registration to the main plugin class (`WC_AI_Syndication::register_rewrite_rules()`) alongside the other hooks for these two classes. Deleted the now-empty `init()` methods from both `WC_AI_Syndication_Llms_Txt` and `WC_AI_Syndication_Ucp` to prevent future changes to those methods from silently doing nothing.

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -311,4 +311,97 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( '## Custom Extension', $output );
 		$this->assertStringContainsString( 'Injected by third party.', $output );
 	}
+
+	// ------------------------------------------------------------------
+	// Cache-hit semantics — the 1.4.4 empty-string regression
+	// ------------------------------------------------------------------
+	//
+	// These tests lock in the defense against the bug that shipped in
+	// production before 1.4.4: the cache-hit check was `false !== $cached`,
+	// which treated an empty-string transient as a valid hit rather than
+	// a miss. If anything ever poisoned the cache with `''` (and one did,
+	// during the 1.4.2 wiring-bug window), blank responses were served
+	// for the full 1-hour TTL. The fix is a pair: treat empty as miss on
+	// read, refuse to write empty on the update path. These tests cover
+	// both halves so a future refactor that only restores one of them
+	// leaves a broken build.
+	//
+	// `get_cached_content()` is private by design; reflection is the
+	// least-invasive way to exercise it without altering visibility.
+
+	public function test_empty_cached_value_is_treated_as_miss(): void {
+		Functions\when( 'get_transient' )->justReturn( '' );
+		$set_transient_called_with = null;
+		Functions\when( 'set_transient' )->alias(
+			static function ( $key, $value ) use ( &$set_transient_called_with ) {
+				$set_transient_called_with = [
+					'key'   => $key,
+					'value' => $value,
+				];
+				return true;
+			}
+		);
+
+		$result = $this->invoke_private( 'get_cached_content' );
+
+		// Non-empty content was produced by regeneration — proves the
+		// empty cached value did NOT short-circuit the lookup.
+		$this->assertNotSame( '', $result );
+		$this->assertStringContainsString( '# Example Store', $result );
+
+		// The fresh non-empty content was written back to the cache,
+		// healing the poisoned state on first request.
+		$this->assertNotNull( $set_transient_called_with );
+		$this->assertNotSame( '', $set_transient_called_with['value'] );
+	}
+
+	public function test_valid_cached_value_is_returned_verbatim(): void {
+		Functions\when( 'get_transient' )->justReturn( "# Cached Content\n\nHello from cache." );
+		Functions\when( 'set_transient' )->justReturn( true );
+
+		$result = $this->invoke_private( 'get_cached_content' );
+
+		// Verbatim return — we did NOT fall through to regeneration
+		// when a valid cached value was present.
+		$this->assertSame( "# Cached Content\n\nHello from cache.", $result );
+	}
+
+	public function test_empty_generated_content_is_not_written_to_cache(): void {
+		Functions\when( 'get_transient' )->justReturn( false ); // Fresh miss.
+		$set_transient_calls = 0;
+		Functions\when( 'set_transient' )->alias(
+			static function () use ( &$set_transient_calls ) {
+				++$set_transient_calls;
+				return true;
+			}
+		);
+		// Force generate() to return empty by having the filter nuke
+		// the lines array. This is the only realistic path to empty
+		// output given generate()'s always-produces-skeleton design;
+		// if a future refactor introduces other empty paths, this
+		// test still catches them via the set_transient observation.
+		Functions\when( 'apply_filters' )->alias(
+			static function ( $hook, $lines ) {
+				return ( 'wc_ai_syndication_llms_txt_lines' === $hook ) ? [] : $lines;
+			}
+		);
+
+		$result = $this->invoke_private( 'get_cached_content' );
+
+		$this->assertSame( '', $result, 'generate() should have returned empty in this setup.' );
+		$this->assertSame( 0, $set_transient_calls, 'Empty content must not be cached — would poison the TTL window.' );
+	}
+
+	/**
+	 * Invoke a private method on the LlmsTxt instance via reflection.
+	 *
+	 * @param string $method Method name.
+	 * @return mixed          Return value of the method.
+	 */
+	private function invoke_private( string $method ) {
+		$reflection = new ReflectionClass( $this->llms );
+		$m          = $reflection->getMethod( $method );
+		$m->setAccessible( true );
+		return $m->invoke( $this->llms );
+	}
 }

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.4.3
+ * Version: 1.4.4
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.4.3' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.4.4' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## The bug that was hiding behind four previous fixes

Production \`curl -I\` showed 200 + every correct header (CORS, text/plain, no canonical redirect). Production \`curl\` (body) returned nothing. 

Root cause in \`get_cached_content()\`:

\`\`\`php
\$cached = get_transient( self::CACHE_KEY );
if ( false !== \$cached ) {     // ← '' !== false → this passes
    return \$cached;              // ← returns '' forever
}
\`\`\`

Classic WP transient footgun: \`get_transient()\` returns \`false\` on miss, but any other falsy value is treated as a valid hit. An empty string had been cached — likely during the 1.4.2 wiring-bug window when the handler ran in a partially-broken state — and was being served verbatim for the full 1-hour TTL.

## Fix

Harden both halves of the cache lifecycle:

1. **Read**: \`if ( false !== \$cached && '' !== \$cached )\` — empty is treated as miss, forcing regeneration.
2. **Write**: refuse to cache an empty \`generate()\` result — prevents future poisoning.

Three unit tests lock in the behavior so a partial revert leaves a broken build.

## Also: drop \`X-Robots-Tag: noindex\`

Gemini reported "not in search index" during our debugging — revealing that at least one AI browsing tool uses Google's search index as a discovery layer. A noindex'd URL never enters the index → those agents never find the file. Since llms.txt is *designed* to be discovered, this was contradicting the plugin's own purpose.

## Why this wasn't caught earlier

This is exactly the kind of regression unit tests CAN catch (unlike the 1.4.2 hook-wiring bug which was integration-only). The gap was that the existing tests covered \`generate()\` (pure content) but not \`get_cached_content()\` (cache-lifecycle semantics). 1.4.4 closes that gap with reflection-based private-method tests.

## Test plan
- [x] PHPCS clean
- [x] PHPStan clean
- [x] PHPUnit: **296 tests / 825 assertions** (was 293/818)
- [ ] After deploy + manual zip upload: \`curl https://pierorocca.com/llms.txt?v=final\` returns markdown content starting with \`# Example Store\` or similar — NOT empty
- [ ] After confirming body: ask Gemini to read \`https://pierorocca.com/llms.txt\`. Should succeed on first try this time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)