### PR TITLE
1.6.4: UCP manifest entity semantic alignment (spec + schema URLs, config relocation)

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -267,9 +267,18 @@ class WC_AI_Syndication_Llms_Txt {
 		}
 
 		// Attribution instructions.
+		//
+		// Example URL uses the `/checkout-link/` pattern, not a
+		// product-page URL, because that's the canonical purchase
+		// path this plugin exposes. A product page doesn't route a
+		// customer to checkout — agents that need to drive purchase
+		// intent use checkout-link (adds items + redirects to
+		// checkout in one step, customer never sees the cart).
+		// The UCP manifest at /.well-known/ucp advertises the full
+		// URL-template family; llms.txt surfaces the canonical one.
 		$lines[] = '## Attribution';
 		$lines[] = '';
-		$lines[] = 'When linking to products, append the following query parameters for order attribution:';
+		$lines[] = 'When linking customers to your store for a purchase, append the following query parameters for order attribution:';
 		$lines[] = '';
 		$lines[] = '- `utm_source`: Your agent identifier (e.g. `chatgpt`, `gemini`, `perplexity`)';
 		$lines[] = '- `utm_medium`: `ai_agent`';
@@ -278,7 +287,15 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = '';
 		$lines[] = 'These map to standard WooCommerce Order Attribution fields.';
 		$lines[] = '';
-		$lines[] = 'Example: `' . $site_url . 'product/example/?utm_source={agent_id}&utm_medium=ai_agent&ai_session_id={session_id}`';
+		$lines[] = 'Example (checkout-link — recommended, sends customer straight to checkout):';
+		$lines[] = '';
+		$lines[] = '`' . $site_url . 'checkout-link/?products={product_id}:{quantity}&utm_source={agent_id}&utm_medium=ai_agent&ai_session_id={session_id}`';
+		$lines[] = '';
+		$lines[] = 'Example (product page — for browsing, not purchase):';
+		$lines[] = '';
+		$lines[] = '`' . $site_url . 'product/{slug}/?utm_source={agent_id}&utm_medium=ai_agent&ai_session_id={session_id}`';
+		$lines[] = '';
+		$lines[] = 'The full URL template family (add-to-cart variants, coupon support, variable products) is in the UCP manifest at `' . $site_url . '.well-known/ucp` under `capabilities["dev.ucp.shopping.checkout"][0].config.purchase_urls`.';
 		$lines[] = '';
 
 		/**

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -194,89 +194,96 @@ class WC_AI_Syndication_Ucp {
 		$cart_url     = wc_get_cart_url();
 		$ucp_endpoint = rest_url( 'wc/ucp/v1' );
 
+		// Shared checkout-capability config. Relocated here from
+		// the service-level `config` in 1.6.4 — the UCP entity
+		// schema permits `config` at both levels, but semantically
+		// these fields (purchase URL templates, UTM attribution
+		// conventions) describe the checkout capability rather
+		// than the service transport. Service-level config is for
+		// transport-specific concerns (auth, rate limits, endpoint
+		// tuning); capability-level config is for
+		// capability-semantic concerns. The pre-1.6.4 placement
+		// was syntactically valid but semantically misaligned.
+		$checkout_config = [
+			'purchase_urls' => [
+				'spec'             => 'https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/',
+				'add_to_cart_spec' => 'https://woocommerce.com/document/quick-guide-to-woocommerce-add-to-cart-urls/',
+
+				// Checkout-link: adds items AND redirects to
+				// checkout. Customer never sees the cart — fewest
+				// clicks to purchase.
+				'checkout_link'    => [
+					'description' => 'Recommended — adds items and redirects to checkout in one step. Customer never sees the cart.',
+					'simple'      => $site_url . 'checkout-link/?products={product_id}:{quantity}',
+					'variable'    => $site_url . 'checkout-link/?products={variation_id}:{quantity}',
+					'multi_item'  => $site_url . 'checkout-link/?products={id}:{qty},{id}:{qty}',
+					'with_coupon' => $site_url . 'checkout-link/?products={id}:{qty}&coupon={coupon_code}',
+					'unsupported' => [ 'grouped', 'external', 'subscription' ],
+				],
+
+				// Classic add-to-cart URL. Three behaviors
+				// depending on base URL — the official WC docs
+				// document all three.
+				'add_to_cart'      => [
+					'description'      => 'Classic WooCommerce add-to-cart URL. Three behaviors depending on base URL.',
+					'add_only'         => $site_url . '?add-to-cart={product_id}&quantity={quantity}',
+					'add_and_cart'     => $cart_url . '?add-to-cart={product_id}&quantity={quantity}',
+					'add_and_checkout' => $checkout_url . '?add-to-cart={product_id}&quantity={quantity}',
+					'grouped'          => [
+						'template' => $checkout_url . '?add-to-cart={grouped_product_id}&quantity[{sub_product_id}]={quantity}',
+						'note'     => 'Use the classic add-to-cart pattern for grouped products. The checkout-link feature does not support them.',
+					],
+					'external_note'    => 'For external/affiliate products (type: external), link directly to the product\'s external_url field from the Store API. Do not use add-to-cart.',
+				],
+			],
+
+			'attribution' => [
+				'spec'       => 'https://woocommerce.com/document/order-attribution-tracking/',
+				'system'     => 'woocommerce_order_attribution',
+				'parameters' => [
+					'utm_source'    => 'Your agent identifier (e.g. chatgpt, gemini, perplexity)',
+					'utm_medium'    => 'Must be set to "ai_agent"',
+					'utm_campaign'  => 'Optional campaign name',
+					'ai_session_id' => 'Conversation/session identifier for tracking',
+				],
+				'usage_note' => 'Append these parameters to any checkout_link or add_to_cart URL. The UCP /checkout-sessions endpoint adds utm_source + utm_medium automatically from the UCP-Agent header.',
+			],
+		];
+
+		// Base docs URL for the version-pinned ucp.dev spec site.
+		// All `spec` and `schema` URLs route through the same
+		// canonical host so consumers have a single origin to
+		// trust/cache. Pattern: `https://ucp.dev/{version}/...`.
+		$spec_base = 'https://ucp.dev/' . self::PROTOCOL_VERSION;
+
 		$manifest = [
 			'ucp'           => [
 				'version'          => self::PROTOCOL_VERSION,
 
 				// Services — single REST binding at our UCP namespace.
 				// Under business_schema, a REST binding requires
-				// `endpoint`; `spec` points at the UCP spec for
-				// consumers that want to verify our shape.
+				// `endpoint`. The service-level `spec` points at the
+				// UCP specification overview (updated in 1.6.4 — the
+				// previous URL pointed at the GitHub schema directory
+				// listing, which isn't a "specification document" per
+				// the entity schema's intent).
+				//
+				// `schema` points at the canonical OpenAPI 3.1 spec
+				// for the UCP Shopping REST service. This gives
+				// agents a machine-readable contract for every
+				// operation exposed at our `endpoint`. The schema's
+				// own `{endpoint}` server variable is a placeholder;
+				// per the OpenAPI document's own note, consumers
+				// must substitute the merchant endpoint from the
+				// discovery profile (i.e. `$ucp_endpoint` below).
 				'services'         => [
 					self::SERVICE_NAME => [
 						[
 							'version'   => self::PROTOCOL_VERSION,
-
-							// Pin the spec URL to the git tag that
-							// matches our declared PROTOCOL_VERSION.
-							// The UCP spec repo publishes date-named
-							// tags (e.g. `v2026-04-08`) that align
-							// with the protocol version string, so
-							// one constant drives both — if we bump
-							// PROTOCOL_VERSION the URL tracks
-							// automatically. Pre-1.4.5 this pointed
-							// at `/tree/main/` which is a moving
-							// target; a consumer verifying our shape
-							// a year later could have been reading
-							// a spec revision we never conformed to.
-							'spec'      => 'https://github.com/Universal-Commerce-Protocol/ucp/tree/v' . self::PROTOCOL_VERSION . '/source/schemas/shopping',
+							'spec'      => $spec_base . '/specification/overview',
+							'schema'    => $spec_base . '/services/shopping/rest.openapi.json',
 							'transport' => 'rest',
 							'endpoint'  => $ucp_endpoint,
-
-							// Service-specific config. UCP's entity
-							// schema explicitly allows this (`config`
-							// on any entity, `additionalProperties:
-							// true`). Kept for documentation value
-							// and for agents that construct checkout
-							// URLs directly; strict UCP consumers
-							// ignore these keys.
-							'config'    => [
-								'purchase_urls' => [
-									'spec'             => 'https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/',
-									'add_to_cart_spec' => 'https://woocommerce.com/document/quick-guide-to-woocommerce-add-to-cart-urls/',
-
-									// Checkout-link: adds items AND
-									// redirects to checkout. Customer
-									// never sees the cart — fewest
-									// clicks to purchase.
-									'checkout_link'    => [
-										'description' => 'Recommended — adds items and redirects to checkout in one step. Customer never sees the cart.',
-										'simple'      => $site_url . 'checkout-link/?products={product_id}:{quantity}',
-										'variable'    => $site_url . 'checkout-link/?products={variation_id}:{quantity}',
-										'multi_item'  => $site_url . 'checkout-link/?products={id}:{qty},{id}:{qty}',
-										'with_coupon' => $site_url . 'checkout-link/?products={id}:{qty}&coupon={coupon_code}',
-										'unsupported' => [ 'grouped', 'external', 'subscription' ],
-									],
-
-									// Classic add-to-cart URL. Three
-									// behaviors depending on base URL
-									// — the official WC docs document
-									// all three.
-									'add_to_cart'      => [
-										'description'      => 'Classic WooCommerce add-to-cart URL. Three behaviors depending on base URL.',
-										'add_only'         => $site_url . '?add-to-cart={product_id}&quantity={quantity}',
-										'add_and_cart'     => $cart_url . '?add-to-cart={product_id}&quantity={quantity}',
-										'add_and_checkout' => $checkout_url . '?add-to-cart={product_id}&quantity={quantity}',
-										'grouped'          => [
-											'template' => $checkout_url . '?add-to-cart={grouped_product_id}&quantity[{sub_product_id}]={quantity}',
-											'note'     => 'Use the classic add-to-cart pattern for grouped products. The checkout-link feature does not support them.',
-										],
-										'external_note'    => 'For external/affiliate products (type: external), link directly to the product\'s external_url field from the Store API. Do not use add-to-cart.',
-									],
-								],
-
-								'attribution'   => [
-									'spec'       => 'https://woocommerce.com/document/order-attribution-tracking/',
-									'system'     => 'woocommerce_order_attribution',
-									'parameters' => [
-										'utm_source'    => 'Your agent identifier (e.g. chatgpt, gemini, perplexity)',
-										'utm_medium'    => 'Must be set to "ai_agent"',
-										'utm_campaign'  => 'Optional campaign name',
-										'ai_session_id' => 'Conversation/session identifier for tracking',
-									],
-									'usage_note' => 'Append these parameters to any checkout_link or add_to_cart URL. The UCP /checkout-sessions endpoint adds utm_source + utm_medium automatically from the UCP-Agent header.',
-								],
-							],
 						],
 					],
 				],
@@ -290,19 +297,28 @@ class WC_AI_Syndication_Ucp {
 				// `dev.ucp.shopping.{capability}` to discover whether
 				// our implementation covers their use case.
 				//
-				// Since 1.6.0 we advertise the two catalog sub-
-				// capabilities explicitly rather than the umbrella
-				// `dev.ucp.shopping.catalog`. The April UCP spec
-				// formalized `catalog.search` and `catalog.lookup`
-				// as separate schemas; splitting the advertisement
-				// lets agents discover precisely which operations
-				// are available. Our implementation covers both.
+				// 1.6.0 split the umbrella `dev.ucp.shopping.catalog`
+				// into the two sub-capabilities per the April spec.
+				// 1.6.4 added `spec` + `schema` URLs to each capability
+				// binding and moved the checkout `config` (purchase
+				// URLs + attribution conventions) from the service
+				// level to the checkout capability — all fields are
+				// valid on the entity schema but semantically belong
+				// with the capability they describe.
 				'capabilities'     => [
 					'dev.ucp.shopping.catalog.search' => [
-						[ 'version' => self::PROTOCOL_VERSION ],
+						[
+							'version' => self::PROTOCOL_VERSION,
+							'spec'    => $spec_base . '/specification/catalog/search',
+							'schema'  => $spec_base . '/schemas/shopping/catalog_search.json',
+						],
 					],
 					'dev.ucp.shopping.catalog.lookup' => [
-						[ 'version' => self::PROTOCOL_VERSION ],
+						[
+							'version' => self::PROTOCOL_VERSION,
+							'spec'    => $spec_base . '/specification/catalog/lookup',
+							'schema'  => $spec_base . '/schemas/shopping/catalog_lookup.json',
+						],
 					],
 					// `mode: handoff` signals that our checkout
 					// implementation is redirect-only — agents that
@@ -320,10 +336,18 @@ class WC_AI_Syndication_Ucp {
 					// `continue_url`, but the manifest-level `mode`
 					// lets agents decide whether to invoke at all
 					// without a roundtrip.
+					//
+					// `config` carries the checkout capability's
+					// purchase-URL templates and UTM attribution
+					// conventions — relocated from service-level in
+					// 1.6.4. See `$checkout_config` above.
 					'dev.ucp.shopping.checkout'       => [
 						[
 							'version' => self::PROTOCOL_VERSION,
+							'spec'    => $spec_base . '/specification/checkout',
+							'schema'  => $spec_base . '/schemas/shopping/checkout.json',
 							'mode'    => 'handoff',
+							'config'  => $checkout_config,
 						],
 					],
 				],

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -237,7 +237,7 @@ class WC_AI_Syndication_Ucp {
 				],
 			],
 
-			'attribution' => [
+			'attribution'   => [
 				'spec'       => 'https://woocommerce.com/document/order-attribution-tracking/',
 				'system'     => 'woocommerce_order_attribution',
 				'parameters' => [

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.6.3
+Stable tag: 1.6.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,12 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.6.4 =
+* Changed: UCP manifest structure reorganized to match April spec's `entity` semantic conventions. Three coordinated changes: (1) the `config` block carrying `purchase_urls` + `attribution` moved from service-level (`services["dev.ucp.shopping"][0].config`) to checkout-capability-level (`capabilities["dev.ucp.shopping.checkout"][0].config`) — both placements are syntactically valid per the UCP entity schema, but semantically these are checkout-specific concerns and belong with the checkout capability; (2) added `spec` + `schema` URLs to every capability binding (`catalog.search`, `catalog.lookup`, `checkout`) pointing at ucp.dev's canonical per-capability documentation and JSON Schema files; (3) added `schema` to the service binding pointing at the OpenAPI 3.1 spec for the UCP Shopping REST service. Agents wanting machine-readable contract validation now have authoritative URLs for both the service-level transport (OpenAPI) and the capability-level payloads (JSON Schema).
+* Changed: all external spec/schema URLs migrated from GitHub `tree/v{VERSION}/source/...` paths to `https://ucp.dev/{VERSION}/...` paths. Single canonical host for every external reference in the manifest. Rendered docs at ucp.dev are the intended consumption path per the UCP project's publishing model; GitHub URLs were functional but aimed at source files rather than rendered specification pages.
+* Changed: service-level `spec` URL now points at `https://ucp.dev/{VERSION}/specification/overview` (the canonical UCP overview doc) instead of the GitHub schema directory listing. The previous URL resolved to a file browser rather than a "human-readable specification document" per the entity schema's intent.
+* Added: 4 regression tests locking in the structural changes — checkout capability owns the config (not service), every capability has `spec` + `schema` URLs, service has an OpenAPI `schema` URL, all external URLs are version-pinned via `ucp.dev/{PROTOCOL_VERSION}/`. Total: 354 tests / 989 assertions.
 
 = 1.6.3 =
 * Added: `## Sitemaps` section in llms.txt surfacing exhaustive URL enumeration paths for agents doing deep catalog discovery. Parallel to the sitemap `Allow:` entries in robots.txt (1.6.1/1.6.2) but in llms.txt's human+machine-readable narrative form. Unlike robots.txt where `Allow:` for non-existent paths is a harmless no-op, listing wrong URLs in llms.txt would be factually incorrect — so each candidate sitemap is HEAD-probed at generation time and only responding URLs make it into the document. Probes are synchronous with 1-second timeout but amortized by the 1-hour transient cache — one round per cache miss, not per request. Typical cache-miss latency: <500ms. Worst case (all 4 candidates time out): 4 seconds, once per hour.

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -162,13 +162,38 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( '`ai_session_id`', $output );
 	}
 
-	public function test_attribution_includes_example_url(): void {
+	public function test_attribution_includes_checkout_link_example(): void {
+		// 1.6.4 change: the attribution example now uses the
+		// `/checkout-link/` pattern — the canonical purchase path
+		// this plugin exposes — rather than a product page URL.
+		// A product page doesn't route to checkout; agents wanting
+		// to drive purchase intent need checkout-link. The product
+		// page example is still included as a secondary example
+		// for browsing intent.
 		$output = $this->llms->generate();
 
 		$this->assertStringContainsString(
-			'https://example.com/product/example/?utm_source=',
-			$output
+			'https://example.com/checkout-link/?products={product_id}:{quantity}&utm_source=',
+			$output,
+			'Primary attribution example should use the checkout-link pattern'
 		);
+		$this->assertStringContainsString(
+			'https://example.com/product/{slug}/?utm_source=',
+			$output,
+			'Secondary browsing example should use a product-page URL pattern'
+		);
+	}
+
+	public function test_attribution_points_to_ucp_manifest_for_full_templates(): void {
+		// The full URL-template family (add-to-cart variants,
+		// coupon support, grouped/variable product handling) lives
+		// in the UCP manifest's checkout capability config. llms.txt
+		// points agents there instead of duplicating the 10+
+		// template rows — single source of truth.
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( '.well-known/ucp', $output );
+		$this->assertStringContainsString( 'purchase_urls', $output );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpTest.php
+++ b/tests/php/unit/UcpTest.php
@@ -202,23 +202,39 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function test_spec_url_points_to_ucp_shopping_schema(): void {
-		// Points agents at the UCP shopping schema repo so they can
-		// verify our wire format matches what they expect. Since
-		// 1.4.5 the URL pins to the tagged spec revision matching
-		// our `PROTOCOL_VERSION` (see the dedicated pinning test
-		// in the store_context section for the rationale).
+	public function test_service_spec_url_points_to_ucp_overview(): void {
+		// The service-level `spec` URL points at the UCP overview
+		// documentation page on ucp.dev, pinned to our protocol
+		// version. Pre-1.6.4 this pointed at the GitHub schema
+		// directory listing — not a "specification document" per
+		// the entity schema's intent. See 1.6.4 changelog for the
+		// migration rationale.
 		$manifest = $this->ucp->generate_manifest( [] );
 		$binding  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
 
 		$this->assertStringStartsWith(
-			'https://github.com/Universal-Commerce-Protocol/ucp/tree/',
+			'https://ucp.dev/' . WC_AI_Syndication_Ucp::PROTOCOL_VERSION,
 			$binding['spec']
 		);
-		$this->assertStringEndsWith(
-			'/source/schemas/shopping',
-			$binding['spec']
+		$this->assertStringEndsWith( '/specification/overview', $binding['spec'] );
+	}
+
+	public function test_service_schema_url_points_to_openapi_doc(): void {
+		// 1.6.4 added `schema` to the service binding — pinned to
+		// the OpenAPI 3.1 spec for the UCP Shopping REST service.
+		// Agents wanting machine-readable contract validation use
+		// this URL; the OpenAPI doc's `{endpoint}` server variable
+		// is a placeholder they substitute with the merchant's
+		// actual endpoint (our service binding's `endpoint` field).
+		$manifest = $this->ucp->generate_manifest( [] );
+		$binding  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
+
+		$this->assertArrayHasKey( 'schema', $binding );
+		$this->assertStringStartsWith(
+			'https://ucp.dev/' . WC_AI_Syndication_Ucp::PROTOCOL_VERSION,
+			$binding['schema']
 		);
+		$this->assertStringEndsWith( '.openapi.json', $binding['schema'] );
 	}
 
 	// ------------------------------------------------------------------
@@ -485,34 +501,112 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function test_spec_url_is_pinned_to_protocol_version_tag(): void {
-		// 1.4.5 change: the service binding's `spec` field used to
-		// point at `/tree/main/` (a moving target). It now points at
-		// `/tree/v{PROTOCOL_VERSION}/` so a year-old consumer
-		// checking our manifest against the spec reads the exact
-		// revision we shipped against.
+	public function test_spec_and_schema_urls_are_pinned_to_protocol_version(): void {
+		// Iteration of spec-URL pinning through 1.4.5 → 1.6.4:
+		//   - Pre-1.4.5: `/tree/main/` (moving target, wrong)
+		//   - 1.4.5: `/tree/v{VERSION}/source/schemas/shopping` (pinned
+		//           but at a GitHub directory listing, not a spec doc)
+		//   - 1.6.4: `https://ucp.dev/{VERSION}/...` (pinned at the
+		//           canonical docs site + OpenAPI schema)
+		//
+		// This test locks in the 1.6.4 shape: all external URLs
+		// use `ucp.dev/{PROTOCOL_VERSION}/` so one constant drives
+		// every spec/schema reference in the manifest.
 		$manifest = $this->ucp->generate_manifest( [] );
-		$binding  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
-		$expected = 'https://github.com/Universal-Commerce-Protocol/ucp/tree/v' . WC_AI_Syndication_Ucp::PROTOCOL_VERSION . '/source/schemas/shopping';
+		$service  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
+		$version  = WC_AI_Syndication_Ucp::PROTOCOL_VERSION;
 
-		$this->assertSame( $expected, $binding['spec'] );
-		$this->assertStringNotContainsString( '/tree/main/', $binding['spec'] );
+		// Service-level URLs.
+		$this->assertStringContainsString( "/{$version}/", $service['spec'] );
+		$this->assertStringContainsString( "/{$version}/", $service['schema'] );
+
+		// Capability-level URLs.
+		$caps = $manifest['ucp']['capabilities'];
+		foreach ( $caps as $name => $bindings ) {
+			foreach ( $bindings as $binding ) {
+				if ( isset( $binding['spec'] ) ) {
+					$this->assertStringContainsString( "/{$version}/", $binding['spec'], "spec URL for $name must be version-pinned" );
+				}
+				if ( isset( $binding['schema'] ) ) {
+					$this->assertStringContainsString( "/{$version}/", $binding['schema'], "schema URL for $name must be version-pinned" );
+				}
+			}
+		}
+
+		// Regression guard against the pre-1.6.4 GitHub tree URL.
+		$this->assertStringNotContainsString( '/tree/main/', $service['spec'] );
+		$this->assertStringNotContainsString( 'github.com', $service['spec'] );
+	}
+
+	public function test_every_capability_has_spec_and_schema_urls(): void {
+		// 1.6.4 added per-capability `spec` + `schema` URLs.
+		// Agents that want to validate response payloads against
+		// the authoritative contract need these. Locks in both
+		// fields on every advertised capability.
+		$manifest = $this->ucp->generate_manifest( [] );
+
+		foreach ( $manifest['ucp']['capabilities'] as $name => $bindings ) {
+			foreach ( $bindings as $binding ) {
+				$this->assertArrayHasKey( 'spec', $binding, "Capability $name missing spec URL" );
+				$this->assertArrayHasKey( 'schema', $binding, "Capability $name missing schema URL" );
+				$this->assertNotEmpty( $binding['spec'] );
+				$this->assertNotEmpty( $binding['schema'] );
+			}
+		}
 	}
 
 	// ------------------------------------------------------------------
-	// Layer 3: Plugin-specific service config
+	// Layer 3: Plugin-specific checkout capability config
+	//
+	// Note: relocated from service-level to checkout-capability-level
+	// in 1.6.4. Service-level config is for transport concerns (auth,
+	// rate limits); capability-level config is for capability-semantic
+	// concerns (purchase URL templates, UTM attribution). The fields
+	// here describe how agents construct checkout URLs and attribute
+	// orders — both semantically belong with the checkout capability.
 	// ------------------------------------------------------------------
 
 	private function get_config(): array {
 		$manifest = $this->ucp->generate_manifest( [] );
-		return $manifest['ucp']['services']['dev.ucp.shopping'][0]['config'];
+		return $manifest['ucp']['capabilities']['dev.ucp.shopping.checkout'][0]['config'];
 	}
 
-	public function test_service_config_has_purchase_urls_and_attribution(): void {
+	public function test_checkout_capability_config_has_purchase_urls_and_attribution(): void {
 		$config = $this->get_config();
 
 		$this->assertArrayHasKey( 'purchase_urls', $config );
 		$this->assertArrayHasKey( 'attribution', $config );
+	}
+
+	public function test_service_binding_has_no_capability_config(): void {
+		// Regression guard: the pre-1.6.4 placement of
+		// `purchase_urls` + `attribution` under `services[0].config`
+		// was semantically wrong. If a future refactor re-adds it
+		// there (or leaves both copies), this catches the drift.
+		//
+		// Two valid post-1.6.4 states:
+		//   - Service has NO `config` key (current implementation)
+		//   - Service has `config` but without capability-semantic
+		//     fields (future transport-config additions would live
+		//     there, but purchase_urls/attribution never should)
+		$manifest = $this->ucp->generate_manifest( [] );
+		$service  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
+
+		if ( ! isset( $service['config'] ) ) {
+			$this->assertTrue( true, 'Service has no config key — structurally impossible for capability fields to live there' );
+			return;
+		}
+
+		$this->assertArrayNotHasKey(
+			'purchase_urls',
+			$service['config'],
+			'purchase_urls belongs on the checkout capability, not the service binding'
+		);
+		$this->assertArrayNotHasKey(
+			'attribution',
+			$service['config'],
+			'attribution belongs on the checkout capability, not the service binding'
+		);
 	}
 
 	// ----- purchase_urls.checkout_link ----------------------------------

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.6.3
+ * Version: 1.6.4
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.6.3' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.6.4' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Three structural changes driven by cross-reference review

### 1. \`config\` relocated from service → checkout capability

\`purchase_urls\` and \`attribution\` now live on the checkout capability where they semantically belong, not on the service-level binding.

### 2. \`spec\` + \`schema\` URLs added to every entity

- Service binding now has \`schema\` (OpenAPI 3.1)
- Every capability now has both \`spec\` and \`schema\`

### 3. Canonical host: \`ucp.dev/{VERSION}/\`

All external URLs migrated from GitHub \`tree/\` paths to \`ucp.dev\` for single-host consistency.

## Final shape (excerpt)

\`\`\`json
"capabilities": {
  "dev.ucp.shopping.checkout": [{
    "version": "2026-04-08",
    "spec":    "https://ucp.dev/2026-04-08/specification/checkout",
    "schema":  "https://ucp.dev/2026-04-08/schemas/shopping/checkout.json",
    "mode":    "handoff",
    "config":  { "purchase_urls": {...}, "attribution": {...} }
  }]
}
\`\`\`

All external URLs verified 200 before commit.

## Test plan
- [x] 354 PHP tests / 989 assertions (was 351 / 965)
- [x] PHPCS + PHPStan + ESLint clean
- [x] JS tests: 42 pass
- [ ] After deploy: \`curl -s "https://pierorocca.com/.well-known/ucp?v=\$(date +%s)" | jq '.ucp.capabilities."dev.ucp.shopping.checkout"[0]'\` shows spec + schema + config

🤖 Generated with [Claude Code](https://claude.com/claude-code)