### PR TITLE
1.6.2: hardcoded sitemap fallbacks for Jetpack-emitted sites

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-robots.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-robots.php
@@ -426,8 +426,24 @@ class WC_AI_Syndication_Robots {
 			// directive is already authoritative per spec, so this
 			// is pure redundancy — but it's free and it accommodates
 			// implementations that over-scope their parsing.
-			foreach ( $sitemap_urls as $sitemap_url ) {
-				$sitemap_path = wp_parse_url( $sitemap_url, PHP_URL_PATH );
+			//
+			// Two-source strategy: paths discovered from the existing
+			// robots.txt body (via `extract_sitemap_urls`, covers
+			// SEO plugins that use the `robots_txt` filter) plus the
+			// hardcoded `COMMON_SITEMAP_PATHS` list (covers SEO
+			// plugins that emit via `do_robotstxt` action — invisible
+			// to our filter but commonly at known paths). Union,
+			// deduped — non-existent paths are no-ops for bots.
+			$discovered_paths = array_filter(
+				array_map(
+					static fn( string $url ): ?string => wp_parse_url( $url, PHP_URL_PATH ) ?: null,
+					$sitemap_urls
+				)
+			);
+			$emit_paths = array_values( array_unique(
+				array_merge( $discovered_paths, self::COMMON_SITEMAP_PATHS )
+			) );
+			foreach ( $emit_paths as $sitemap_path ) {
 				if ( is_string( $sitemap_path ) && '' !== $sitemap_path ) {
 					$output .= "Allow: {$sitemap_path}\n";
 				}
@@ -491,18 +507,59 @@ class WC_AI_Syndication_Robots {
 	}
 
 	/**
+	 * Common sitemap paths emitted by WordPress core and popular SEO
+	 * plugins. We emit `Allow:` for every entry in this list
+	 * regardless of whether the specific path is active on the
+	 * merchant's site — an `Allow:` directive for a non-existent
+	 * path is a no-op (bots still get 404 if they try to fetch it),
+	 * so this is harmless fallback coverage for sites whose SEO
+	 * plugin emits `Sitemap:` via the `do_robotstxt` action rather
+	 * than the `robots_txt` filter (a common pattern that leaves
+	 * our auto-discovery blind to their URLs).
+	 *
+	 * Paths chosen from observed real-world usage:
+	 *   - `/sitemap.xml`        — Yoast, Rank Math, AIOSEO default,
+	 *                             WooCommerce SEO, many custom configs
+	 *   - `/sitemap_index.xml`  — Yoast's index format (`sitemap.xml`
+	 *                             is often an alias to this)
+	 *   - `/wp-sitemap.xml`     — WordPress core (since 5.5)
+	 *   - `/news-sitemap.xml`   — Yoast Premium's Google News variant,
+	 *                             also some Rank Math setups
+	 *
+	 * @var string[]
+	 */
+	const COMMON_SITEMAP_PATHS = [
+		'/sitemap.xml',
+		'/sitemap_index.xml',
+		'/wp-sitemap.xml',
+		'/news-sitemap.xml',
+	];
+
+	/**
 	 * Extract sitemap URLs from existing robots.txt content.
 	 *
-	 * Parses all top-level `Sitemap:` directives (case-insensitive
-	 * per spec). Returns unique URLs in discovery order. Falls back
-	 * to `get_sitemap_url( 'index' )` — the WordPress core helper
-	 * since 5.5 — if no Sitemap directives are present, so the
-	 * plugin still references the correct sitemap on sites that
-	 * don't have an SEO plugin configuring one explicitly.
+	 * Two discovery strategies layered:
+	 *
+	 *   1. Regex the existing `$output` body for `Sitemap:`
+	 *      directives. Catches any SEO plugin that uses the
+	 *      `robots_txt` filter correctly (emission flows through
+	 *      `$output`).
+	 *
+	 *   2. Fall back to `get_sitemap_url( 'index' )` — WP core
+	 *      helper since 5.5 — for sites running the default
+	 *      core sitemap with no SEO plugin configured.
+	 *
+	 * NOT covered by either strategy: SEO plugins that emit
+	 * `Sitemap:` via the `do_robotstxt` action (direct `echo`).
+	 * Those lines appear in the final robots.txt body but aren't
+	 * visible to our filter. For those sites, the caller falls
+	 * back to the hardcoded `COMMON_SITEMAP_PATHS` list — this
+	 * function's job is to return specifically-discovered URLs,
+	 * not to guarantee coverage.
 	 *
 	 * @param string $robots_txt The full robots.txt body at the
 	 *                           moment our filter runs.
-	 * @return string[]          Discovered sitemap URLs.
+	 * @return string[]          Discovered sitemap URLs (may be empty).
 	 */
 	private static function extract_sitemap_urls( string $robots_txt ): array {
 		if ( preg_match_all( '/^\s*Sitemap:\s*(\S+)/mi', $robots_txt, $matches ) ) {

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.6.1
+Stable tag: 1.6.2
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,10 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.6.2 =
+* Fixed: 1.6.1's sitemap auto-discovery missed sites whose SEO/sitemap plugin (notably Jetpack's Sitemaps module, default on WordPress.com Atomic) emits `Sitemap:` directives via the `do_robotstxt` action with direct `echo` instead of through the `robots_txt` filter. Our filter runs in isolation from the echoed output, so the discovery regex saw nothing and fell back to WP core's `/wp-sitemap.xml` — which doesn't exist on Jetpack-powered sites. Merchants with Jetpack (i.e. every WP.com Atomic install) saw `Allow: /wp-sitemap.xml` in each AI-bot block instead of the actually-correct `Allow: /sitemap.xml`.
+* Added: `COMMON_SITEMAP_PATHS` constant with hardcoded fallback paths (`/sitemap.xml`, `/sitemap_index.xml`, `/wp-sitemap.xml`, `/news-sitemap.xml`) emitted alongside any auto-discovered paths. Union + dedupe, so sites that DO emit via the filter correctly (Yoast SEO, Rank Math, AIOSEO in standard config) still see their specific URLs without duplication. Sites on Jetpack get their standard `/sitemap.xml` + `/news-sitemap.xml` paths inside every AI-bot block via the fallback. `Allow:` directives for non-existent paths are no-ops for crawlers, so this is zero-harm belt-and-suspenders.
 
 = 1.6.1 =
 * Fixed: Perplexity's browsing tool (and other Chromium-headless AI crawlers) couldn't read `/robots.txt` because the response had no CORS headers — same class of bug fixed for `/llms.txt` in 1.4.1, but robots.txt is served by WordPress core, not by our plugin, so the 1.4.1 fix didn't cover it. Added `do_robotstxt` action hook at priority 5 that injects `Access-Control-Allow-Origin: *`, `Access-Control-Allow-Methods: GET, OPTIONS`, and `X-Content-Type-Options: nosniff` before WP core flushes the body. Verified via curl with `PerplexityBot/1.0` UA: response now includes CORS headers.

--- a/tests/php/unit/RobotsTest.php
+++ b/tests/php/unit/RobotsTest.php
@@ -717,6 +717,47 @@ class RobotsTest extends \PHPUnit\Framework\TestCase {
 	// CORS + nosniff headers on robots.txt (do_robotstxt hook)
 	// ------------------------------------------------------------------
 
+	public function test_common_sitemap_paths_always_emitted_even_without_discovery(): void {
+		// Real-world case from pierorocca.com: Yoast SEO emits
+		// Sitemap directives via `do_robotstxt` action (direct
+		// echo) rather than the `robots_txt` filter, so our
+		// regex discovery sees nothing. Without the hardcoded
+		// fallback the merchant's `/sitemap.xml` URL never
+		// makes it into an `Allow:` directive.
+		//
+		// With COMMON_SITEMAP_PATHS, `/sitemap.xml` is always
+		// in each named block regardless of what we could or
+		// couldn't discover — covering this common deployment.
+		$base = "User-agent: *\nDisallow: /wp-admin/\n";
+
+		$output = $this->generate_robots_output( $base );
+
+		$this->assertStringContainsString( 'Allow: /sitemap.xml', $output );
+		$this->assertStringContainsString( 'Allow: /sitemap_index.xml', $output );
+		$this->assertStringContainsString( 'Allow: /wp-sitemap.xml', $output );
+		$this->assertStringContainsString( 'Allow: /news-sitemap.xml', $output );
+	}
+
+	public function test_discovered_sitemap_paths_not_duplicated_with_hardcoded(): void {
+		// Union + dedupe: when `/sitemap.xml` is both discovered
+		// from the input AND in COMMON_SITEMAP_PATHS, it should
+		// only appear once per named block — not twice.
+		$base = "Sitemap: https://example.com/sitemap.xml\n"
+			. "User-agent: *\nDisallow: /wp-admin/\n";
+
+		$output = $this->generate_robots_output( $base );
+
+		// Count per-block occurrences. Two allowed bots in the
+		// fixture, so we expect exactly 2 instances of
+		// `Allow: /sitemap.xml` — not 4 (which would indicate
+		// discovered + hardcoded both emitted).
+		$this->assertEquals(
+			2,
+			substr_count( $output, 'Allow: /sitemap.xml' ),
+			'Duplicate /sitemap.xml from discovered + hardcoded should be deduped'
+		);
+	}
+
 	public function test_cors_headers_method_is_hooked_on_do_robotstxt(): void {
 		// Can't test the actual `header()` calls without process
 		// isolation (PHP headers-sent state leaks between tests).

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.6.1
+ * Version: 1.6.2
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.6.1' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.6.2' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## The bug

1.6.1 added sitemap auto-discovery by regex-matching \`Sitemap:\` directives in the existing \`robots_txt\` filter input. Works great for SEO plugins that use the filter correctly (Yoast, Rank Math in standard config).

**Doesn't work for Jetpack** — which is the default sitemap on every WordPress.com Atomic site. Jetpack's Sitemaps module emits \`Sitemap:\` via the \`do_robotstxt\` action with direct \`echo\`, bypassing the filter entirely. Our regex saw nothing; WP core's \`get_sitemap_url('index')\` fallback returned \`/wp-sitemap.xml\` (the core path); Jetpack sites shipped \`Allow: /wp-sitemap.xml\` pointing at a 404 while their actual \`/sitemap.xml\` was unlisted in our blocks.

Confirmed on pierorocca.com (self-identifies Jetpack in sitemap XML: \`<!--generator='jetpack-15.8-a.3'-->\`).

## The fix

Hardcoded \`COMMON_SITEMAP_PATHS\` fallback covering WP core, Yoast, Rank Math, AIOSEO, Jetpack:

\`\`\`php
const COMMON_SITEMAP_PATHS = [
    '/sitemap.xml',
    '/sitemap_index.xml',
    '/wp-sitemap.xml',
    '/news-sitemap.xml',
];
\`\`\`

Emitted alongside auto-discovered paths (union + dedupe). Sites where discovery works keep their specific URLs once; sites where it doesn't get the common paths covered. Allow for non-existent paths is a no-op per spec.

## Test plan
- [x] 2 new tests — always-emit + dedupe behavior
- [x] 347 total PHP tests (was 345), all passing
- [x] PHPCS + PHPStan + ESLint clean
- [ ] After deploy: \`curl -s https://pierorocca.com/robots.txt | grep -c "Allow: /sitemap.xml"\` returns non-zero

🤖 Generated with [Claude Code](https://claude.com/claude-code)