### PR TITLE
1.6.5: canonical UCP checkout + com.woocommerce.ai_syndication extension

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -266,37 +266,54 @@ class WC_AI_Syndication_Llms_Txt {
 			$lines[] = '';
 		}
 
-		// Attribution instructions.
+		// Attribution instructions. This section is the
+		// AUTHORITATIVE merchant-facing guidance for AI-agent
+		// attribution. The UCP manifest carries the same parameter
+		// set under the `com.woocommerce.ai_syndication` extension,
+		// but UCP itself doesn't define attribution semantics —
+		// so the canonical guidance lives here in the
+		// human+machine-readable document, not in the wire-format
+		// manifest.
 		//
-		// Example URL uses the `/checkout-link/` pattern, not a
-		// product-page URL, because that's the canonical purchase
-		// path this plugin exposes. A product page doesn't route a
-		// customer to checkout — agents that need to drive purchase
-		// intent use checkout-link (adds items + redirects to
-		// checkout in one step, customer never sees the cart).
-		// The UCP manifest at /.well-known/ucp advertises the full
-		// URL-template family; llms.txt surfaces the canonical one.
-		$lines[] = '## Attribution';
-		$lines[] = '';
-		$lines[] = 'When linking customers to your store for a purchase, append the following query parameters for order attribution:';
-		$lines[] = '';
-		$lines[] = '- `utm_source`: Your agent identifier (e.g. `chatgpt`, `gemini`, `perplexity`)';
-		$lines[] = '- `utm_medium`: `ai_agent`';
-		$lines[] = '- `utm_campaign`: Optional campaign name';
-		$lines[] = '- `ai_session_id`: The current conversation/session ID';
-		$lines[] = '';
-		$lines[] = 'These map to standard WooCommerce Order Attribution fields.';
-		$lines[] = '';
-		$lines[] = 'Example (checkout-link — recommended, sends customer straight to checkout):';
-		$lines[] = '';
-		$lines[] = '`' . $site_url . 'checkout-link/?products={product_id}:{quantity}&utm_source={agent_id}&utm_medium=ai_agent&ai_session_id={session_id}`';
-		$lines[] = '';
-		$lines[] = 'Example (product page — for browsing, not purchase):';
-		$lines[] = '';
-		$lines[] = '`' . $site_url . 'product/{slug}/?utm_source={agent_id}&utm_medium=ai_agent&ai_session_id={session_id}`';
-		$lines[] = '';
-		$lines[] = 'The full URL template family (add-to-cart variants, coupon support, variable products) is in the UCP manifest at `' . $site_url . '.well-known/ucp` under `capabilities["dev.ucp.shopping.checkout"][0].config.purchase_urls`.';
-		$lines[] = '';
+		// 1.6.5 removed URL-template examples in favor of the
+		// API-first flow (`POST /checkout-sessions`), matching the
+		// UCP checkout spec's SHOULD directive that businesses
+		// should provide continue_url rather than platforms
+		// constructing their own. Agents that prefer direct URL
+		// construction can still derive the pattern from
+		// WooCommerce's public /checkout-link/ documentation —
+		// we just don't advertise templates that nudge agents
+		// away from the canonical path.
+		$ucp_rest_base = rtrim( rest_url( 'wc/ucp/v1' ), '/' );
+		$lines[]       = '## Attribution';
+		$lines[]       = '';
+		$lines[]       = 'The recommended purchase flow is to `POST` line items to our UCP checkout endpoint; the server returns a `continue_url` with attribution pre-attached, and the agent redirects the user there. This matches the UCP checkout specification\'s `requires_escalation` / `continue_url` contract.';
+		$lines[]       = '';
+		$lines[]       = 'Endpoint:';
+		$lines[]       = '';
+		$lines[]       = '`POST ' . $ucp_rest_base . '/checkout-sessions`';
+		$lines[]       = '';
+		$lines[]       = 'Request body (UCP Checkout schema):';
+		$lines[]       = '';
+		$lines[]       = '```json';
+		$lines[]       = '{';
+		$lines[]       = '  "line_items": [{ "item": { "id": "123" }, "quantity": 1 }]';
+		$lines[]       = '}';
+		$lines[]       = '```';
+		$lines[]       = '';
+		$lines[]       = 'Set the `UCP-Agent` request header to your agent\'s discovery profile URL; the server uses the hostname from that header as `utm_source` automatically, so you do not need to construct UTM parameters yourself.';
+		$lines[]       = '';
+		$lines[]       = 'Response includes `status: "requires_escalation"` and a `continue_url` with `utm_source` + `utm_medium=ai_agent` already attached. Redirect the user to that URL to complete the purchase on our site.';
+		$lines[]       = '';
+		$lines[]       = 'If you must construct a checkout URL client-side (legacy or non-UCP-aware flow), append these parameters for order attribution:';
+		$lines[]       = '';
+		$lines[]       = '- `utm_source`: Your agent identifier (e.g. `chatgpt`, `gemini`, `perplexity`)';
+		$lines[]       = '- `utm_medium`: `ai_agent`';
+		$lines[]       = '- `utm_campaign`: Optional campaign name';
+		$lines[]       = '- `ai_session_id`: The current conversation/session ID';
+		$lines[]       = '';
+		$lines[]       = 'These map to standard WooCommerce Order Attribution fields. See the WooCommerce [Shareable Checkout URLs](https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/) documentation for URL construction patterns.';
+		$lines[]       = '';
 
 		/**
 		 * Filter the llms.txt content lines before rendering.

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -189,65 +189,37 @@ class WC_AI_Syndication_Ucp {
 	 * @return array The manifest data.
 	 */
 	public function generate_manifest( $settings ) {
-		$site_url     = home_url( '/' );
-		$checkout_url = wc_get_checkout_url();
-		$cart_url     = wc_get_cart_url();
 		$ucp_endpoint = rest_url( 'wc/ucp/v1' );
 
-		// Shared checkout-capability config. Relocated here from
-		// the service-level `config` in 1.6.4 — the UCP entity
-		// schema permits `config` at both levels, but semantically
-		// these fields (purchase URL templates, UTM attribution
-		// conventions) describe the checkout capability rather
-		// than the service transport. Service-level config is for
-		// transport-specific concerns (auth, rate limits, endpoint
-		// tuning); capability-level config is for
-		// capability-semantic concerns. The pre-1.6.4 placement
-		// was syntactically valid but semantically misaligned.
-		$checkout_config = [
-			'purchase_urls' => [
-				'spec'             => 'https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/',
-				'add_to_cart_spec' => 'https://woocommerce.com/document/quick-guide-to-woocommerce-add-to-cart-urls/',
-
-				// Checkout-link: adds items AND redirects to
-				// checkout. Customer never sees the cart — fewest
-				// clicks to purchase.
-				'checkout_link'    => [
-					'description' => 'Recommended — adds items and redirects to checkout in one step. Customer never sees the cart.',
-					'simple'      => $site_url . 'checkout-link/?products={product_id}:{quantity}',
-					'variable'    => $site_url . 'checkout-link/?products={variation_id}:{quantity}',
-					'multi_item'  => $site_url . 'checkout-link/?products={id}:{qty},{id}:{qty}',
-					'with_coupon' => $site_url . 'checkout-link/?products={id}:{qty}&coupon={coupon_code}',
-					'unsupported' => [ 'grouped', 'external', 'subscription' ],
-				],
-
-				// Classic add-to-cart URL. Three behaviors
-				// depending on base URL — the official WC docs
-				// document all three.
-				'add_to_cart'      => [
-					'description'      => 'Classic WooCommerce add-to-cart URL. Three behaviors depending on base URL.',
-					'add_only'         => $site_url . '?add-to-cart={product_id}&quantity={quantity}',
-					'add_and_cart'     => $cart_url . '?add-to-cart={product_id}&quantity={quantity}',
-					'add_and_checkout' => $checkout_url . '?add-to-cart={product_id}&quantity={quantity}',
-					'grouped'          => [
-						'template' => $checkout_url . '?add-to-cart={grouped_product_id}&quantity[{sub_product_id}]={quantity}',
-						'note'     => 'Use the classic add-to-cart pattern for grouped products. The checkout-link feature does not support them.',
-					],
-					'external_note'    => 'For external/affiliate products (type: external), link directly to the product\'s external_url field from the Store API. Do not use add-to-cart.',
-				],
+		// Attribution conventions for the WooCommerce Order
+		// Attribution system. Used to document the UTM parameter
+		// contract so merchant analytics segment AI-sourced orders
+		// consistently. Canonical guidance lives in llms.txt (the
+		// human-readable document) per spec-discipline: UCP doesn't
+		// define attribution semantics, so machine-readable hint
+		// here must not pretend to be canonical — it's merchant
+		// metadata, hence the `com.woocommerce.*` extension home.
+		//
+		// Purchase URL templates (checkout_link, add_to_cart) that
+		// lived here before 1.6.5 were removed. The canonical UCP
+		// checkout path is the `POST /checkout-sessions` API: agents
+		// send line items, the server constructs the continue_url
+		// (with these UTM parameters pre-attached from the
+		// UCP-Agent header), and returns `status: requires_escalation`.
+		// Client-side URL construction from templates was the "less
+		// preferred" path per the UCP spec's SHOULD directive on
+		// business-provided continue_url. Spec-strict agents use
+		// the API; legacy path is documented in llms.txt only.
+		$attribution_config = [
+			'spec'       => 'https://woocommerce.com/document/order-attribution-tracking/',
+			'system'     => 'woocommerce_order_attribution',
+			'parameters' => [
+				'utm_source'    => 'Your agent identifier (e.g. chatgpt, gemini, perplexity)',
+				'utm_medium'    => 'Must be set to "ai_agent"',
+				'utm_campaign'  => 'Optional campaign name',
+				'ai_session_id' => 'Conversation/session identifier for tracking',
 			],
-
-			'attribution'   => [
-				'spec'       => 'https://woocommerce.com/document/order-attribution-tracking/',
-				'system'     => 'woocommerce_order_attribution',
-				'parameters' => [
-					'utm_source'    => 'Your agent identifier (e.g. chatgpt, gemini, perplexity)',
-					'utm_medium'    => 'Must be set to "ai_agent"',
-					'utm_campaign'  => 'Optional campaign name',
-					'ai_session_id' => 'Conversation/session identifier for tracking',
-				],
-				'usage_note' => 'Append these parameters to any checkout_link or add_to_cart URL. The UCP /checkout-sessions endpoint adds utm_source + utm_medium automatically from the UCP-Agent header.',
-			],
+			'usage_note' => 'The UCP /checkout-sessions endpoint adds utm_source + utm_medium automatically from the UCP-Agent header. See llms.txt for the canonical agent-attribution flow.',
 		];
 
 		// Base docs URL for the version-pinned ucp.dev spec site.
@@ -257,7 +229,7 @@ class WC_AI_Syndication_Ucp {
 		$spec_base = 'https://ucp.dev/' . self::PROTOCOL_VERSION;
 
 		$manifest = [
-			'ucp'           => [
+			'ucp' => [
 				'version'          => self::PROTOCOL_VERSION,
 
 				// Services — single REST binding at our UCP namespace.
@@ -320,34 +292,51 @@ class WC_AI_Syndication_Ucp {
 							'schema'  => $spec_base . '/schemas/shopping/catalog_lookup.json',
 						],
 					],
-					// `mode: handoff` signals that our checkout
-					// implementation is redirect-only — agents that
-					// call POST /checkout-sessions get a `continue_url`
-					// back and are expected to redirect the user to
-					// WooCommerce's own checkout. No in-chat payment
-					// processing, no server-side cart lifecycle. This
-					// is an additive hint (UCP schema's
-					// additionalProperties: true accommodates it) so
-					// agents that understand it can branch on it, and
-					// agents that don't just see an extra field.
-					//
-					// The runtime signal for the same pattern is the
-					// response's `status: requires_escalation` +
-					// `continue_url`, but the manifest-level `mode`
-					// lets agents decide whether to invoke at all
-					// without a roundtrip.
-					//
-					// `config` carries the checkout capability's
-					// purchase-URL templates and UTM attribution
-					// conventions — relocated from service-level in
-					// 1.6.4. See `$checkout_config` above.
+					// Pure canonical UCP — no `mode`, no `config`. The
+					// pre-1.6.5 `mode: "handoff"` hint is non-canonical
+					// (not defined in capability.json) and redundant
+					// with the runtime `status: requires_escalation`
+					// signal that already carries the handoff intent
+					// in the response. The pre-1.6.5 `config` with
+					// purchase URL templates was the "less preferred"
+					// path per the UCP checkout spec's SHOULD directive
+					// on business-provided continue_url. Canonical
+					// flow: agent POSTs to /checkout-sessions → server
+					// builds continue_url with UTM → returns with
+					// status: requires_escalation → agent redirects.
 					'dev.ucp.shopping.checkout'       => [
 						[
 							'version' => self::PROTOCOL_VERSION,
 							'spec'    => $spec_base . '/specification/checkout',
 							'schema'  => $spec_base . '/schemas/shopping/checkout.json',
-							'mode'    => 'handoff',
-							'config'  => $checkout_config,
+						],
+					],
+
+					// Merchant-specific extension capability. Carries
+					// commerce context (currency, locale, tax/shipping
+					// posture) and attribution conventions that UCP
+					// doesn't define but agents benefit from knowing
+					// upfront. Uses the spec-defined extension pattern
+					// (`extends` pointing at a parent service/capability)
+					// rather than a root-level custom field — this
+					// is the idiomatic UCP home for vendor-specific
+					// merchant data. See
+					// `source/schemas/capability.json` `base.extends`
+					// for the pattern definition.
+					//
+					// Agents that only iterate standard `dev.ucp.*`
+					// capabilities ignore this entirely; agents that
+					// want upfront store facts (currency to quote in,
+					// whether prices include tax, whether shipping
+					// applies) find them without an extra API call.
+					'com.woocommerce.ai_syndication'  => [
+						[
+							'version' => self::PROTOCOL_VERSION,
+							'extends' => self::SERVICE_NAME,
+							'config'  => [
+								'store_context' => $this->build_store_context(),
+								'attribution'   => $attribution_config,
+							],
 						],
 					],
 				],
@@ -357,15 +346,6 @@ class WC_AI_Syndication_Ucp {
 				// checkout handles payment via their configured gateway.
 				'payment_handlers' => (object) [],
 			],
-
-			// Merchant-level commerce context. Sibling to `ucp`
-			// rather than nested inside, because these facts are
-			// agnostic of the UCP spec — any AI-commerce ecosystem
-			// tool (UCP-aware or not) can read them. Fields match
-			// common ecommerce-platform conventions (Stripe, Shopify)
-			// so consumer code already familiar with those names
-			// reads our manifest without a glossary step.
-			'store_context' => $this->build_store_context(),
 		];
 
 		/**

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.6.4
+Stable tag: 1.6.5
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -109,6 +109,13 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.6.5 =
+* Changed: UCP manifest restructured to match the spec's canonical-capabilities-plus-extension pattern (`capability.json` `base.extends`). Three structural changes: (1) removed `mode: "handoff"` from the `dev.ucp.shopping.checkout` capability — non-canonical (not defined in `capability.json`) and redundant with the runtime `status: requires_escalation` signal the endpoint already returns; (2) removed the `config` block containing `purchase_urls` + `attribution` from the checkout capability — the UCP checkout spec carries a SHOULD directive that businesses provide `continue_url` rather than platforms constructing permalinks, so advertising URL templates in the canonical capability was nudging agents toward the less-preferred path; (3) introduced the `com.woocommerce.ai_syndication` extension capability with `extends: "dev.ucp.shopping"` as the idiomatic UCP home for merchant-specific metadata — carries `store_context` (currency, locale, country, tax/shipping posture) and `attribution` (UTM convention documentation).
+* Changed: root-level `store_context` field removed — relocated inside the extension capability at `capabilities["com.woocommerce.ai_syndication"][0].config.store_context`. The root-level placement from 1.4.5 was valid under `additionalProperties: true` but not spec-idiomatic; the extension-capability home is the spec's designed pattern for vendor-specific data.
+* Changed: llms.txt is now the authoritative source for agent attribution guidance. Its `## Attribution` section leads with the canonical UCP flow (`POST /checkout-sessions` → server constructs `continue_url` with UTM pre-attached → response returns `status: "requires_escalation"` → agent redirects user), followed by fallback UTM-parameter guidance for agents that must construct URLs client-side. Pre-1.6.5 llms.txt emitted literal URL-template examples; those are now removed in favor of a pointer to WooCommerce's public `/checkout-link/` documentation for agents that need URL patterns.
+* Removed: URL-template library (`purchase_urls.checkout_link.*` and `purchase_urls.add_to_cart.*`) from the UCP manifest entirely. Agents unable to use the `POST /checkout-sessions` canonical flow should consult the public WooCommerce shareable-checkout-URL docs referenced in llms.txt. Rationale: the UCP spec's SHOULD directive; with zero documented autonomous-agent usage of the templates (the one live test was a manually-prompted Gemini session, not in-the-wild behavior), keeping them was more signal-confusion than value.
+* Added: regression tests locking in the new structure — `checkout_capability_has_no_mode_or_config`, `declared_capabilities_are_exactly_three_canonical_plus_one_extension`, `store_context_no_longer_lives_at_manifest_root`, `checkout_capability_has_no_purchase_urls_after_1_6_5`, and extension-specific attribution tests. Total: 345 tests / 980 assertions.
 
 = 1.6.4 =
 * Changed: UCP manifest structure reorganized to match April spec's `entity` semantic conventions. Three coordinated changes: (1) the `config` block carrying `purchase_urls` + `attribution` moved from service-level (`services["dev.ucp.shopping"][0].config`) to checkout-capability-level (`capabilities["dev.ucp.shopping.checkout"][0].config`) — both placements are syntactically valid per the UCP entity schema, but semantically these are checkout-specific concerns and belong with the checkout capability; (2) added `spec` + `schema` URLs to every capability binding (`catalog.search`, `catalog.lookup`, `checkout`) pointing at ucp.dev's canonical per-capability documentation and JSON Schema files; (3) added `schema` to the service binding pointing at the OpenAPI 3.1 spec for the UCP Shopping REST service. Agents wanting machine-readable contract validation now have authoritative URLs for both the service-level transport (OpenAPI) and the capability-level payloads (JSON Schema).

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -162,38 +162,42 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( '`ai_session_id`', $output );
 	}
 
-	public function test_attribution_includes_checkout_link_example(): void {
-		// 1.6.4 change: the attribution example now uses the
-		// `/checkout-link/` pattern — the canonical purchase path
-		// this plugin exposes — rather than a product page URL.
-		// A product page doesn't route to checkout; agents wanting
-		// to drive purchase intent need checkout-link. The product
-		// page example is still included as a secondary example
-		// for browsing intent.
+	public function test_attribution_leads_with_api_first_checkout_flow(): void {
+		// 1.6.5 change: the attribution section now leads with the
+		// canonical UCP flow (POST /checkout-sessions) rather than
+		// URL-template examples. Matches the UCP checkout spec's
+		// SHOULD directive: businesses provide continue_url,
+		// platforms don't construct their own.
 		$output = $this->llms->generate();
 
-		$this->assertStringContainsString(
-			'https://example.com/checkout-link/?products={product_id}:{quantity}&utm_source=',
-			$output,
-			'Primary attribution example should use the checkout-link pattern'
-		);
-		$this->assertStringContainsString(
-			'https://example.com/product/{slug}/?utm_source=',
-			$output,
-			'Secondary browsing example should use a product-page URL pattern'
-		);
+		$this->assertStringContainsString( '/checkout-sessions', $output );
+		$this->assertStringContainsString( 'UCP-Agent', $output );
+		$this->assertStringContainsString( 'requires_escalation', $output );
+		$this->assertStringContainsString( 'continue_url', $output );
 	}
 
-	public function test_attribution_points_to_ucp_manifest_for_full_templates(): void {
-		// The full URL-template family (add-to-cart variants,
-		// coupon support, grouped/variable product handling) lives
-		// in the UCP manifest's checkout capability config. llms.txt
-		// points agents there instead of duplicating the 10+
-		// template rows — single source of truth.
+	public function test_attribution_still_documents_utm_parameters_for_legacy_flow(): void {
+		// Agents that must construct URLs client-side (non-UCP-aware
+		// or legacy flows) still need the UTM convention documented.
+		// Kept in llms.txt as authoritative human-readable guidance
+		// after 1.6.5 removed the template library from the manifest.
 		$output = $this->llms->generate();
 
-		$this->assertStringContainsString( '.well-known/ucp', $output );
-		$this->assertStringContainsString( 'purchase_urls', $output );
+		$this->assertStringContainsString( 'utm_source', $output );
+		$this->assertStringContainsString( 'utm_medium', $output );
+		$this->assertStringContainsString( 'ai_agent', $output );
+		$this->assertStringContainsString( 'ai_session_id', $output );
+	}
+
+	public function test_attribution_points_to_woocommerce_public_docs_for_url_construction(): void {
+		// When manifest templates are removed, agents that need URL
+		// patterns should be directed to WooCommerce's public
+		// documentation rather than discovering them by trial.
+		// 1.6.5 added this pointer in place of the manifest
+		// purchase_urls reference.
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( 'woocommerce.com/document/creating-sharable-checkout-urls', $output );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpTest.php
+++ b/tests/php/unit/UcpTest.php
@@ -288,24 +288,26 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	public function test_checkout_capability_declares_handoff_mode(): void {
-		// Agents reading the manifest need a programmatic signal that
-		// our checkout is redirect-only (no in-chat payment, no
-		// server-side cart lifecycle) before deciding to invoke the
-		// endpoint. Without this hint they have to call the endpoint
-		// and parse `status: requires_escalation` in the response —
-		// wasted roundtrip for agents that don't support handoff
-		// flows. The `mode: handoff` field is a schema-compatible
-		// additive hint (UCP entities allow additionalProperties).
+	public function test_checkout_capability_has_no_mode_or_config(): void {
+		// 1.6.5 reversal: pre-1.6.5 we emitted `mode: "handoff"` +
+		// a `config` block with URL templates on the checkout
+		// capability. Neither is defined in UCP's capability.json —
+		// both were additive under the spec's
+		// `additionalProperties: true`. The canonical UCP checkout
+		// handoff contract is runtime: the endpoint returns
+		// `status: "requires_escalation"` + a `continue_url`. The
+		// spec's SHOULD directive prefers business-provided
+		// continue_url over platform-constructed checkout permalinks,
+		// which argued against keeping the template library here.
 		//
-		// If this field is ever dropped, agents that relied on the
-		// upfront signal would regress to the roundtrip. Locks in the
-		// contract.
+		// Post-1.6.5, the checkout capability is canonical UCP only.
+		// Merchant-specific attribution + store_context lives in
+		// the `com.woocommerce.ai_syndication` extension capability.
 		$manifest = $this->ucp->generate_manifest( [] );
+		$binding  = $manifest['ucp']['capabilities']['dev.ucp.shopping.checkout'][0];
 
-		$binding = $manifest['ucp']['capabilities']['dev.ucp.shopping.checkout'][0];
-		$this->assertArrayHasKey( 'mode', $binding );
-		$this->assertEquals( 'handoff', $binding['mode'] );
+		$this->assertArrayNotHasKey( 'mode', $binding, 'mode was removed in 1.6.5 — non-canonical hint replaced by runtime status signal' );
+		$this->assertArrayNotHasKey( 'config', $binding, 'config was removed in 1.6.5 — URL templates moved to llms.txt; canonical flow is POST /checkout-sessions' );
 	}
 
 	public function test_catalog_sub_capabilities_have_no_mode_hint(): void {
@@ -331,10 +333,15 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// would fail strict schema validation.
 		$manifest = $this->ucp->generate_manifest( [] );
 
+		// Includes the 1.6.5 extension capability
+		// (com.woocommerce.ai_syndication) — extensions follow the
+		// same [{binding}] shape as canonical capabilities per the
+		// UCP capability schema.
 		$capabilities = [
 			'dev.ucp.shopping.catalog.search',
 			'dev.ucp.shopping.catalog.lookup',
 			'dev.ucp.shopping.checkout',
+			'com.woocommerce.ai_syndication',
 		];
 
 		foreach ( $capabilities as $cap ) {
@@ -350,14 +357,16 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
-	public function test_no_extraneous_capabilities_declared(): void {
-		// Regression guard: we implement catalog.search + catalog.lookup
-		// + checkout only. If a future refactor accidentally declared
-		// cart, order, identity linking, payment token exchange, etc.,
-		// agents would try to invoke operations we haven't built — and
-		// fail. Declaring only what we've implemented is the honest
-		// posture. When we DO add new capabilities (order is the likely
-		// 1.7.0 candidate) this test gets updated explicitly.
+	public function test_declared_capabilities_are_exactly_three_canonical_plus_one_extension(): void {
+		// Regression guard on the exact capability set:
+		//   - 3 canonical UCP capabilities we implement
+		//     (catalog.search, catalog.lookup, checkout)
+		//   - 1 merchant-specific extension carrying store_context +
+		//     attribution (com.woocommerce.ai_syndication)
+		//
+		// Extensions use the `extends` field to link back to the
+		// parent capability/service; canonical capabilities have
+		// no `extends`. That's the structural invariant below.
 		$manifest = $this->ucp->generate_manifest( [] );
 
 		$this->assertEqualsCanonicalizing(
@@ -365,9 +374,24 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 				'dev.ucp.shopping.catalog.search',
 				'dev.ucp.shopping.catalog.lookup',
 				'dev.ucp.shopping.checkout',
+				'com.woocommerce.ai_syndication',
 			],
 			array_keys( $manifest['ucp']['capabilities'] )
 		);
+
+		// Canonical capabilities MUST NOT have `extends` (they ARE
+		// the base capabilities other things extend).
+		foreach ( [ 'dev.ucp.shopping.catalog.search', 'dev.ucp.shopping.catalog.lookup', 'dev.ucp.shopping.checkout' ] as $canonical ) {
+			$this->assertArrayNotHasKey(
+				'extends',
+				$manifest['ucp']['capabilities'][ $canonical ][0],
+				"$canonical is a canonical capability — it should not carry an extends field"
+			);
+		}
+
+		// The extension MUST carry `extends` pointing at the parent.
+		$ext = $manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0];
+		$this->assertSame( 'dev.ucp.shopping', $ext['extends'] );
 	}
 
 	public function test_payment_handlers_is_empty_object(): void {
@@ -413,30 +437,46 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// Layer 2.5: store_context block (1.4.5+)
+	// Layer 2.5: com.woocommerce.ai_syndication extension capability
 	// ------------------------------------------------------------------
 	//
-	// Added in 1.4.5 after cross-agent review feedback that the
-	// manifest lacked merchant-level commerce context (currency,
-	// locale, tax/shipping posture). These tests lock in the five
-	// contract fields and cover the ICU→BCP 47 locale conversion
-	// that's the most likely regression source — WordPress stores
-	// locales in underscore form and it's easy to forward that
-	// verbatim into the manifest by mistake.
+	// Pre-1.6.5: store_context lived as a root-level sibling of the
+	// `ucp` wrapper. 1.6.5 moved it inside the extension capability
+	// `com.woocommerce.ai_syndication.config.store_context` per the
+	// UCP spec's extension pattern (a capability with `extends`
+	// pointing at a parent). The five store_context contract fields
+	// are unchanged; only the path in the manifest changed.
+	//
+	// The extension also now carries attribution guidance (moved
+	// from the checkout capability's config in the same release).
 
-	public function test_manifest_has_store_context_top_level_key(): void {
+	/**
+	 * Resolve the extension's config block for store_context / attribution
+	 * tests. Pre-1.6.5 this was `$manifest['store_context']`; post-1.6.5
+	 * it's `$manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config']['store_context']`.
+	 */
+	private function get_store_context(): array {
+		$manifest = $this->ucp->generate_manifest( [] );
+		return $manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config']['store_context'];
+	}
+
+	public function test_store_context_no_longer_lives_at_manifest_root(): void {
+		// Regression guard: the 1.4.5 → 1.6.4 placement at
+		// `$manifest['store_context']` was moved inside the extension
+		// capability in 1.6.5. A future refactor that re-emits it at
+		// root (e.g. for perceived convenience) would collide with
+		// this assertion and force a conscious re-decision.
 		$manifest = $this->ucp->generate_manifest( [] );
 
-		$this->assertArrayHasKey( 'store_context', $manifest );
-		$this->assertIsArray( $manifest['store_context'] );
+		$this->assertArrayNotHasKey( 'store_context', $manifest );
 	}
 
 	public function test_store_context_declares_iso_4217_currency(): void {
 		Functions\when( 'get_woocommerce_currency' )->justReturn( 'EUR' );
 
-		$manifest = $this->ucp->generate_manifest( [] );
+		$ctx = $this->get_store_context();
 
-		$this->assertSame( 'EUR', $manifest['store_context']['currency'] );
+		$this->assertSame( 'EUR', $ctx['currency'] );
 	}
 
 	public function test_store_context_locale_uses_bcp_47_hyphen_not_icu_underscore(): void {
@@ -446,35 +486,29 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// side and asserting the manifest side locks it in.
 		Functions\when( 'get_locale' )->justReturn( 'pt_BR' );
 
-		$manifest = $this->ucp->generate_manifest( [] );
+		$ctx = $this->get_store_context();
 
-		$this->assertSame( 'pt-BR', $manifest['store_context']['locale'] );
-		$this->assertStringNotContainsString( '_', $manifest['store_context']['locale'] );
+		$this->assertSame( 'pt-BR', $ctx['locale'] );
+		$this->assertStringNotContainsString( '_', $ctx['locale'] );
 	}
 
 	public function test_store_context_reports_prices_include_tax(): void {
 		// EU-style VAT-inclusive storefront.
 		Functions\when( 'wc_prices_include_tax' )->justReturn( true );
 
-		$manifest = $this->ucp->generate_manifest( [] );
-
-		$this->assertTrue( $manifest['store_context']['prices_include_tax'] );
+		$this->assertTrue( $this->get_store_context()['prices_include_tax'] );
 	}
 
 	public function test_store_context_reports_prices_exclude_tax(): void {
 		// US-style tax-exclusive storefront — default in the
 		// setUp stub.
-		$manifest = $this->ucp->generate_manifest( [] );
-
-		$this->assertFalse( $manifest['store_context']['prices_include_tax'] );
+		$this->assertFalse( $this->get_store_context()['prices_include_tax'] );
 	}
 
 	public function test_store_context_reports_shipping_disabled_for_digital_only(): void {
 		Functions\when( 'wc_shipping_enabled' )->justReturn( false );
 
-		$manifest = $this->ucp->generate_manifest( [] );
-
-		$this->assertFalse( $manifest['store_context']['shipping_enabled'] );
+		$this->assertFalse( $this->get_store_context()['shipping_enabled'] );
 	}
 
 	public function test_store_context_country_is_null_when_wc_countries_unavailable(): void {
@@ -482,9 +516,7 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// falls through to null. Asserting this locks in the
 		// graceful-degradation branch: the manifest must not crash
 		// or emit garbage when the WC global isn't ready.
-		$manifest = $this->ucp->generate_manifest( [] );
-
-		$this->assertNull( $manifest['store_context']['country'] );
+		$this->assertNull( $this->get_store_context()['country'] );
 	}
 
 	public function test_store_context_fields_are_exactly_those_documented(): void {
@@ -493,11 +525,9 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// consumer documentation, this test fires. The fix is
 		// deliberate: either update this test (conscious addition)
 		// or remove the stray field.
-		$manifest = $this->ucp->generate_manifest( [] );
-
 		$this->assertSame(
 			[ 'currency', 'locale', 'country', 'prices_include_tax', 'shipping_enabled' ],
-			array_keys( $manifest['store_context'] )
+			array_keys( $this->get_store_context() )
 		);
 	}
 
@@ -538,17 +568,25 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringNotContainsString( 'github.com', $service['spec'] );
 	}
 
-	public function test_every_capability_has_spec_and_schema_urls(): void {
-		// 1.6.4 added per-capability `spec` + `schema` URLs.
-		// Agents that want to validate response payloads against
-		// the authoritative contract need these. Locks in both
-		// fields on every advertised capability.
-		$manifest = $this->ucp->generate_manifest( [] );
+	public function test_every_canonical_capability_has_spec_and_schema_urls(): void {
+		// 1.6.4 added per-capability `spec` + `schema` URLs for
+		// canonical UCP capabilities. Extension capabilities
+		// (`com.woocommerce.*`) are vendor-specific and don't
+		// carry canonical spec/schema URLs — they derive their
+		// contract from the `extends` relationship back to the
+		// parent. Only the canonical capabilities are required to
+		// carry both URLs.
+		$manifest       = $this->ucp->generate_manifest( [] );
+		$canonical_caps = [
+			'dev.ucp.shopping.catalog.search',
+			'dev.ucp.shopping.catalog.lookup',
+			'dev.ucp.shopping.checkout',
+		];
 
-		foreach ( $manifest['ucp']['capabilities'] as $name => $bindings ) {
-			foreach ( $bindings as $binding ) {
-				$this->assertArrayHasKey( 'spec', $binding, "Capability $name missing spec URL" );
-				$this->assertArrayHasKey( 'schema', $binding, "Capability $name missing schema URL" );
+		foreach ( $canonical_caps as $name ) {
+			foreach ( $manifest['ucp']['capabilities'][ $name ] as $binding ) {
+				$this->assertArrayHasKey( 'spec', $binding, "Canonical capability $name missing spec URL" );
+				$this->assertArrayHasKey( 'schema', $binding, "Canonical capability $name missing schema URL" );
 				$this->assertNotEmpty( $binding['spec'] );
 				$this->assertNotEmpty( $binding['schema'] );
 			}
@@ -556,223 +594,84 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// Layer 3: Plugin-specific checkout capability config
-	//
-	// Note: relocated from service-level to checkout-capability-level
-	// in 1.6.4. Service-level config is for transport concerns (auth,
-	// rate limits); capability-level config is for capability-semantic
-	// concerns (purchase URL templates, UTM attribution). The fields
-	// here describe how agents construct checkout URLs and attribute
-	// orders — both semantically belong with the checkout capability.
+	// Layer 3: com.woocommerce.ai_syndication extension — attribution
 	// ------------------------------------------------------------------
+	//
+	// 1.6.5 structural change rationale:
+	//   - Pre-1.6.5 attribution config lived at
+	//     `capabilities["dev.ucp.shopping.checkout"][0].config.attribution`
+	//   - Post-1.6.5 it lives at
+	//     `capabilities["com.woocommerce.ai_syndication"][0].config.attribution`
+	//
+	// The canonical checkout capability stays pure UCP (no
+	// attribution config). Attribution conventions are merchant-
+	// specific (UCP doesn't define the attribution schema), so
+	// they belong in the extension capability. llms.txt carries
+	// the canonical human-readable guidance; the extension config
+	// is the machine-readable mirror.
+	//
+	// The purchase_urls test suite (11 tests total from 1.3.x)
+	// was removed in 1.6.5 because the URL templates themselves
+	// were removed — the canonical UCP checkout path is now the
+	// POST /checkout-sessions API, and template-based direct URL
+	// construction is documented only in llms.txt for agents that
+	// cannot use the API.
 
-	private function get_config(): array {
+	private function get_attribution(): array {
 		$manifest = $this->ucp->generate_manifest( [] );
-		return $manifest['ucp']['capabilities']['dev.ucp.shopping.checkout'][0]['config'];
+		return $manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config']['attribution'];
 	}
 
-	public function test_checkout_capability_config_has_purchase_urls_and_attribution(): void {
-		$config = $this->get_config();
-
-		$this->assertArrayHasKey( 'purchase_urls', $config );
-		$this->assertArrayHasKey( 'attribution', $config );
-	}
-
-	public function test_service_binding_has_no_capability_config(): void {
-		// Regression guard: the pre-1.6.4 placement of
-		// `purchase_urls` + `attribution` under `services[0].config`
-		// was semantically wrong. If a future refactor re-adds it
-		// there (or leaves both copies), this catches the drift.
-		//
-		// Two valid post-1.6.4 states:
-		//   - Service has NO `config` key (current implementation)
-		//   - Service has `config` but without capability-semantic
-		//     fields (future transport-config additions would live
-		//     there, but purchase_urls/attribution never should)
+	public function test_checkout_capability_has_no_purchase_urls_after_1_6_5(): void {
+		// Regression guard for the 1.6.5 removal. If any future
+		// change re-adds `purchase_urls` to the checkout capability,
+		// this test fires — forcing a conscious re-decision vs the
+		// spec's SHOULD directive preferring business-provided
+		// continue_url over platform-constructed templates.
 		$manifest = $this->ucp->generate_manifest( [] );
-		$service  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
+		$binding  = $manifest['ucp']['capabilities']['dev.ucp.shopping.checkout'][0];
 
-		if ( ! isset( $service['config'] ) ) {
-			$this->assertTrue( true, 'Service has no config key — structurally impossible for capability fields to live there' );
-			return;
-		}
-
-		$this->assertArrayNotHasKey(
-			'purchase_urls',
-			$service['config'],
-			'purchase_urls belongs on the checkout capability, not the service binding'
-		);
-		$this->assertArrayNotHasKey(
-			'attribution',
-			$service['config'],
-			'attribution belongs on the checkout capability, not the service binding'
-		);
+		$this->assertArrayNotHasKey( 'config', $binding );
 	}
 
-	// ----- purchase_urls.checkout_link ----------------------------------
-
-	public function test_checkout_link_templates_cover_all_supported_types(): void {
-		// Agents generating purchase URLs need the full vocabulary of
-		// product types the /checkout-link/ feature supports. Missing
-		// one means that product type can't be handled by agents that
-		// only read the manifest.
-		$cl = $this->get_config()['purchase_urls']['checkout_link'];
-
-		$this->assertArrayHasKey( 'simple', $cl );
-		$this->assertArrayHasKey( 'variable', $cl );
-		$this->assertArrayHasKey( 'multi_item', $cl );
-		$this->assertArrayHasKey( 'with_coupon', $cl );
-		$this->assertArrayHasKey( 'unsupported', $cl );
-	}
-
-	public function test_checkout_link_simple_template_matches_wc_spec(): void {
-		// Per https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/
-		// single-product format is: /checkout-link/?products=PRODUCT_ID:QUANTITY
-		$cl = $this->get_config()['purchase_urls']['checkout_link'];
-
-		$this->assertEquals(
-			'https://example.com/checkout-link/?products={product_id}:{quantity}',
-			$cl['simple']
-		);
-	}
-
-	public function test_checkout_link_multi_item_uses_comma_separator(): void {
-		// Per WC docs: multi-product format is
-		// `?products=id:qty,id:qty`.
-		$cl = $this->get_config()['purchase_urls']['checkout_link'];
-
-		$this->assertStringContainsString( ',', $cl['multi_item'] );
-		$this->assertStringContainsString( ':', $cl['multi_item'] );
-	}
-
-	public function test_checkout_link_with_coupon_includes_coupon_param(): void {
-		$cl = $this->get_config()['purchase_urls']['checkout_link'];
-
-		$this->assertStringContainsString( 'coupon={coupon_code}', $cl['with_coupon'] );
-	}
-
-	public function test_checkout_link_declares_unsupported_types(): void {
-		// Grouped, external, and subscription products CANNOT use the
-		// /checkout-link/ feature. Agents need to know not to try.
-		$cl = $this->get_config()['purchase_urls']['checkout_link'];
-
-		$this->assertEqualsCanonicalizing(
-			[ 'grouped', 'external', 'subscription' ],
-			$cl['unsupported']
-		);
-	}
-
-	// ----- purchase_urls.add_to_cart ------------------------------------
-
-	public function test_add_to_cart_has_three_redirect_variants(): void {
-		// Per https://woocommerce.com/document/quick-guide-to-woocommerce-add-to-cart-urls/
-		// the three variants are: no redirect (home), redirect to cart,
-		// redirect to checkout. All three have different base URLs.
-		$a2c = $this->get_config()['purchase_urls']['add_to_cart'];
-
-		$this->assertArrayHasKey( 'add_only', $a2c );
-		$this->assertArrayHasKey( 'add_and_cart', $a2c );
-		$this->assertArrayHasKey( 'add_and_checkout', $a2c );
-	}
-
-	public function test_add_and_cart_uses_cart_url_as_base(): void {
-		$a2c = $this->get_config()['purchase_urls']['add_to_cart'];
-
-		$this->assertStringStartsWith(
-			'https://example.com/cart/',
-			$a2c['add_and_cart']
-		);
-	}
-
-	public function test_add_and_checkout_uses_checkout_url_as_base(): void {
-		$a2c = $this->get_config()['purchase_urls']['add_to_cart'];
-
-		$this->assertStringStartsWith(
-			'https://example.com/checkout/',
-			$a2c['add_and_checkout']
-		);
-	}
-
-	public function test_add_to_cart_grouped_has_template_and_note(): void {
-		// Grouped products have a separate entry because their URL
-		// shape differs (quantity is a per-sub-product map, not a
-		// single number). The note documents the quirk.
-		$grouped = $this->get_config()['purchase_urls']['add_to_cart']['grouped'];
-
-		$this->assertArrayHasKey( 'template', $grouped );
-		$this->assertArrayHasKey( 'note', $grouped );
-		$this->assertStringContainsString(
-			'quantity[{sub_product_id}]={quantity}',
-			$grouped['template']
-		);
-	}
-
-	public function test_add_to_cart_external_note_present(): void {
-		// External/affiliate products must not be add-to-carted —
-		// agents link directly to the product's external_url field.
-		$a2c = $this->get_config()['purchase_urls']['add_to_cart'];
-
-		$this->assertArrayHasKey( 'external_note', $a2c );
-		$this->assertStringContainsString( 'external_url', $a2c['external_note'] );
-	}
-
-	// ----- purchase_urls spec pointers ----------------------------------
-
-	public function test_purchase_urls_points_to_canonical_wc_spec(): void {
-		// Both spec URLs were verified during authorship. If they ever
-		// break, AI agents reading the manifest get pointed at broken
-		// docs. A link-check on these in CI would be ideal future work.
-		$pu = $this->get_config()['purchase_urls'];
-
-		$this->assertEquals(
-			'https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/',
-			$pu['spec']
-		);
-		$this->assertEquals(
-			'https://woocommerce.com/document/quick-guide-to-woocommerce-add-to-cart-urls/',
-			$pu['add_to_cart_spec']
-		);
-	}
-
-	// ----- attribution ---------------------------------------------------
-
-	public function test_attribution_declares_woocommerce_order_attribution(): void {
+	public function test_attribution_declares_woocommerce_order_attribution_system(): void {
 		// The plugin's attribution strategy is "use WC's built-in
 		// system" — not a custom invention. The `system` field makes
 		// that explicit for agents that want to verify.
-		$attr = $this->get_config()['attribution'];
-
-		$this->assertEquals( 'woocommerce_order_attribution', $attr['system'] );
+		$this->assertSame( 'woocommerce_order_attribution', $this->get_attribution()['system'] );
 	}
 
 	public function test_attribution_exposes_required_utm_parameters(): void {
-		$attr = $this->get_config()['attribution'];
+		$attr = $this->get_attribution();
 
-		$this->assertArrayHasKey( 'utm_source', $attr['parameters'] );
-		$this->assertArrayHasKey( 'utm_medium', $attr['parameters'] );
-		$this->assertArrayHasKey( 'utm_campaign', $attr['parameters'] );
-		$this->assertArrayHasKey( 'ai_session_id', $attr['parameters'] );
+		foreach ( [ 'utm_source', 'utm_medium', 'utm_campaign', 'ai_session_id' ] as $required ) {
+			$this->assertArrayHasKey( $required, $attr['parameters'] );
+		}
 	}
 
 	public function test_attribution_utm_medium_documents_required_value(): void {
 		// utm_medium MUST be "ai_agent" for the PHP-side detector to
 		// capture the order. Document that in the param description
 		// so agents know it's not free-form.
-		$attr = $this->get_config()['attribution'];
-
 		$this->assertStringContainsString(
 			'ai_agent',
-			$attr['parameters']['utm_medium']
+			$this->get_attribution()['parameters']['utm_medium']
 		);
 	}
 
 	public function test_attribution_spec_points_to_wc_order_attribution_docs(): void {
-		$attr = $this->get_config()['attribution'];
-
-		$this->assertEquals(
+		$this->assertSame(
 			'https://woocommerce.com/document/order-attribution-tracking/',
-			$attr['spec']
+			$this->get_attribution()['spec']
 		);
+	}
+
+	public function test_attribution_usage_note_points_to_llms_txt_for_canonical_flow(): void {
+		// 1.6.5: the canonical human-readable attribution guidance
+		// lives in llms.txt, not in the UCP manifest. The usage_note
+		// should direct readers there rather than duplicating the
+		// full narrative.
+		$this->assertStringContainsString( 'llms.txt', $this->get_attribution()['usage_note'] );
 	}
 
 	// ------------------------------------------------------------------

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.6.4
+ * Version: 1.6.5
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.6.4' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.6.5' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Spec-alignment pass after reading canonical checkout spec

Authoritative spec source: https://ucp.dev/latest/specification/checkout/

### Three structural changes

1. **Removed `mode: "handoff"`** from checkout capability — not in \`capability.json\`; redundant with runtime \`status: "requires_escalation"\` signal
2. **Removed \`config\` block** from checkout capability — UCP spec SHOULD directive prefers business-provided \`continue_url\` over platform-constructed templates
3. **Added \`com.woocommerce.ai_syndication\` extension capability** with \`extends: "dev.ucp.shopping"\` — idiomatic UCP home for merchant-specific metadata (store_context + attribution conventions)

### llms.txt now authoritative for agent attribution

Pre-1.6.5 llms.txt emitted literal URL-template examples. Post-1.6.5 it leads with the canonical \`POST /checkout-sessions\` flow (request/response shape + UCP-Agent header explanation), followed by fallback UTM guidance for agents that must construct URLs client-side. Pointer to WooCommerce's public \`/checkout-link/\` docs for URL patterns.

### Why remove templates entirely

- UCP spec SHOULD directive: businesses provide continue_url, not platforms
- Single observed template use was a manually-prompted Gemini test, not autonomous in-the-wild behavior
- No documented user-facing cost to removal
- Real spec-compliance gain

## Test plan
- [x] 345 PHP tests / 980 assertions (-9 test count, -9 assertions — net removal because 11 deleted purchase_urls tests covered removed fields)
- [x] PHPCS + PHPStan + ESLint clean
- [ ] After deploy: \`curl -s "https://pierorocca.com/.well-known/ucp?v=\$(date +%s)" | jq '.ucp.capabilities'\` shows 4 keys (3 canonical + 1 extension)
- [ ] After deploy: checkout capability has no \`mode\` or \`config\`
- [ ] After deploy: \`com.woocommerce.ai_syndication.config.store_context\` has currency/locale/etc

🤖 Generated with [Claude Code](https://claude.com/claude-code)