### PR TITLE
1.6.3: llms.txt sitemap section with HEAD-probe validation

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -212,6 +212,29 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[]   = "- **Commerce Protocol Manifest**: `{$ucp_url}` — declares capabilities, checkout policy, and purchase URL templates";
 		$lines[]   = '';
 
+		// Sitemaps section. Surfaces exhaustive URL enumeration
+		// paths for agents doing deep catalog discovery — parallel
+		// to robots.txt's per-bot `Allow:` sitemap entries from
+		// 1.6.1/1.6.2, but in llms.txt's human+machine-readable
+		// narrative form. Unlike robots.txt (where `Allow:` for
+		// non-existent paths is harmless), here we probe each
+		// candidate via HEAD so only URLs that actually respond
+		// make it into the document. Probes are synchronous but
+		// amortized by the 1-hour transient cache in
+		// `get_cached_content()` — one round of probing per
+		// cache miss.
+		$sitemap_urls = self::discover_sitemap_urls( $site_url );
+		if ( ! empty( $sitemap_urls ) ) {
+			$lines[] = '## Sitemaps';
+			$lines[] = '';
+			$lines[] = 'Exhaustive URL lists for catalog enumeration. Agents wanting every product/category URL in one pass fetch these instead of paginating the Store API.';
+			$lines[] = '';
+			foreach ( $sitemap_urls as $sitemap_url ) {
+				$lines[] = "- {$sitemap_url}";
+			}
+			$lines[] = '';
+		}
+
 		// Product categories summary.
 		$categories = $this->get_syndicated_categories( $settings );
 		if ( ! empty( $categories ) ) {
@@ -276,6 +299,79 @@ class WC_AI_Syndication_Llms_Txt {
 	 * @param array $settings AI syndication settings.
 	 * @return WP_Term[]
 	 */
+	/**
+	 * Discover sitemap URLs by probing known paths + WP core's helper.
+	 *
+	 * Unlike the robots.txt sitemap handling (where `Allow:` for a
+	 * non-existent path is a harmless no-op), llms.txt is a
+	 * user-facing content document — emitting URLs that 404 would
+	 * be factually incorrect. So here we HEAD-probe each candidate
+	 * and only include the ones that actually respond.
+	 *
+	 * Probe sources:
+	 *   - `get_sitemap_url( 'index' )` — WP core canonical (5.5+)
+	 *   - `WC_AI_Syndication_Robots::COMMON_SITEMAP_PATHS` — common
+	 *     plugin paths (Jetpack, Yoast, Rank Math, etc.) appended
+	 *     to site URL
+	 *
+	 * Synchronous HEAD requests with a 1-second timeout, made on
+	 * the same origin. Amortized by the 1-hour transient cache in
+	 * `get_cached_content()` — probes run once per cache miss, not
+	 * per request. Worst case (all 4 paths time out): 4 seconds of
+	 * generation latency once per hour. Typical case (paths exist
+	 * or fast 404): <500ms.
+	 *
+	 * @param string $site_url Home URL with trailing slash.
+	 * @return string[]        Sitemap URLs that returned 2xx/3xx to
+	 *                         a HEAD probe. Empty on sites with no
+	 *                         sitemap at any common path.
+	 */
+	private static function discover_sitemap_urls( string $site_url ): array {
+		$candidates = [];
+
+		// WP core canonical (returns full URL when core sitemap is
+		// enabled; returns empty string if disabled via filter).
+		if ( function_exists( 'get_sitemap_url' ) ) {
+			$core = get_sitemap_url( 'index' );
+			if ( is_string( $core ) && '' !== $core ) {
+				$candidates[] = $core;
+			}
+		}
+
+		// Common plugin paths, absolute-URL form for llms.txt output.
+		$base = rtrim( $site_url, '/' );
+		foreach ( WC_AI_Syndication_Robots::COMMON_SITEMAP_PATHS as $path ) {
+			$candidates[] = $base . $path;
+		}
+		$candidates = array_values( array_unique( $candidates ) );
+
+		// HEAD-probe each. Only URLs returning 2xx/3xx make it in.
+		$existent = [];
+		foreach ( $candidates as $candidate ) {
+			$response = wp_remote_head(
+				$candidate,
+				[
+					'timeout'     => 1,
+					'redirection' => 1,
+					'blocking'    => true,
+					// Skip SSL verify on self-origin probes — some
+					// local/dev environments have self-signed certs
+					// that would otherwise reject the probe.
+					'sslverify'   => false,
+				]
+			);
+			if ( is_wp_error( $response ) ) {
+				continue;
+			}
+			$code = wp_remote_retrieve_response_code( $response );
+			if ( $code >= 200 && $code < 400 ) {
+				$existent[] = $candidate;
+			}
+		}
+
+		return $existent;
+	}
+
 	private function get_syndicated_categories( $settings ) {
 		$args = [
 			'taxonomy'   => 'product_cat',

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.6.2
+Stable tag: 1.6.3
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,10 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.6.3 =
+* Added: `## Sitemaps` section in llms.txt surfacing exhaustive URL enumeration paths for agents doing deep catalog discovery. Parallel to the sitemap `Allow:` entries in robots.txt (1.6.1/1.6.2) but in llms.txt's human+machine-readable narrative form. Unlike robots.txt where `Allow:` for non-existent paths is a harmless no-op, listing wrong URLs in llms.txt would be factually incorrect — so each candidate sitemap is HEAD-probed at generation time and only responding URLs make it into the document. Probes are synchronous with 1-second timeout but amortized by the 1-hour transient cache — one round per cache miss, not per request. Typical cache-miss latency: <500ms. Worst case (all 4 candidates time out): 4 seconds, once per hour.
+* Changed: sitemap discovery sources in llms.txt match robots.txt's behavior — `get_sitemap_url( 'index' )` for WP core canonical + the four hardcoded paths from `WC_AI_Syndication_Robots::COMMON_SITEMAP_PATHS` (`/sitemap.xml`, `/sitemap_index.xml`, `/wp-sitemap.xml`, `/news-sitemap.xml`), covering WP core, Jetpack, Yoast, Rank Math, and AIOSEO between them.
 
 = 1.6.2 =
 * Fixed: 1.6.1's sitemap auto-discovery missed sites whose SEO/sitemap plugin (notably Jetpack's Sitemaps module, default on WordPress.com Atomic) emits `Sitemap:` directives via the `do_robotstxt` action with direct `echo` instead of through the `robots_txt` filter. Our filter runs in isolation from the echoed output, so the discovery regex saw nothing and fell back to WP core's `/wp-sitemap.xml` — which doesn't exist on Jetpack-powered sites. Merchants with Jetpack (i.e. every WP.com Atomic install) saw `Allow: /wp-sitemap.xml` in each AI-bot block instead of the actually-correct `Allow: /sitemap.xml`.

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -68,6 +68,17 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		);
 		Functions\when( 'wc_get_products' )->justReturn( [] );
 		Functions\when( 'apply_filters' )->returnArg( 2 );
+
+		// Sitemap-discovery stubs. Default: nothing found (no sitemap
+		// section in output). Individual tests override via
+		// `Functions\when()->alias()` to simulate found sitemaps.
+		// `is_wp_error` is globally stubbed in `tests/php/stubs.php`
+		// (too early for Patchwork to redefine it here).
+		Functions\when( 'get_sitemap_url' )->justReturn( '' );
+		Functions\when( 'wp_remote_head' )->justReturn(
+			new WP_Error( 'no_probe', 'Not stubbed in test' )
+		);
+		Functions\when( 'wp_remote_retrieve_response_code' )->justReturn( 0 );
 	}
 
 	protected function tearDown(): void {
@@ -390,6 +401,88 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertSame( '', $result, 'generate() should have returned empty in this setup.' );
 		$this->assertSame( 0, $set_transient_calls, 'Empty content must not be cached — would poison the TTL window.' );
+	}
+
+	// ------------------------------------------------------------------
+	// Sitemaps section (1.6.3)
+	// ------------------------------------------------------------------
+
+	public function test_sitemap_section_absent_when_no_sitemaps_respond(): void {
+		// Default stubs: wp_remote_head returns WP_Error for every
+		// probe, get_sitemap_url returns empty → zero candidates
+		// confirmed existent → section not rendered.
+		$output = $this->llms->generate();
+
+		$this->assertStringNotContainsString( '## Sitemaps', $output );
+	}
+
+	public function test_sitemap_section_rendered_when_sitemap_exists(): void {
+		// Simulate a site where /sitemap.xml responds 200 to a HEAD
+		// probe. The section should render with that URL listed.
+		Functions\when( 'wp_remote_head' )->alias(
+			static function ( string $url ): array {
+				if ( str_ends_with( $url, '/sitemap.xml' ) ) {
+					return [ 'response' => [ 'code' => 200 ] ];
+				}
+				return [ 'response' => [ 'code' => 404 ] ];
+			}
+		);
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			static fn( $response ) =>
+				is_array( $response ) && isset( $response['response']['code'] )
+					? (int) $response['response']['code']
+					: 0
+		);
+
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( '## Sitemaps', $output );
+		$this->assertStringContainsString( '- https://example.com/sitemap.xml', $output );
+	}
+
+	public function test_sitemap_section_excludes_paths_that_404(): void {
+		// When some candidates probe OK and others don't, only
+		// the responding URLs make it into the output. Validates
+		// the HEAD-filter logic — emitting non-existent paths in
+		// llms.txt would be factually wrong (unlike robots.txt
+		// Allow, which is a harmless no-op).
+		Functions\when( 'wp_remote_head' )->alias(
+			static function ( string $url ): array {
+				// Only /sitemap.xml responds; /sitemap_index.xml,
+				// /wp-sitemap.xml, /news-sitemap.xml all 404.
+				$code = str_ends_with( $url, '/sitemap.xml' ) ? 200 : 404;
+				return [ 'response' => [ 'code' => $code ] ];
+			}
+		);
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			static fn( $response ) => (int) $response['response']['code']
+		);
+
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( '- https://example.com/sitemap.xml', $output );
+		$this->assertStringNotContainsString( '/sitemap_index.xml', $output );
+		$this->assertStringNotContainsString( '/news-sitemap.xml', $output );
+	}
+
+	public function test_wp_core_sitemap_included_when_non_empty(): void {
+		// `get_sitemap_url( 'index' )` returns WP core's canonical
+		// sitemap URL when the feature is active. That candidate
+		// should be probed alongside the hardcoded COMMON_SITEMAP_PATHS.
+		Functions\when( 'get_sitemap_url' )->justReturn( 'https://example.com/wp-sitemap.xml' );
+		Functions\when( 'wp_remote_head' )->alias(
+			static function ( string $url ): array {
+				$code = str_ends_with( $url, '/wp-sitemap.xml' ) ? 200 : 404;
+				return [ 'response' => [ 'code' => $code ] ];
+			}
+		);
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			static fn( $response ) => (int) $response['response']['code']
+		);
+
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( '- https://example.com/wp-sitemap.xml', $output );
 	}
 
 	/**

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.6.2
+ * Version: 1.6.3
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.6.2' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.6.3' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Parallel to 1.6.1/1.6.2 but for llms.txt

Agents reading llms.txt now see exhaustive URL enumeration paths via a new \`## Sitemaps\` section. Deep-catalog-discovery agents (product comparison, exhaustive search) don't have to paginate the Store API to map the store — they can fetch the sitemap directly.

## Why HEAD-probing (vs. emit-everything like robots.txt)

| Layer | Treatment of non-existent paths |
|-------|--------------------------------|
| robots.txt \`Allow:\` | Harmless no-op per spec — bots still 404 on fetch, nothing ships wrong |
| **llms.txt content** | Factually incorrect to list a URL that 404s — so we probe each candidate |

Probes: \`wp_remote_head\`, 1s timeout, follow 1 redirect (Yoast aliases \`/sitemap.xml\` → \`/sitemap_index.xml\`). 200-399 passes; everything else is dropped.

## Latency analysis

- **Happy path**: <500ms for 4 probes on a healthy site
- **Typical cache miss**: 1-2s including TLS handshakes
- **Worst case**: 4s (every probe times out), **once per hour** (1hr transient cache amortizes)
- **Warm cache**: zero probe cost

## Test plan
- [x] 4 new LlmsTxtTest tests (section absent/rendered/filtered/WP-core)
- [x] 351 total PHP tests / 965 assertions (was 347 / 958)
- [x] PHPCS + PHPStan clean
- [ ] After deploy + cache bust: \`curl -s "https://pierorocca.com/llms.txt?cb=\$(date +%s)" | grep -A 10 "## Sitemaps"\` shows real sitemap URLs

🤖 Generated with [Claude Code](https://claude.com/claude-code)