### PR TITLE
1.4.5: add store_context to UCP manifest, pin spec URL

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -165,9 +165,19 @@ class WC_AI_Syndication_Ucp {
 	 * trip. UCP schema permits `config` as additionalProperties on
 	 * any entity, so strict consumers ignore it gracefully.
 	 *
+	 * A sibling `store_context` object declares merchant-level
+	 * context (currency, locale, country, tax/shipping posture) so
+	 * agents know what currency they'll be quoting in and whether
+	 * the catalog price matches the checkout price — without having
+	 * to either fetch llms.txt first or call the Store API. Added in
+	 * 1.4.5 in response to cross-agent review feedback that surfaced
+	 * this as the dominant manifest-level gap. See
+	 * `build_store_context()` for field-by-field rationale.
+	 *
 	 * Not included (deliberately):
-	 *   - Store metadata (name, description, currency): redundant
-	 *     with Store API responses and llms.txt.
+	 *   - Store name/description: redundant with Store API responses
+	 *     and llms.txt. The store_context block is for commerce-
+	 *     semantic hints only, not human-readable metadata.
 	 *   - Rate limits: enforced through HTTP 429 / Retry-After
 	 *     response headers, not manifest advertisement.
 	 *   - Pointers to llms.txt / sitemap: agents find llms.txt at
@@ -185,7 +195,7 @@ class WC_AI_Syndication_Ucp {
 		$ucp_endpoint = rest_url( 'wc/ucp/v1' );
 
 		$manifest = [
-			'ucp' => [
+			'ucp'           => [
 				'version'          => self::PROTOCOL_VERSION,
 
 				// Services — single REST binding at our UCP namespace.
@@ -196,7 +206,20 @@ class WC_AI_Syndication_Ucp {
 					self::SERVICE_NAME => [
 						[
 							'version'   => self::PROTOCOL_VERSION,
-							'spec'      => 'https://github.com/Universal-Commerce-Protocol/ucp/tree/main/source/schemas/shopping',
+
+							// Pin the spec URL to the git tag that
+							// matches our declared PROTOCOL_VERSION.
+							// The UCP spec repo publishes date-named
+							// tags (e.g. `v2026-04-08`) that align
+							// with the protocol version string, so
+							// one constant drives both — if we bump
+							// PROTOCOL_VERSION the URL tracks
+							// automatically. Pre-1.4.5 this pointed
+							// at `/tree/main/` which is a moving
+							// target; a consumer verifying our shape
+							// a year later could have been reading
+							// a spec revision we never conformed to.
+							'spec'      => 'https://github.com/Universal-Commerce-Protocol/ucp/tree/v' . self::PROTOCOL_VERSION . '/source/schemas/shopping',
 							'transport' => 'rest',
 							'endpoint'  => $ucp_endpoint,
 
@@ -299,6 +322,15 @@ class WC_AI_Syndication_Ucp {
 				// checkout handles payment via their configured gateway.
 				'payment_handlers' => (object) [],
 			],
+
+			// Merchant-level commerce context. Sibling to `ucp`
+			// rather than nested inside, because these facts are
+			// agnostic of the UCP spec — any AI-commerce ecosystem
+			// tool (UCP-aware or not) can read them. Fields match
+			// common ecommerce-platform conventions (Stripe, Shopify)
+			// so consumer code already familiar with those names
+			// reads our manifest without a glossary step.
+			'store_context' => $this->build_store_context(),
 		];
 
 		/**
@@ -309,5 +341,71 @@ class WC_AI_Syndication_Ucp {
 		 * @param array $settings The AI syndication settings.
 		 */
 		return apply_filters( 'wc_ai_syndication_ucp_manifest', $manifest, $settings );
+	}
+
+	/**
+	 * Build the merchant-level commerce context block.
+	 *
+	 * Declares the store's currency, locale, base country, and
+	 * commerce-posture facts (tax inclusion, shipping enablement)
+	 * that agents need to know BEFORE they start consuming catalog
+	 * data — not after. Pre-1.4.5 this information lived only in
+	 * llms.txt (currency) and Store API responses (tax posture
+	 * on per-price endpoints), leaving agents who only fetched the
+	 * UCP manifest flying blind on basic commerce semantics.
+	 *
+	 * Field notes:
+	 *
+	 *   - `currency`: ISO 4217. Source of truth is WooCommerce's
+	 *     stored currency setting; drives every price string on
+	 *     the store.
+	 *
+	 *   - `locale`: BCP 47 form (`en-US`). WordPress stores locale
+	 *     in ICU underscore form (`en_US`); we convert for standards
+	 *     compatibility — HTTP `Accept-Language`, browser
+	 *     `navigator.language`, and most web APIs expect hyphens.
+	 *
+	 *   - `country`: ISO 3166-1 alpha-2. The merchant's base
+	 *     country, which controls default tax and shipping behavior.
+	 *     Not the customer's country — an AI agent talking to a
+	 *     customer in France buying from a US-based store should
+	 *     see `country: US` here.
+	 *
+	 *   - `prices_include_tax`: boolean. Tells agents whether the
+	 *     price string they see on catalog endpoints already
+	 *     includes tax, or whether tax will be added at checkout.
+	 *     This is THE critical signal for agents quoting totals
+	 *     honestly to users. VAT-inclusive storefronts (common in
+	 *     EU) return `true`; US-style tax-exclusive storefronts
+	 *     return `false`.
+	 *
+	 *   - `shipping_enabled`: boolean. Whether the store collects
+	 *     shipping addresses at checkout. `false` → digital-only
+	 *     or in-person-only store; agents can skip shipping
+	 *     prompts. Detected via `wc_shipping_enabled()`, which
+	 *     reflects the top-level WC shipping toggle.
+	 *
+	 * @return array The store context block.
+	 */
+	private function build_store_context() {
+		$country = null;
+		if ( function_exists( 'WC' ) && WC() && method_exists( WC(), 'countries' ) && WC()->countries ) {
+			$country = WC()->countries->get_base_country();
+		}
+
+		// `get_locale()` returns ICU format (e.g. `en_US`). BCP 47
+		// uses hyphens. Swap the single underscore delimiter; if
+		// future WP releases add more (e.g. script subtags), the
+		// conversion still holds because BCP 47 also uses hyphens
+		// for those.
+		$locale = str_replace( '_', '-', get_locale() );
+
+		return [
+			'currency'           => get_woocommerce_currency(),
+			'locale'             => $locale,
+			'country'            => $country ? $country : null,
+			'prices_include_tax' => (bool) wc_prices_include_tax(),
+			'shipping_enabled'   => (bool) wc_shipping_enabled(),
+		];
 	}
 }

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.4.4
+Stable tag: 1.4.5
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,11 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.4.5 =
+* Added: `store_context` top-level block in the UCP manifest declaring merchant-level commerce context — `currency` (ISO 4217), `locale` (BCP 47), `country` (ISO 3166-1 alpha-2), `prices_include_tax` (boolean), `shipping_enabled` (boolean). Pre-1.4.5 agents fetching only the UCP manifest couldn't tell what currency they'd be quoting in, whether catalog prices already included tax, or whether the store needed shipping addresses — they'd have to fall back to llms.txt or a Store API probe. Added in response to cross-agent review feedback from Claude that called out this as the dominant manifest-level gap: "for the CLDR project you're thinking about, this is exactly the gap — an agent has no machine-readable way to know what currency it'll be quoting in." The block is a sibling to `ucp` rather than nested inside it, because the facts are agnostic of the UCP spec — any AI-commerce tool (UCP-aware or not) reads them.
+* Changed: UCP spec URL in the service binding now pins to the tagged spec revision matching `PROTOCOL_VERSION` (`tree/v2026-04-08/source/schemas/shopping`) instead of the moving `main` branch. A consumer verifying our manifest against the spec a year from now reads the exact revision we conformed to — not whatever HEAD happens to be. The UCP spec repo tags follow the same date-versioning as the protocol version, so bumping `PROTOCOL_VERSION` automatically tracks the URL; no extra coupling to maintain.
+* Added: locale conversion from WordPress ICU form (`en_US`, underscore) to BCP 47 form (`en-US`, hyphen) for the manifest's `store_context.locale` field. Web-ecosystem consumers (HTTP `Accept-Language`, browser `navigator.language`, most APIs) expect hyphens; WordPress stores with underscores. The boundary conversion happens here so agents see the standards-compliant form.
 
 = 1.4.4 =
 * Fixed: llms.txt served an empty body on sites whose transient cache had been poisoned with an empty string during an earlier broken state (most likely during the 1.4.2 wiring-bug window before 1.4.3 shipped). The cache-hit check was `if ( false !== $cached )`, which passed for `''` because empty-string !== false — so the poisoned value was served verbatim for the full 1-hour TTL even after every upstream fix was in place. Production `curl -I` showed 200 with all the right headers (CORS, text/plain, no 301), but `curl` (GET without -I) returned nothing. Fix hardens the cache path on both halves: treat empty/falsy cached values as a miss (forcing regeneration + a fresh cache write that heals the poison), and refuse to write empty generate() output back into the cache (prevents future poisoning from the same root cause). New unit tests lock in both halves so a partial refactor can't re-introduce the bug.

--- a/tests/php/unit/UcpTest.php
+++ b/tests/php/unit/UcpTest.php
@@ -44,6 +44,17 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 			static fn( $path ) => 'https://example.com/wp-json/' . ltrim( $path, '/' )
 		);
 		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		// Store-context defaults. Individual tests override via
+		// Functions\when() to exercise specific scenarios (e.g.
+		// VAT-inclusive EU store, digital-only catalog).
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		Functions\when( 'get_locale' )->justReturn( 'en_US' );
+		Functions\when( 'wc_prices_include_tax' )->justReturn( false );
+		Functions\when( 'wc_shipping_enabled' )->justReturn( true );
+		// WC() isn't stubbed — `build_store_context()` falls through
+		// to `country => null` when the global function isn't
+		// available. Specific country-testing scenarios stub it.
 	}
 
 	protected function tearDown(): void {
@@ -193,12 +204,19 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 
 	public function test_spec_url_points_to_ucp_shopping_schema(): void {
 		// Points agents at the UCP shopping schema repo so they can
-		// verify our wire format matches what they expect.
+		// verify our wire format matches what they expect. Since
+		// 1.4.5 the URL pins to the tagged spec revision matching
+		// our `PROTOCOL_VERSION` (see the dedicated pinning test
+		// in the store_context section for the rationale).
 		$manifest = $this->ucp->generate_manifest( [] );
 		$binding  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
 
-		$this->assertEquals(
-			'https://github.com/Universal-Commerce-Protocol/ucp/tree/main/source/schemas/shopping',
+		$this->assertStringStartsWith(
+			'https://github.com/Universal-Commerce-Protocol/ucp/tree/',
+			$binding['spec']
+		);
+		$this->assertStringEndsWith(
+			'/source/schemas/shopping',
 			$binding['spec']
 		);
 	}
@@ -329,6 +347,10 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// Regression guard: the 1.1.x manifest had these fields at the
 		// top level. If a future refactor accidentally resurrects them
 		// alongside the `ucp` key, the manifest violates the schema.
+		//
+		// Note: `store_context` IS a top-level field (added in 1.4.5) —
+		// intentionally a sibling to `ucp`, not a stale leftover. Tests
+		// for that live in the store_context section below.
 		$manifest = $this->ucp->generate_manifest( [] );
 
 		$this->assertArrayNotHasKey( 'protocol_version', $manifest );
@@ -338,6 +360,109 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		$this->assertArrayNotHasKey( 'discovery', $manifest );
 		$this->assertArrayNotHasKey( 'rate_limits', $manifest );
 		$this->assertArrayNotHasKey( 'store_api', $manifest );
+	}
+
+	// ------------------------------------------------------------------
+	// Layer 2.5: store_context block (1.4.5+)
+	// ------------------------------------------------------------------
+	//
+	// Added in 1.4.5 after cross-agent review feedback that the
+	// manifest lacked merchant-level commerce context (currency,
+	// locale, tax/shipping posture). These tests lock in the five
+	// contract fields and cover the ICU→BCP 47 locale conversion
+	// that's the most likely regression source — WordPress stores
+	// locales in underscore form and it's easy to forward that
+	// verbatim into the manifest by mistake.
+
+	public function test_manifest_has_store_context_top_level_key(): void {
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertArrayHasKey( 'store_context', $manifest );
+		$this->assertIsArray( $manifest['store_context'] );
+	}
+
+	public function test_store_context_declares_iso_4217_currency(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'EUR' );
+
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertSame( 'EUR', $manifest['store_context']['currency'] );
+	}
+
+	public function test_store_context_locale_uses_bcp_47_hyphen_not_icu_underscore(): void {
+		// WordPress stores `en_US`; agents consuming the manifest
+		// expect web-standard `en-US`. This conversion is the single
+		// biggest correctness risk in the block — stubbing the WP
+		// side and asserting the manifest side locks it in.
+		Functions\when( 'get_locale' )->justReturn( 'pt_BR' );
+
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertSame( 'pt-BR', $manifest['store_context']['locale'] );
+		$this->assertStringNotContainsString( '_', $manifest['store_context']['locale'] );
+	}
+
+	public function test_store_context_reports_prices_include_tax(): void {
+		// EU-style VAT-inclusive storefront.
+		Functions\when( 'wc_prices_include_tax' )->justReturn( true );
+
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertTrue( $manifest['store_context']['prices_include_tax'] );
+	}
+
+	public function test_store_context_reports_prices_exclude_tax(): void {
+		// US-style tax-exclusive storefront — default in the
+		// setUp stub.
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertFalse( $manifest['store_context']['prices_include_tax'] );
+	}
+
+	public function test_store_context_reports_shipping_disabled_for_digital_only(): void {
+		Functions\when( 'wc_shipping_enabled' )->justReturn( false );
+
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertFalse( $manifest['store_context']['shipping_enabled'] );
+	}
+
+	public function test_store_context_country_is_null_when_wc_countries_unavailable(): void {
+		// WC() not stubbed in this test environment; the code path
+		// falls through to null. Asserting this locks in the
+		// graceful-degradation branch: the manifest must not crash
+		// or emit garbage when the WC global isn't ready.
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertNull( $manifest['store_context']['country'] );
+	}
+
+	public function test_store_context_fields_are_exactly_those_documented(): void {
+		// Regression guard against field drift. If a future refactor
+		// adds a new key to store_context without also updating
+		// consumer documentation, this test fires. The fix is
+		// deliberate: either update this test (conscious addition)
+		// or remove the stray field.
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		$this->assertSame(
+			[ 'currency', 'locale', 'country', 'prices_include_tax', 'shipping_enabled' ],
+			array_keys( $manifest['store_context'] )
+		);
+	}
+
+	public function test_spec_url_is_pinned_to_protocol_version_tag(): void {
+		// 1.4.5 change: the service binding's `spec` field used to
+		// point at `/tree/main/` (a moving target). It now points at
+		// `/tree/v{PROTOCOL_VERSION}/` so a year-old consumer
+		// checking our manifest against the spec reads the exact
+		// revision we shipped against.
+		$manifest = $this->ucp->generate_manifest( [] );
+		$binding  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
+		$expected = 'https://github.com/Universal-Commerce-Protocol/ucp/tree/v' . WC_AI_Syndication_Ucp::PROTOCOL_VERSION . '/source/schemas/shopping';
+
+		$this->assertSame( $expected, $binding['spec'] );
+		$this->assertStringNotContainsString( '/tree/main/', $binding['spec'] );
 	}
 
 	// ------------------------------------------------------------------

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.4.4
+ * Version: 1.4.5
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.4.4' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.4.5' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Cross-agent review feedback, implemented

Claude chat identified three real gaps in the 1.3.0-era manifest:

> - No locale/currency declaration at the protocol level. The store is USD-only per llms.txt, but the UCP manifest doesn't say so. For the CLDR project you're thinking about, this is exactly the gap — an agent has no machine-readable way to know what currency it'll be quoting in, let alone what locale-formatted strings to expect back.
> - No tax_inclusive / shipping_required hints. Agents quoting totals to users are flying blind on whether the price in the catalog is the price at checkout.
> - The spec URL points to a GitHub tree that may or may not be stable — worth pinning to a tagged version or commit for reproducibility.

All three addressed in this PR.

## Changes

### New \`store_context\` top-level block

\`\`\`json
{
  "ucp": { ... },
  "store_context": {
    "currency":           "USD",
    "locale":             "en-US",
    "country":            "US",
    "prices_include_tax": false,
    "shipping_enabled":   true
  }
}
\`\`\`

**Why sibling-to-\`ucp\` and not nested inside**: these are merchant facts, not UCP-spec declarations. Any AI-commerce tool (UCP-aware or not) reads them.

**Field-name conventions**: Stripe/Shopify-aligned so consumers familiar with either read our manifest without a glossary.

### Spec URL pinned to tag

Old: \`https://github.com/Universal-Commerce-Protocol/ucp/tree/main/source/schemas/shopping\`
New: \`https://github.com/Universal-Commerce-Protocol/ucp/tree/v2026-04-08/source/schemas/shopping\`

UCP spec repo uses date-tags matching our \`PROTOCOL_VERSION\` constant → one source of truth drives both.

### ICU→BCP 47 locale conversion

WP stores \`en_US\` (underscore). Web standards want \`en-US\` (hyphen). Boundary conversion in \`build_store_context()\` means agents never see the ICU form.

## Test plan
- [x] 9 new tests for store_context — all 5 fields, ICU→BCP 47 conversion, graceful-degradation when WC() unavailable, spec URL pin
- [x] PHPCS clean
- [x] PHPStan clean
- [x] PHPUnit: **305 tests / 838 assertions** (was 296/825)

After deploy + upload, manifest consumers should see:

\`\`\`bash
curl -s https://pierorocca.com/.well-known/ucp | jq .store_context
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)