### PR TITLE
1.6.7 — canonicalize utm_source, remove redundant AI Agent orders column

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,7 +89,7 @@ The operational counterpart to the discovery layer. Translates the WooCommerce S
 
 | File | Purpose |
 |------|---------|
-| `class-wc-ai-syndication-attribution.php` | Captures AI-referred orders via standard WooCommerce Order Attribution (`utm_medium=ai_agent`). Adds AI Agent column to orders list (HPOS + legacy). SQL aggregation for per-agent revenue stats. |
+| `class-wc-ai-syndication-attribution.php` | Captures AI-referred orders via standard WooCommerce Order Attribution (`utm_medium=ai_agent`). Surfaces agent name in WC core's "Origin" column (fed by `utm_source`); no custom column since 1.6.7. SQL aggregation for per-agent revenue stats. |
 
 ### Rate Limiting
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Plus integrations with WordPress and WooCommerce:
 
 - **`robots.txt`** — per-crawler allowlist for 12 commerce-relevant AI bots
 - **Store API rate limiting** — built-in WC rate limiter fingerprints AI bots by user-agent (regular customer traffic is unaffected)
-- **Order Attribution** — standard `utm_medium=ai_agent` capture, surfaced as an `AI Agent` column + filter in the orders list
+- **Order Attribution** — standard `utm_medium=ai_agent` capture, surfaced in WooCommerce core's built-in "Origin" column (no custom column since 1.6.7)
 
 ## What it doesn't do
 

--- a/includes/ai-syndication/class-wc-ai-syndication-attribution.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-attribution.php
@@ -39,6 +39,14 @@ class WC_AI_Syndication_Attribution {
 
 	/**
 	 * Initialize hooks.
+	 *
+	 * Deliberately minimal: we capture agent metadata onto the order
+	 * and render it in the order-edit screen, then stop. The orders
+	 * list surfaces agent attribution through WooCommerce core's
+	 * native "Origin" column (fed by `_wc_order_attribution_utm_source`,
+	 * which we set via the continue_url's `utm_source` param) — so a
+	 * custom "AI Agent" column on the list would be pure duplication.
+	 * Removed in 1.6.7; see AGENTS.md "Attribution" for the rationale.
 	 */
 	public function init() {
 		// Capture ai_session_id from the request and store on the order.
@@ -49,18 +57,6 @@ class WC_AI_Syndication_Attribution {
 
 		// Display AI attribution data in admin order view.
 		add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'display_attribution_in_admin' ], 20, 1 );
-
-		// Add AI agent column to orders list — support both HPOS and legacy post type.
-		add_filter( 'manage_woocommerce_page_wc-orders_columns', [ $this, 'add_order_list_column' ] );
-		add_action( 'manage_woocommerce_page_wc-orders_custom_column', [ $this, 'render_order_list_column' ], 10, 2 );
-		add_filter( 'manage_edit-shop_order_columns', [ $this, 'add_order_list_column' ] );
-		add_action( 'manage_shop_order_posts_custom_column', [ $this, 'render_order_list_column' ], 10, 2 );
-
-		// Add AI agent filter dropdown to orders list.
-		add_action( 'woocommerce_order_list_table_restrict_manage_orders', [ $this, 'render_agent_filter' ], 20 );
-		add_action( 'restrict_manage_posts', [ $this, 'render_agent_filter_legacy' ], 20 );
-		add_filter( 'woocommerce_order_list_table_prepare_items_query_args', [ $this, 'filter_orders_by_agent' ] );
-		add_action( 'pre_get_posts', [ $this, 'filter_orders_by_agent_legacy' ] );
 	}
 
 	/**
@@ -145,56 +141,6 @@ class WC_AI_Syndication_Attribution {
 		}
 
 		echo '</div>';
-	}
-
-	/**
-	 * Add AI agent column to HPOS orders list.
-	 *
-	 * @param array $columns Order list columns.
-	 * @return array
-	 */
-	public function add_order_list_column( $columns ) {
-		$settings = WC_AI_Syndication::get_settings();
-		if ( 'yes' !== ( $settings['enabled'] ?? 'no' ) ) {
-			return $columns;
-		}
-
-		// Insert after 'order_status' column.
-		$new_columns = [];
-		foreach ( $columns as $key => $label ) {
-			$new_columns[ $key ] = $label;
-			if ( 'order_status' === $key ) {
-				$new_columns['ai_agent'] = __( 'AI Agent', 'woocommerce-ai-syndication' );
-			}
-		}
-
-		return $new_columns;
-	}
-
-	/**
-	 * Render AI agent column in orders list.
-	 *
-	 * Works with both the legacy post-based orders list (where the second
-	 * parameter is an int post ID) and the HPOS orders list (where it's
-	 * already a WC_Order instance). The `instanceof` guard at the start
-	 * of the method handles the polymorphism.
-	 *
-	 * @param string       $column_name Column name.
-	 * @param int|WC_Order $order_id    Order ID (legacy) or WC_Order (HPOS).
-	 */
-	public function render_order_list_column( $column_name, $order_id ) {
-		if ( 'ai_agent' !== $column_name ) {
-			return;
-		}
-
-		$order = $order_id instanceof WC_Order ? $order_id : wc_get_order( $order_id );
-		if ( ! $order ) {
-			echo '&mdash;';
-			return;
-		}
-
-		$agent = $order->get_meta( self::AGENT_META_KEY );
-		echo $agent ? esc_html( $agent ) : '&mdash;';
 	}
 
 	/**
@@ -327,137 +273,5 @@ class WC_AI_Syndication_Attribution {
 			'currency'         => get_woocommerce_currency(),
 			'by_agent'         => $by_agent,
 		];
-	}
-
-	/**
-	 * Get distinct AI agent names from order meta for the filter dropdown.
-	 *
-	 * @return string[]
-	 */
-	private static function get_known_agents() {
-		global $wpdb;
-
-		if ( class_exists( 'Automattic\WooCommerce\Utilities\OrderUtil' )
-			&& \Automattic\WooCommerce\Utilities\OrderUtil::custom_orders_table_usage_is_enabled() ) {
-			$meta_table = $wpdb->prefix . 'wc_orders_meta';
-			// phpcs:disable WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-			$agents = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT DISTINCT meta_value FROM {$meta_table} WHERE meta_key = %s AND meta_value != '' ORDER BY meta_value",
-					self::AGENT_META_KEY
-				)
-			);
-			// phpcs:enable
-		} else {
-			// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
-			$agents = $wpdb->get_col(
-				$wpdb->prepare(
-					"SELECT DISTINCT meta_value FROM {$wpdb->postmeta} WHERE meta_key = %s AND meta_value != '' ORDER BY meta_value",
-					self::AGENT_META_KEY
-				)
-			);
-		}
-
-		return is_array( $agents ) ? $agents : [];
-	}
-
-	/**
-	 * Render the AI agent filter dropdown (HPOS orders list).
-	 */
-	public function render_agent_filter() {
-		$agents = self::get_known_agents();
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$current = isset( $_GET['ai_agent_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['ai_agent_filter'] ) ) : '';
-
-		echo '<select name="ai_agent_filter">';
-		echo '<option value="">' . esc_html__( 'Filter by AI agent', 'woocommerce-ai-syndication' ) . '</option>';
-		if ( ! empty( $agents ) ) {
-			echo '<option value="_any"' . selected( $current, '_any', false ) . '>' . esc_html__( 'Any AI agent', 'woocommerce-ai-syndication' ) . '</option>';
-			foreach ( $agents as $agent ) {
-				echo '<option value="' . esc_attr( $agent ) . '"' . selected( $current, $agent, false ) . '>' . esc_html( $agent ) . '</option>';
-			}
-		}
-		echo '</select>';
-	}
-
-	/**
-	 * Render the AI agent filter dropdown (legacy shop_order).
-	 *
-	 * @param string $post_type Current post type.
-	 */
-	public function render_agent_filter_legacy( $post_type ) {
-		if ( 'shop_order' !== $post_type ) {
-			return;
-		}
-		$this->render_agent_filter();
-	}
-
-	/**
-	 * Filter HPOS orders by AI agent meta.
-	 *
-	 * @param array $query_args Order query arguments.
-	 * @return array
-	 */
-	public function filter_orders_by_agent( $query_args ) {
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$agent = isset( $_GET['ai_agent_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['ai_agent_filter'] ) ) : '';
-
-		if ( empty( $agent ) ) {
-			return $query_args;
-		}
-
-		if ( '_any' === $agent ) {
-			$query_args['meta_query'][] = [
-				'key'     => self::AGENT_META_KEY,
-				'compare' => 'EXISTS',
-			];
-		} else {
-			$query_args['meta_query'][] = [
-				'key'   => self::AGENT_META_KEY,
-				'value' => $agent,
-			];
-		}
-
-		return $query_args;
-	}
-
-	/**
-	 * Filter legacy shop_order posts by AI agent meta.
-	 *
-	 * @param WP_Query $query The query.
-	 */
-	public function filter_orders_by_agent_legacy( $query ) {
-		global $pagenow;
-
-		if ( 'edit.php' !== $pagenow || ( $query->get( 'post_type' ) ?? '' ) !== 'shop_order' ) {
-			return;
-		}
-
-		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$agent = isset( $_GET['ai_agent_filter'] ) ? sanitize_text_field( wp_unslash( $_GET['ai_agent_filter'] ) ) : '';
-
-		if ( empty( $agent ) ) {
-			return;
-		}
-
-		$meta_query = $query->get( 'meta_query' );
-		if ( ! is_array( $meta_query ) ) {
-			$meta_query = [];
-		}
-
-		if ( '_any' === $agent ) {
-			$meta_query[] = [
-				'key'     => self::AGENT_META_KEY,
-				'compare' => 'EXISTS',
-			];
-		} else {
-			$meta_query[] = [
-				'key'   => self::AGENT_META_KEY,
-				'value' => $agent,
-			];
-		}
-
-		$query->set( 'meta_query', $meta_query );
 	}
 }

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-agent-header.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-agent-header.php
@@ -36,6 +36,104 @@ class WC_AI_Syndication_UCP_Agent_Header {
 	const FALLBACK_SOURCE = 'ucp_unknown';
 
 	/**
+	 * Map of UCP-Agent profile hostnames → short canonical brand names.
+	 *
+	 * The canonical name lands in the continue_url's `utm_source`
+	 * parameter, which WooCommerce Order Attribution captures into
+	 * `_wc_order_attribution_utm_source`. The Orders list then displays
+	 * it in the built-in "Origin" column as `Source: {name}` — so this
+	 * map directly controls what merchants see when an AI-sourced
+	 * order appears in wp-admin.
+	 *
+	 * Naming convention: short, brand-clean, merchant-readable.
+	 * Matches the spirit of the Discovery crawler list
+	 * (`WC_AI_Syndication_Robots::LIVE_BROWSING_AGENTS`) but drops the
+	 * UA-style suffixes (`-User`, `-SearchBot`) — those signal crawler
+	 * *variant* in robots.txt, which is noise in an Origin column where
+	 * the merchant just wants to know "which AI sent this order."
+	 *
+	 * Keys MUST be lower-case hostnames. Lookup is exact-match with a
+	 * lower-case of the incoming hostname; no wildcard/subdomain logic.
+	 * Subdomains that share a brand (e.g., `agents.openai.com`) can be
+	 * added as additional keys when encountered. Over-matching (e.g.
+	 * glob on `*.google.com`) would collapse distinct Google products
+	 * — Gemini conversational, Storebot shopping overviews, Bard
+	 * research — under a single label and lose valuable attribution
+	 * detail, so keep the map literal.
+	 *
+	 * When a hostname is NOT in this map, the raw hostname is returned
+	 * verbatim (see `canonicalize_host()`). That preserves traceability
+	 * for novel agents while the map catches the 90% of known vendors.
+	 *
+	 * @var array<string, string>
+	 */
+	const KNOWN_AGENT_HOSTS = [
+		// OpenAI.
+		'chatgpt.com'           => 'ChatGPT',
+		'openai.com'            => 'ChatGPT',
+
+		// Anthropic.
+		'claude.ai'             => 'Claude',
+		'anthropic.com'         => 'Claude',
+
+		// Google — Gemini is the conversational surface; keep
+		// distinct from `Storebot-Google` which is the Shopping
+		// Overviews crawler, a separate product.
+		'gemini.google.com'     => 'Gemini',
+		'deepmind.google'       => 'Gemini',
+
+		// Microsoft.
+		'copilot.microsoft.com' => 'Copilot',
+		'bing.com'              => 'Copilot',
+
+		// Perplexity.
+		'perplexity.ai'         => 'Perplexity',
+
+		// Apple — Siri is the conversational assistant; distinct
+		// from Applebot (search index) and Applebot-Extended (AI
+		// training) which live in the Discovery crawler list.
+		'siri.apple.com'        => 'Siri',
+
+		// Amazon — Rufus is the conversational shopping assistant,
+		// AmazonBuyForMe is its agentic-purchase crawler variant.
+		'rufus.amazon.com'      => 'Rufus',
+
+		// Klarna.
+		'klarna.com'            => 'Klarna',
+
+		// You.com.
+		'you.com'               => 'You',
+
+		// Kagi.
+		'kagi.com'              => 'Kagi',
+	];
+
+	/**
+	 * Canonicalize a hostname to a short brand name for merchant-facing
+	 * attribution display (utm_source → Origin column).
+	 *
+	 * Returns the mapped brand name when the hostname is known, else
+	 * the hostname itself. NEVER returns empty — callers can use the
+	 * result directly as a utm_source value without a null-check.
+	 *
+	 * Separate from `extract_profile_hostname()` so the raw-hostname
+	 * extraction stays pure (useful for logging/diagnostics) while
+	 * display-layer canonicalization is explicit at the call site.
+	 *
+	 * @param string $host Hostname extracted from a UCP-Agent profile URL.
+	 * @return string Short canonical brand name, or the hostname unchanged
+	 *                when no mapping exists. Empty input returns empty.
+	 */
+	public static function canonicalize_host( string $host ): string {
+		if ( '' === $host ) {
+			return '';
+		}
+
+		$lower = strtolower( $host );
+		return self::KNOWN_AGENT_HOSTS[ $lower ] ?? $host;
+	}
+
+	/**
 	 * Extract the agent's profile URL hostname from a UCP-Agent header value.
 	 *
 	 * Implementation is a v1 shortcut — it finds the first occurrence of

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -684,7 +684,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			);
 		}
 
-		$agent_host = self::resolve_agent_host( $request );
+		$agent_name = self::resolve_agent_host( $request );
 		$currency   = function_exists( 'get_woocommerce_currency' )
 			? (string) get_woocommerce_currency()
 			: 'USD';
@@ -711,7 +711,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 
 		$has_valid_items = ! empty( $processed );
 		$continue_url    = $has_valid_items
-			? self::build_continue_url( $processed, $agent_host )
+			? self::build_continue_url( $processed, $agent_name )
 			: '';
 
 		// Response line_items: echo successfully-processed items with
@@ -1427,14 +1427,19 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	// ------------------------------------------------------------------
 
 	/**
-	 * Resolve the hostname from the UCP-Agent header for attribution,
-	 * falling back to the plugin's `ucp_unknown` sentinel when the
-	 * header is missing/malformed.
+	 * Resolve the canonical agent name for attribution, derived from the
+	 * UCP-Agent header's profile URL. Falls back to the `ucp_unknown`
+	 * sentinel when the header is missing/malformed.
 	 *
-	 * Used as `utm_source` in the Shareable Checkout URL — lets
-	 * merchants see order attribution flowing through WooCommerce's
-	 * native Order Attribution system, so they can measure AI-sourced
-	 * revenue without extra integration.
+	 * The returned value lands in `utm_source` on the continue_url, is
+	 * captured by WooCommerce Order Attribution into
+	 * `_wc_order_attribution_utm_source`, and shows up verbatim in the
+	 * Orders list's "Origin" column as `Source: {name}`. Canonicalizing
+	 * here (rather than at display time) keeps that WC-captured value
+	 * clean and queryable for stats breakdowns.
+	 *
+	 * @see WC_AI_Syndication_UCP_Agent_Header::canonicalize_host() for
+	 *      the hostname → brand-name mapping rationale.
 	 */
 	private static function resolve_agent_host( WP_REST_Request $request ): string {
 		$header = $request->get_header( 'ucp-agent' );
@@ -1442,7 +1447,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		if ( is_string( $header ) && '' !== $header ) {
 			$host = WC_AI_Syndication_UCP_Agent_Header::extract_profile_hostname( $header );
 			if ( '' !== $host ) {
-				return $host;
+				return WC_AI_Syndication_UCP_Agent_Header::canonicalize_host( $host );
 			}
 		}
 
@@ -1616,15 +1621,19 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 *   /checkout-link/?products=ID:QTY,ID:QTY
 	 *
 	 * UTM parameters append for attribution:
-	 *   &utm_source={agent_host}&utm_medium=ai_agent
+	 *   &utm_source={agent_name}&utm_medium=ai_agent
 	 *
 	 * WC's own Order Attribution system captures these on the resulting
 	 * order, so merchants see agent-sourced traffic without needing any
 	 * extra plumbing.
 	 *
-	 * @param array<int, array<string, mixed>> $processed Successfully-processed line items.
+	 * @param array<int, array<string, mixed>> $processed  Successfully-processed line items.
+	 * @param string                           $agent_name Canonical brand name for `utm_source`
+	 *                                                     (e.g. "Gemini", "ChatGPT"), as produced
+	 *                                                     by `resolve_agent_host()`. Shows up in
+	 *                                                     WC's Origin column as `Source: {name}`.
 	 */
-	private static function build_continue_url( array $processed, string $agent_host ): string {
+	private static function build_continue_url( array $processed, string $agent_name ): string {
 		$segments = [];
 		foreach ( $processed as $p ) {
 			$segments[] = $p['wc_id'] . ':' . $p['quantity'];
@@ -1636,7 +1645,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 
 		return $base
 			. '?products=' . implode( ',', $segments )
-			. '&utm_source=' . rawurlencode( $agent_host )
+			. '&utm_source=' . rawurlencode( $agent_name )
 			. '&utm_medium=ai_agent';
 	}
 

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.0
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 1.6.6
+Stable tag: 1.6.7
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 
@@ -42,7 +42,7 @@ Uses WordPress's `robots.txt` to declare which AI crawlers are allowed. Uses Woo
 3. A Markdown store guide is published at `/llms.txt` pointing AI agents at your product catalog, Store API, and UCP manifest.
 4. A JSON manifest at `/.well-known/ucp` declares that checkout is web-redirect only (never delegated, never in-chat) and documents the purchase URL templates agents can use.
 5. Product pages ship enhanced Schema.org JSON-LD with a BuyAction pointing back to your checkout with attribution placeholders.
-6. When a customer clicks through from an AI agent and buys, WooCommerce's standard Order Attribution captures the agent name in order meta. The admin shows AI orders alongside regular orders with an "AI Agent" column, and the plugin's settings page displays AI-attributed revenue by agent and time period.
+6. When a customer clicks through from an AI agent and buys, WooCommerce's standard Order Attribution captures the agent name in order meta. The agent is displayed in WooCommerce's built-in "Origin" column on the orders list (as `Source: ChatGPT`, `Source: Gemini`, etc.), and the plugin's settings page displays AI-attributed revenue by agent and time period.
 
 = Data sovereignty =
 
@@ -77,7 +77,7 @@ Well-behaved AI crawlers respect `robots.txt` directives. Compliance is not univ
 
 = How does attribution work? =
 
-When an AI agent links to a product page, it appends `utm_source={agent_id}&utm_medium=ai_agent&ai_session_id={session_id}` query parameters. WooCommerce's Order Attribution system (included in WooCommerce core since 8.5) captures these values into order meta. The plugin adds an `AI Agent` column to the orders list and surfaces per-agent revenue totals in the settings overview.
+When an AI agent links to a product page, it appends `utm_source={agent_name}&utm_medium=ai_agent&ai_session_id={session_id}` query parameters. WooCommerce's Order Attribution system (included in WooCommerce core since 8.5) captures these values into order meta and displays them in the built-in "Origin" column on the orders list — no custom column needed. The plugin surfaces per-agent revenue totals in the settings overview.
 
 = What's the difference between llms.txt, robots.txt, and the UCP manifest? =
 
@@ -109,6 +109,11 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_syndication_session_id` (conversation identifier)
 
 == Changelog ==
+
+= 1.6.7 =
+* Changed: `utm_source` on the `continue_url` returned by `POST /checkout-sessions` is now a short, human-readable brand name (`ChatGPT`, `Gemini`, `Claude`, `Perplexity`, `Copilot`, `Siri`, `Rufus`, `Klarna`, `You`, `Kagi`) instead of the raw UCP-Agent profile hostname. WooCommerce Order Attribution feeds this into `_wc_order_attribution_utm_source`, which WC's built-in "Origin" column on the Orders list displays as `Source: {name}` — so the previous `Source: Gemini.google.com` now reads `Source: Gemini`. Unknown / novel agents pass through verbatim so attribution is never lost, just refined for known vendors. The map lives in `WC_AI_Syndication_UCP_Agent_Header::KNOWN_AGENT_HOSTS`; adding a new vendor is a single constant entry plus a test-provider row.
+* Removed: the custom "AI Agent" column and "Filter by AI agent" dropdown on the WooCommerce Orders list. Both duplicated WooCommerce core's built-in "Origin" column (which has been fed correctly by our `utm_source` / `utm_medium` pair all along). 186 lines removed from `class-wc-ai-syndication-attribution.php` including four hooks, four methods, and the `get_known_agents()` SQL helper. The order-edit meta box is unchanged — it still shows the AI session ID, which WC's native attribution UI doesn't surface.
+* Added: regression guards in `AttributionTest.php` asserting that `init()` does not register any of the eight removed hooks and that none of the six removed methods exist on the class. Reintroducing the duplicate column without a conscious design review will fail CI. Also added an integration test in `UcpCheckoutSessionsTest.php` pinning the `gemini.google.com → Gemini` end-to-end wiring, plus unit tests for every entry in the `KNOWN_AGENT_HOSTS` map, case-insensitive matching, unknown-host passthrough, and the deliberate no-subdomain-match behavior.
 
 = 1.6.6 =
 * Added: explicit "merchant-only checkout" posture lock-in. Two complementary changes: (1) a new `## Checkout Policy` section in llms.txt declaring affirmatively that all purchases complete on the merchant site, and enumerating the five UCP surfaces we deliberately don't support (in-chat payment, embedded checkout, AP2 Mandates / agent-delegated authorization, persistent agent carts, payment handler tokens); (2) a dedicated regression test file `UcpCheckoutPostureTest.php` with 11 tests that lock every layer of the defense stack — empty `payment_handlers`, no `ap2_mandate` or `cart` capability, REST-only transport (no Embedded Protocol / MCP / A2A), exactly the 3 expected REST routes registered (no Complete Checkout endpoint), no `signing_keys` at profile root, no payment-related keys anywhere in the manifest. A future maintainer accidentally adding any of these weakens the posture; the tests fire and force a conscious posture review rather than silent capability drift.

--- a/tests/php/unit/AttributionTest.php
+++ b/tests/php/unit/AttributionTest.php
@@ -2,8 +2,10 @@
 /**
  * Tests for WC_AI_Syndication_Attribution.
  *
- * Covers capture_ai_attribution (meta detection, session/agent capture)
- * and the column rendering.
+ * Covers capture_ai_attribution (meta detection, session/agent capture).
+ * The custom "AI Agent" orders-list column was removed in 1.6.7 —
+ * WooCommerce core's "Origin" column already displays the same data
+ * sourced from `_wc_order_attribution_utm_source`.
  *
  * @package WooCommerce_AI_Syndication
  */
@@ -109,55 +111,71 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// render_order_list_column
+	// No custom orders-list column since 1.6.7.
+	//
+	// Lock-in: if a future change reintroduces a custom column (or
+	// filter dropdown) that duplicates WC core's "Origin" column,
+	// these assertions fire and force a conscious design review.
 	// ------------------------------------------------------------------
 
-	public function test_render_column_shows_agent_name(): void {
-		$order = new WC_Order();
-		$order->set_test_meta( '_wc_ai_syndication_agent', 'perplexity' );
+	public function test_init_does_not_register_custom_orders_list_column(): void {
+		// Track every add_filter / add_action call during init() and
+		// assert none of them touch the orders-list column or filter
+		// hooks. This is a regression guard: the 1.6.7 removal wasn't
+		// enforced by runtime code — it was enforced by not attaching
+		// the hooks. If someone re-adds the hooks, this test fires.
+		$hooks = [];
+		Functions\when( 'add_action' )->alias(
+			static function ( $hook ) use ( &$hooks ) {
+				$hooks[] = $hook;
+			}
+		);
+		Functions\when( 'add_filter' )->alias(
+			static function ( $hook ) use ( &$hooks ) {
+				$hooks[] = $hook;
+			}
+		);
 
-		Functions\expect( 'wc_get_order' )->andReturn( $order );
-		Functions\expect( 'esc_html' )->andReturnFirstArg();
+		$this->attribution->init();
 
-		ob_start();
-		$this->attribution->render_order_list_column( 'ai_agent', 1 );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'perplexity', $output );
+		$forbidden = [
+			'manage_woocommerce_page_wc-orders_columns',
+			'manage_woocommerce_page_wc-orders_custom_column',
+			'manage_edit-shop_order_columns',
+			'manage_shop_order_posts_custom_column',
+			'woocommerce_order_list_table_restrict_manage_orders',
+			'restrict_manage_posts',
+			'woocommerce_order_list_table_prepare_items_query_args',
+			'pre_get_posts',
+		];
+		foreach ( $forbidden as $hook ) {
+			$this->assertNotContains(
+				$hook,
+				$hooks,
+				"Hook {$hook} reintroduces the orders-list column or filter removed in 1.6.7 — WC core's Origin column already shows this data"
+			);
+		}
 	}
 
-	public function test_render_column_shows_dash_for_non_ai_order(): void {
-		$order = new WC_Order();
-		// No agent meta.
-
-		Functions\expect( 'wc_get_order' )->andReturn( $order );
-
-		ob_start();
-		$this->attribution->render_order_list_column( 'ai_agent', 1 );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( '&mdash;', $output );
-	}
-
-	public function test_render_column_ignores_other_columns(): void {
-		ob_start();
-		$this->attribution->render_order_list_column( 'order_total', 1 );
-		$output = ob_get_clean();
-
-		$this->assertEmpty( $output );
-	}
-
-	public function test_render_column_handles_wc_order_object(): void {
-		$order = new WC_Order();
-		$order->set_test_meta( '_wc_ai_syndication_agent', 'copilot' );
-
-		Functions\expect( 'esc_html' )->andReturnFirstArg();
-
-		// HPOS passes the WC_Order object directly.
-		ob_start();
-		$this->attribution->render_order_list_column( 'ai_agent', $order );
-		$output = ob_get_clean();
-
-		$this->assertStringContainsString( 'copilot', $output );
+	public function test_attribution_class_exposes_no_column_rendering_methods(): void {
+		// If a future maintainer reintroduces the column-rendering
+		// methods (render_order_list_column, add_order_list_column,
+		// render_agent_filter, filter_orders_by_agent), they must
+		// also wire up the hooks — which the test above prevents.
+		// Belt-and-braces: catch the method-level reintroduction too.
+		$removed = [
+			'add_order_list_column',
+			'render_order_list_column',
+			'render_agent_filter',
+			'render_agent_filter_legacy',
+			'filter_orders_by_agent',
+			'filter_orders_by_agent_legacy',
+		];
+		foreach ( $removed as $method ) {
+			$this->assertFalse(
+				method_exists( $this->attribution, $method ),
+				"Method {$method} was removed in 1.6.7; reintroduction duplicates WC core's Origin column"
+			);
+		}
 	}
 }

--- a/tests/php/unit/UcpAgentHeaderTest.php
+++ b/tests/php/unit/UcpAgentHeaderTest.php
@@ -139,4 +139,86 @@ class UcpAgentHeaderTest extends \PHPUnit\Framework\TestCase {
 			WC_AI_Syndication_UCP_Agent_Header::FALLBACK_SOURCE
 		);
 	}
+
+	// ------------------------------------------------------------------
+	// canonicalize_host() — hostname → short brand name
+	// ------------------------------------------------------------------
+
+	/**
+	 * @dataProvider known_host_provider
+	 */
+	public function test_canonicalize_host_maps_known_hostnames( string $input, string $expected ): void {
+		// Every entry in KNOWN_AGENT_HOSTS must resolve to its brand
+		// name. Adding a new brand: add it to the constant AND add a
+		// data-provider row here — the test doubles as the map's
+		// spec so the two can't silently drift.
+		$this->assertEquals(
+			$expected,
+			WC_AI_Syndication_UCP_Agent_Header::canonicalize_host( $input )
+		);
+	}
+
+	public static function known_host_provider(): array {
+		return [
+			'OpenAI ChatGPT'      => [ 'chatgpt.com', 'ChatGPT' ],
+			'OpenAI corporate'    => [ 'openai.com', 'ChatGPT' ],
+			'Anthropic Claude'    => [ 'claude.ai', 'Claude' ],
+			'Anthropic corporate' => [ 'anthropic.com', 'Claude' ],
+			'Google Gemini'       => [ 'gemini.google.com', 'Gemini' ],
+			'Google DeepMind'     => [ 'deepmind.google', 'Gemini' ],
+			'Microsoft Copilot'   => [ 'copilot.microsoft.com', 'Copilot' ],
+			'Microsoft Bing'      => [ 'bing.com', 'Copilot' ],
+			'Perplexity'          => [ 'perplexity.ai', 'Perplexity' ],
+			'Apple Siri'          => [ 'siri.apple.com', 'Siri' ],
+			'Amazon Rufus'        => [ 'rufus.amazon.com', 'Rufus' ],
+			'Klarna'              => [ 'klarna.com', 'Klarna' ],
+			'You.com'             => [ 'you.com', 'You' ],
+			'Kagi'                => [ 'kagi.com', 'Kagi' ],
+		];
+	}
+
+	public function test_canonicalize_host_is_case_insensitive(): void {
+		// DNS hostnames are case-insensitive by RFC, and some agents
+		// send mixed-case (observed: `Gemini.google.com` from Google's
+		// Gemini profile URL). Canonicalization must collapse case
+		// before lookup or the mapping silently misses.
+		$this->assertEquals(
+			'Gemini',
+			WC_AI_Syndication_UCP_Agent_Header::canonicalize_host( 'Gemini.Google.COM' )
+		);
+	}
+
+	public function test_canonicalize_host_returns_hostname_when_unknown(): void {
+		// Unknown agents keep their hostname so merchants still see
+		// *something* in the Origin column — "Source: foo-ai.example"
+		// is useful traceability. An empty/sentinel value here would
+		// erase attribution for every novel vendor.
+		$this->assertEquals(
+			'unknown-agent.example.com',
+			WC_AI_Syndication_UCP_Agent_Header::canonicalize_host( 'unknown-agent.example.com' )
+		);
+	}
+
+	public function test_canonicalize_host_returns_empty_for_empty_input(): void {
+		// Guards against `wp_parse_url()` returning an empty string for
+		// a malformed profile URL. An empty input should pass through
+		// untouched so `resolve_agent_host()` can detect the failure
+		// and fall back to FALLBACK_SOURCE.
+		$this->assertEquals(
+			'',
+			WC_AI_Syndication_UCP_Agent_Header::canonicalize_host( '' )
+		);
+	}
+
+	public function test_canonicalize_host_does_not_subdomain_match(): void {
+		// Deliberate non-feature: we do NOT glob-match subdomains.
+		// `foo.openai.com` is NOT `openai.com`; an agent at that
+		// subdomain might be a different product (training bot,
+		// internal tool, partner integration) and collapsing it to
+		// "ChatGPT" would misattribute.
+		$this->assertEquals(
+			'foo.openai.com',
+			WC_AI_Syndication_UCP_Agent_Header::canonicalize_host( 'foo.openai.com' )
+		);
+	}
 }

--- a/tests/php/unit/UcpCheckoutSessionsTest.php
+++ b/tests/php/unit/UcpCheckoutSessionsTest.php
@@ -681,7 +681,11 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 	// UTM attribution
 	// ------------------------------------------------------------------
 
-	public function test_ucp_agent_hostname_becomes_utm_source(): void {
+	public function test_unknown_agent_hostname_passes_through_to_utm_source(): void {
+		// Novel / unregistered agent hostname — not in KNOWN_AGENT_HOSTS.
+		// Canonicalization should pass it through verbatim so merchants
+		// still see something useful in the Origin column rather than
+		// losing attribution entirely for unknown vendors.
 		$this->seed_simple_product( 1 );
 
 		$result = $this->call_handler(
@@ -695,6 +699,26 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 		);
 		$this->assertStringContainsString(
 			'utm_medium=ai_agent',
+			$result['data']['continue_url']
+		);
+	}
+
+	public function test_known_agent_hostname_is_canonicalized_in_utm_source(): void {
+		// Integration check: a hostname in KNOWN_AGENT_HOSTS must be
+		// mapped to its brand name BEFORE landing in utm_source, so
+		// WC's Origin column reads "Source: Gemini" (not
+		// "Source: gemini.google.com") once the order is captured.
+		// The unit-level mapping is exhaustively covered in
+		// UcpAgentHeaderTest; this test pins the end-to-end wiring.
+		$this->seed_simple_product( 1 );
+
+		$result = $this->call_handler(
+			[ 'line_items' => [ [ 'item' => [ 'id' => 'prod_1' ], 'quantity' => 1 ] ] ],
+			'profile="https://gemini.google.com/profile.json"'
+		);
+
+		$this->assertStringContainsString(
+			'utm_source=Gemini',
 			$result['data']['continue_url']
 		);
 	}

--- a/woocommerce-ai-syndication.php
+++ b/woocommerce-ai-syndication.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Syndication
  * Plugin URI: https://woocommerce.com/
  * Description: Merchant-led AI product syndication for WooCommerce. Expose products to AI shopping agents (ChatGPT, Gemini, Perplexity, Claude) with full merchant control. Store-only checkout, standard WooCommerce attribution.
- * Version: 1.6.6
+ * Version: 1.6.7
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-syndication
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_SYNDICATION_VERSION', '1.6.6' );
+define( 'WC_AI_SYNDICATION_VERSION', '1.6.7' );
 define( 'WC_AI_SYNDICATION_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_SYNDICATION_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_SYNDICATION_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Summary
- **Canonicalize `utm_source`.** `gemini.google.com` → `Gemini`, `chatgpt.com` → `ChatGPT`, `claude.ai` → `Claude`, etc. via the new `WC_AI_Syndication_UCP_Agent_Header::KNOWN_AGENT_HOSTS` map. Unknown hostnames pass through verbatim. WC Order Attribution captures the brand name directly into `_wc_order_attribution_utm_source`, which WC's built-in "Origin" column displays as `Source: {name}` — so the previous `Source: Gemini.google.com` now reads `Source: Gemini`.
- **Remove the duplicate "AI Agent" orders-list column + filter.** WC core's built-in Origin column already displays the same data. 186 lines removed from `class-wc-ai-syndication-attribution.php` including four hooks, six methods, and the `get_known_agents()` SQL helper. The order-edit meta box stays — it surfaces the plugin-specific AI session ID that WC's native attribution UI doesn't.
- **Regression guards** in `AttributionTest.php`: `init()` must not register any of the eight removed hooks, and none of the six removed methods may exist on the class. Reintroducing the duplicate column without a conscious design review fails CI.

## Why
Merchant feedback from testing the 1.6.6 continue_url flow: "Orders page already has an Origin column that shows the source, so the AI Agent column is not needed. Remove it. The Origin field value is 'Source: Gemini.google.com' — it only needs to be the name of the UA as shown in the Discovery crawler list."

The duplicate column was genuine overlap from pre-UCP days when we were the only thing writing agent attribution meta; as of 1.6.x WC's native Order Attribution system handles the capture cleanly via the utm_* params our continue_url now sets.

## Test plan
- [x] PHPUnit: 374 tests / 1039 assertions (+17 from 1.6.6)
- [x] PHPCS: clean
- [x] PHPStan: clean
- [x] Jest: 84 tests pass
- [ ] Manual: fresh order from Gemini shows `Source: Gemini` in Origin column, not `Source: Gemini.google.com`
- [ ] Manual: no "AI Agent" column on Orders list; no "Filter by AI agent" dropdown
- [ ] Manual: order-edit screen still shows the AI Session ID section

🤖 Generated with [Claude Code](https://claude.com/claude-code)