### PR TITLE
Richer UCP catalog data: options, pricing, stock, barcodes, attributes, ratings + on_sale/tag filters

### DIFF
--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php
@@ -1,0 +1,219 @@
+<?php
+/**
+ * AI Syndication: Store API Extension
+ *
+ * Registers a `barcodes` field on the WooCommerce Store API product
+ * response, surfacing WC core's native `global_unique_id` (introduced
+ * in WC 9.4) as a structured `[{type, value}]` list that our UCP
+ * variant translator can forward to the UCP `variants[].barcodes`
+ * field.
+ *
+ * ## Why this extension exists
+ *
+ * WC 9.4+ stores a product's GTIN / UPC / EAN / MPN / ISBN
+ * identifier on every product via `get_global_unique_id()` — but the
+ * Store API `/products` schema does NOT expose this field yet (see
+ * the enhancement request we filed against woocommerce/woocommerce).
+ * Until core picks it up, this extension bridges the gap via the
+ * officially-supported `woocommerce_store_api_register_endpoint_data`
+ * hook: we read the product meta server-side and emit it under
+ * `extensions.{namespace}.barcodes` on every product/variation
+ * response, exactly where UCP consumers expect extension-provided
+ * data to land.
+ *
+ * ## Why `barcodes` plural
+ *
+ * WC's `global_unique_id` is a single string, not typed — the
+ * merchant enters whatever identifier fits their products (GTIN-13
+ * for retail, ISBN for books, MPN for manufacturer-specific, etc.).
+ * UCP's `variants[].barcodes` is an array of typed objects
+ * (`{type, value}`) because a single product can have multiple
+ * parallel identifiers (GTIN + MPN, for example). Emitting an
+ * array with one detected-type entry today leaves room to add
+ * more sources later (third-party barcode plugins) without
+ * reshaping the API contract.
+ *
+ * ## Type detection
+ *
+ * We detect the barcode type from the value's length and character
+ * set using the conventional GTIN heuristic — 8/12/13/14 digit
+ * numeric strings map to GTIN-8/12/13/14 respectively. Anything
+ * that doesn't match a standard length is emitted as type `other`
+ * so agents can still match by raw value without the type claim.
+ * ISBN/MPN would require explicit type hints from another source
+ * since they can be any length.
+ *
+ * @package WooCommerce_AI_Syndication
+ * @since 1.8.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Registers extra product data on the WC Store API response.
+ */
+class WC_AI_Syndication_Store_Api_Extension {
+
+	/**
+	 * Namespace under which the extension data appears in the Store
+	 * API response. Accessed by consumers as
+	 * `response.extensions[self::NAMESPACE]`. Matches the UCP
+	 * extension capability identifier we publish in the manifest so
+	 * the "namespace" concept is consistent across surfaces.
+	 */
+	const NAMESPACE = 'com-woocommerce-ai-syndication';
+
+	/**
+	 * Register the barcodes field on the Store API product endpoint.
+	 *
+	 * MUST be called on the `woocommerce_blocks_loaded` action (WC's
+	 * documented trigger for extension registration). Running earlier
+	 * risks the Store API infrastructure not being ready yet;
+	 * running later risks missing the initial request of the
+	 * lifecycle.
+	 *
+	 * Early-returns when the helper function doesn't exist — on old
+	 * WC versions (< 7.something) we just don't register anything
+	 * and barcodes silently won't appear. UCP variant translator's
+	 * `extract_barcodes` already tolerates an absent extensions
+	 * payload, so the degradation is silent.
+	 */
+	public function init(): void {
+		add_action( 'woocommerce_blocks_loaded', [ $this, 'register_endpoint_data' ] );
+	}
+
+	/**
+	 * Invoke the Store API extension registration.
+	 *
+	 * Separated from `init()` for testability.
+	 */
+	public function register_endpoint_data(): void {
+		if ( ! function_exists( 'woocommerce_store_api_register_endpoint_data' ) ) {
+			return;
+		}
+
+		// Register on the ProductSchema identifier. The string literal
+		// `'product'` is what `\Automattic\WooCommerce\StoreApi\Schemas\V1\ProductSchema::IDENTIFIER`
+		// evaluates to — we use the literal rather than the constant
+		// so this code doesn't trigger a fatal on PHP autoload if WC
+		// Blocks aren't initialized yet at this point in the lifecycle.
+		woocommerce_store_api_register_endpoint_data(
+			[
+				'endpoint'        => 'product',
+				'namespace'       => self::NAMESPACE,
+				'data_callback'   => [ $this, 'get_product_data' ],
+				'schema_callback' => [ $this, 'get_schema' ],
+				'schema_type'     => ARRAY_A,
+			]
+		);
+	}
+
+	/**
+	 * Build the extension data payload for a given product or
+	 * variation. Called by the Store API per-request for each product
+	 * in the response.
+	 *
+	 * Signature: Store API invokes the data_callback with the
+	 * WC_Product instance (or the variation object for variation
+	 * endpoints). We return the shape declared by `get_schema()`.
+	 *
+	 * @param \WC_Product|null $product The product/variation object.
+	 * @return array<string, array<int, array{type: string, value: string}>>
+	 */
+	public function get_product_data( $product ): array {
+		if ( ! $product instanceof \WC_Product ) {
+			return [ 'barcodes' => [] ];
+		}
+
+		$barcodes = [];
+
+		// Native WC 9.4+ field. Older WC versions don't implement
+		// the method — guard with method_exists so the extension
+		// quietly returns empty rather than fatal-erroring.
+		if ( method_exists( $product, 'get_global_unique_id' ) ) {
+			$gtin = (string) $product->get_global_unique_id();
+			if ( '' !== $gtin ) {
+				$barcodes[] = [
+					'type'  => self::detect_gtin_type( $gtin ),
+					'value' => $gtin,
+				];
+			}
+		}
+
+		return [ 'barcodes' => $barcodes ];
+	}
+
+	/**
+	 * JSON Schema describing the extension payload. Store API uses
+	 * this to validate and document the shape in its OpenAPI-adjacent
+	 * self-description endpoint.
+	 *
+	 * @return array<string, mixed>
+	 */
+	public function get_schema(): array {
+		return [
+			'barcodes' => [
+				'description' => __(
+					'Product identifiers (GTIN, UPC, EAN, MPN, ISBN). Each entry is a typed barcode.',
+					'woocommerce-ai-syndication'
+				),
+				'type'        => 'array',
+				'context'     => [ 'view' ],
+				'readonly'    => true,
+				'items'       => [
+					'type'       => 'object',
+					'properties' => [
+						'type'  => [
+							'type'        => 'string',
+							'description' => __(
+								'Barcode type (gtin8, gtin12, gtin13, gtin14, other).',
+								'woocommerce-ai-syndication'
+							),
+						],
+						'value' => [
+							'type'        => 'string',
+							'description' => __(
+								'The barcode value as stored by the merchant.',
+								'woocommerce-ai-syndication'
+							),
+						],
+					],
+				],
+			],
+		];
+	}
+
+	/**
+	 * Infer the GTIN sub-type from the value's length.
+	 *
+	 * Conventional GTIN lengths (GS1 standard):
+	 *   - GTIN-8  — 8 digits, commonly EAN-8
+	 *   - GTIN-12 — 12 digits, commonly UPC-A (North America retail)
+	 *   - GTIN-13 — 13 digits, commonly EAN-13 (global retail)
+	 *   - GTIN-14 — 14 digits, commonly ITF-14 (wholesale/case-level)
+	 *
+	 * Anything outside these lengths or non-numeric (MPN, ISBN-10,
+	 * custom SKU-ish identifiers) is flagged `other`. Agents can
+	 * match against the raw value even without a precise type claim.
+	 *
+	 * @param string $value Raw identifier string from product meta.
+	 * @return string       One of: gtin8, gtin12, gtin13, gtin14, other.
+	 */
+	private static function detect_gtin_type( string $value ): string {
+		if ( ! ctype_digit( $value ) ) {
+			return 'other';
+		}
+		switch ( strlen( $value ) ) {
+			case 8:
+				return 'gtin8';
+			case 12:
+				return 'gtin12';
+			case 13:
+				return 'gtin13';
+			case 14:
+				return 'gtin14';
+			default:
+				return 'other';
+		}
+	}
+}

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php
@@ -133,8 +133,15 @@ class WC_AI_Syndication_Store_Api_Extension {
 		// Native WC 9.4+ field. Older WC versions don't implement
 		// the method — guard with method_exists so the extension
 		// quietly returns empty rather than fatal-erroring.
+		//
+		// Trim whitespace: merchants occasionally paste GTINs with
+		// trailing spaces. A whitespace-only value would pass a naive
+		// `'' !== $gtin` check but emit a meaningless `value` with a
+		// misleading `type` from detect_gtin_type. Checking emptiness
+		// on the trimmed form (and using it for both storage and type
+		// detection) keeps the output honest.
 		if ( method_exists( $product, 'get_global_unique_id' ) ) {
-			$gtin = (string) $product->get_global_unique_id();
+			$gtin = trim( (string) $product->get_global_unique_id() );
 			if ( '' !== $gtin ) {
 				$barcodes[] = [
 					'type'  => self::detect_gtin_type( $gtin ),

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php
@@ -72,11 +72,14 @@ class WC_AI_Syndication_Store_Api_Extension {
 	 * running later risks missing the initial request of the
 	 * lifecycle.
 	 *
-	 * Early-returns when the helper function doesn't exist — on old
-	 * WC versions (< 7.something) we just don't register anything
-	 * and barcodes silently won't appear. UCP variant translator's
-	 * `extract_barcodes` already tolerates an absent extensions
-	 * payload, so the degradation is silent.
+	 * Early-returns when the helper function doesn't exist. The
+	 * plugin's declared minimum WC (9.9) ships this helper, so the
+	 * guard is defensive belt-and-suspenders rather than a real
+	 * compatibility path — but if an install somehow loses the
+	 * helper (partial WC upgrade, WC disabled mid-request, etc.),
+	 * we no-op cleanly. UCP variant translator's `extract_barcodes`
+	 * tolerates an absent extensions payload, so the degradation
+	 * is silent.
 	 */
 	public function init(): void {
 		add_action( 'woocommerce_blocks_loaded', [ $this, 'register_endpoint_data' ] );

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
@@ -252,19 +252,18 @@ class WC_AI_Syndication_UCP_Product_Translator {
 		$raw = (string) ( $wc_product['short_description'] ?? '' );
 		// wp_strip_all_tags() rationale documented on the companion
 		// method in UCP Variant Translator (::extract_description).
-		$plain = html_entity_decode(
-			wp_strip_all_tags( $raw ),
-			ENT_QUOTES,
-			'UTF-8'
-		);
+		$stripped = wp_strip_all_tags( $raw );
+		$plain    = html_entity_decode( $stripped, ENT_QUOTES, 'UTF-8' );
 
 		$description = [ 'plain' => $plain ];
 
-		// Only include HTML if it's meaningfully different from plain.
-		// wp_strip_all_tags() returns input unchanged when there are
-		// no tags; comparing against the raw source is the cleanest
-		// detector for "source had markup worth preserving."
-		if ( '' !== $raw && $raw !== $plain ) {
+		// Only include HTML if the source actually contains markup.
+		// Compare `$raw` to `$stripped` (before entity decoding) — if
+		// they match, there were no tags, even when the source contained
+		// entities like `&amp;`. Comparing against the entity-decoded
+		// `$plain` would false-positive on plain text like
+		// "Fish &amp; Chips" and emit a redundant `html` field.
+		if ( '' !== $raw && $raw !== $stripped ) {
 			$description['html'] = $raw;
 		}
 

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
@@ -107,9 +107,11 @@ class WC_AI_Syndication_UCP_Product_Translator {
 		// the canonical product level because UCP's shopping schema
 		// doesn't have a standardized ratings field yet (the UCP spec
 		// is intentionally minimal; ratings are a "nice to have" that
-		// vendors wire through extension capabilities). Consistent
-		// with how we already carry store_context and attribution in
-		// the same extension.
+		// vendors wire through extension capabilities). The same
+		// extension namespace carries store_context + attribution at
+		// the manifest level (see WC_AI_Syndication_UCP::build_*);
+		// per-product data like ratings is the product-scoped
+		// counterpart. Emitted only when reviews exist.
 		$ratings = self::extract_ratings( $wc_product );
 		if ( null !== $ratings ) {
 			$product['extensions'] = [
@@ -258,12 +260,17 @@ class WC_AI_Syndication_UCP_Product_Translator {
 		$description = [ 'plain' => $plain ];
 
 		// Only include HTML if the source actually contains markup.
-		// Compare `$raw` to `$stripped` (before entity decoding) — if
-		// they match, there were no tags, even when the source contained
-		// entities like `&amp;`. Comparing against the entity-decoded
-		// `$plain` would false-positive on plain text like
-		// "Fish &amp; Chips" and emit a redundant `html` field.
-		if ( '' !== $raw && $raw !== $stripped ) {
+		// Compare `$stripped` to `trim( $raw )` (both before entity
+		// decoding) — if they match, there were no tags.
+		//
+		// Why trim: wp_strip_all_tags() trims leading/trailing
+		// whitespace as a side-effect, so comparing against an
+		// un-trimmed `$raw` would false-positive on plain text with
+		// trailing newlines.
+		// Why pre-decode: comparing against the entity-decoded `$plain`
+		// would false-positive on plain text like "Fish &amp; Chips"
+		// (entities != markup).
+		if ( '' !== $raw && trim( $raw ) !== $stripped ) {
 			$description['html'] = $raw;
 		}
 

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
@@ -77,14 +77,46 @@ class WC_AI_Syndication_UCP_Product_Translator {
 			$product['url'] = $wc_product['permalink'];
 		}
 
-		if ( ! empty( $wc_product['categories'] ) ) {
-			$product['categories'] = self::extract_categories(
-				$wc_product['categories']
-			);
+		// Categories + tags are both emitted into `categories` with
+		// distinct `taxonomy` values ("merchant" for WC categories,
+		// "tag" for WC tags). UCP's categories shape accepts this
+		// polymorphism — a single flat list indexed by taxonomy lets
+		// agents filter on either axis without a separate schema.
+		$taxonomies = self::extract_taxonomies( $wc_product );
+		if ( ! empty( $taxonomies ) ) {
+			$product['categories'] = $taxonomies;
 		}
 
 		if ( ! empty( $wc_product['images'] ) ) {
 			$product['media'] = self::extract_media( $wc_product['images'] );
+		}
+
+		// Product-level attributes — "Material: Cotton", "Fit: Slim",
+		// etc. For variable products WC surfaces the same attributes
+		// on each variation (as `options`, handled in the variant
+		// translator), but simple products store attributes here too.
+		// Emitting them at product level lets agents filter "show me
+		// only cotton items" without walking variants.
+		$attributes = self::extract_attributes( $wc_product );
+		if ( ! empty( $attributes ) ) {
+			$product['attributes'] = $attributes;
+		}
+
+		// Ratings + review count land in the
+		// `com.woocommerce.ai_syndication` extension rather than at
+		// the canonical product level because UCP's shopping schema
+		// doesn't have a standardized ratings field yet (the UCP spec
+		// is intentionally minimal; ratings are a "nice to have" that
+		// vendors wire through extension capabilities). Consistent
+		// with how we already carry store_context and attribution in
+		// the same extension.
+		$ratings = self::extract_ratings( $wc_product );
+		if ( null !== $ratings ) {
+			$product['extensions'] = [
+				'com.woocommerce.ai_syndication' => [
+					'ratings' => $ratings,
+				],
+			];
 		}
 
 		return $product;
@@ -173,32 +205,6 @@ class WC_AI_Syndication_UCP_Product_Translator {
 	}
 
 	/**
-	 * Map WC category objects to UCP category entries with merchant
-	 * taxonomy tagging.
-	 *
-	 * UCP `category` type has `value` (the category name/ID) and
-	 * `taxonomy` (which taxonomy the value belongs to). Standard
-	 * taxonomies include `google_product_category`, `shopify`, and
-	 * `merchant` for business-specific values. Our WC categories are
-	 * merchant-defined, so we tag them `merchant`.
-	 *
-	 * @param array<int, array<string, mixed>> $wc_categories
-	 * @return array<int, array{value: string, taxonomy: string}>
-	 */
-	private static function extract_categories( array $wc_categories ): array {
-		$result = [];
-		foreach ( $wc_categories as $cat ) {
-			if ( ! empty( $cat['name'] ) ) {
-				$result[] = [
-					'value'    => $cat['name'],
-					'taxonomy' => 'merchant',
-				];
-			}
-		}
-		return $result;
-	}
-
-	/**
 	 * Map WC image objects to UCP media entries.
 	 *
 	 * UCP media shape: `{type, url, alt_text}`. v1 handles image
@@ -229,18 +235,181 @@ class WC_AI_Syndication_UCP_Product_Translator {
 	/**
 	 * Extract a UCP description object from the WC response.
 	 *
+	 * Emits BOTH `plain` and `html` when the source short_description
+	 * has structure worth preserving. The `plain` form strips all
+	 * tags for agents that want flat text; `html` preserves lists,
+	 * emphasis, line breaks for agents that can render. UCP's
+	 * description object accepts either or both.
+	 *
+	 * Falls back to only `plain` when short_description is empty or
+	 * is already plain text (no tags detected). Avoids emitting a
+	 * redundant `html` key that carries identical content.
+	 *
 	 * @param array<string, mixed> $wc_product
-	 * @return array{plain: string}
+	 * @return array{plain: string, html?: string}
 	 */
 	private static function extract_description( array $wc_product ): array {
-		$raw = $wc_product['short_description'] ?? '';
+		$raw = (string) ( $wc_product['short_description'] ?? '' );
 		// wp_strip_all_tags() rationale documented on the companion
 		// method in UCP Variant Translator (::extract_description).
 		$plain = html_entity_decode(
-			wp_strip_all_tags( (string) $raw ),
+			wp_strip_all_tags( $raw ),
 			ENT_QUOTES,
 			'UTF-8'
 		);
-		return [ 'plain' => $plain ];
+
+		$description = [ 'plain' => $plain ];
+
+		// Only include HTML if it's meaningfully different from plain.
+		// wp_strip_all_tags() returns input unchanged when there are
+		// no tags; comparing against the raw source is the cleanest
+		// detector for "source had markup worth preserving."
+		if ( '' !== $raw && $raw !== $plain ) {
+			$description['html'] = $raw;
+		}
+
+		return $description;
+	}
+
+	/**
+	 * Extract the combined taxonomies list (categories + tags).
+	 *
+	 * Both come back as UCP category entries (`{value, taxonomy}`)
+	 * with distinct `taxonomy` slugs: "merchant" for WC categories
+	 * (our pre-existing convention), "tag" for WC tags. Tags are an
+	 * optional cross-cutting discovery signal ("summer",
+	 * "eco-friendly") that's orthogonal to categorical hierarchy;
+	 * merging them into one `categories` list keeps the UCP product
+	 * schema flat while letting agents filter/match on either axis.
+	 *
+	 * Tags emit only when present; merchants who don't use tags
+	 * pay zero extra payload.
+	 *
+	 * @param array<string, mixed> $wc_product
+	 * @return array<int, array{value: string, taxonomy: string}>
+	 */
+	private static function extract_taxonomies( array $wc_product ): array {
+		$result = [];
+
+		if ( ! empty( $wc_product['categories'] ) && is_array( $wc_product['categories'] ) ) {
+			foreach ( $wc_product['categories'] as $cat ) {
+				if ( is_array( $cat ) && ! empty( $cat['name'] ) ) {
+					$result[] = [
+						'value'    => (string) $cat['name'],
+						'taxonomy' => 'merchant',
+					];
+				}
+			}
+		}
+
+		if ( ! empty( $wc_product['tags'] ) && is_array( $wc_product['tags'] ) ) {
+			foreach ( $wc_product['tags'] as $tag ) {
+				if ( is_array( $tag ) && ! empty( $tag['name'] ) ) {
+					$result[] = [
+						'value'    => (string) $tag['name'],
+						'taxonomy' => 'tag',
+					];
+				}
+			}
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract product-level attributes for discovery filtering.
+	 *
+	 * WC Store API returns attributes as a flat array on the product
+	 * response. Each entry has `name` (display label, e.g. "Material"),
+	 * `taxonomy` (slug, e.g. "pa_material"), and `terms` (the values
+	 * the merchant has tagged this product with — a product might
+	 * be both "Cotton" and "Recycled").
+	 *
+	 * Shape: `[{ name, values: [string] }]`. Only attributes with at
+	 * least one term are emitted; empty-term entries produce no
+	 * payload. Attributes that ARE variation axes (identified by WC's
+	 * `has_variations: true` flag) are SKIPPED at the product level —
+	 * those belong on variant `options`, not here. Non-variation
+	 * attributes (things that apply uniformly to all variants, or to
+	 * simple products) land here.
+	 *
+	 * @param array<string, mixed> $wc_product
+	 * @return array<int, array{name: string, values: array<int, string>}>
+	 */
+	private static function extract_attributes( array $wc_product ): array {
+		$attributes = $wc_product['attributes'] ?? [];
+		if ( ! is_array( $attributes ) ) {
+			return [];
+		}
+
+		$result = [];
+		foreach ( $attributes as $attribute ) {
+			if ( ! is_array( $attribute ) ) {
+				continue;
+			}
+
+			// Skip variation-defining attributes; those belong on
+			// variant `options`, not at product level.
+			if ( ! empty( $attribute['has_variations'] ) ) {
+				continue;
+			}
+
+			$name  = (string) ( $attribute['name'] ?? '' );
+			$terms = $attribute['terms'] ?? [];
+			if ( '' === $name || ! is_array( $terms ) || empty( $terms ) ) {
+				continue;
+			}
+
+			$values = [];
+			foreach ( $terms as $term ) {
+				if ( is_array( $term ) && ! empty( $term['name'] ) ) {
+					$values[] = (string) $term['name'];
+				}
+			}
+			if ( empty( $values ) ) {
+				continue;
+			}
+
+			$result[] = [
+				'name'   => $name,
+				'values' => $values,
+			];
+		}
+
+		return $result;
+	}
+
+	/**
+	 * Extract ratings for the extension capability.
+	 *
+	 * Returns a compact `{average, count}` shape when the merchant
+	 * has at least one review, otherwise null (caller skips the
+	 * extension payload). Average rating is a string in the Store
+	 * API response (e.g. "4.67"); we coerce to float for agents that
+	 * do numeric comparisons. Review count is already an int.
+	 *
+	 * Agents recommending products benefit enormously from rating
+	 * data — "customers rate it 4.7 / 2,384 reviews" is dominant
+	 * social proof that converts. The data is already computed by
+	 * WC; we just forward it.
+	 *
+	 * @param array<string, mixed> $wc_product
+	 * @return array{average: float, count: int}|null
+	 */
+	private static function extract_ratings( array $wc_product ): ?array {
+		$count = isset( $wc_product['review_count'] )
+			? (int) $wc_product['review_count']
+			: 0;
+
+		if ( $count <= 0 ) {
+			return null;
+		}
+
+		return [
+			'average' => isset( $wc_product['average_rating'] )
+				? (float) $wc_product['average_rating']
+				: 0.0,
+			'count'   => $count,
+		];
 	}
 }

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1217,7 +1217,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 * returned messages array so agents learn their filter didn't
 	 * apply (instead of silently receiving the unfiltered catalog).
 	 *
-	 * @return array{0: array<string, string|int>, 1: array<int, array<string, mixed>>}
+	 * @return array{0: array<string, string|int|bool>, 1: array<int, array<string, mixed>>}
 	 *         [params, messages]
 	 */
 	private static function map_ucp_search_to_store_api( WP_REST_Request $request ): array {
@@ -1337,6 +1337,41 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			}
 		}
 
+		// On-sale filter — agents searching for deals pass
+		// `filters.on_sale: true`. Store API's `on_sale` param is a
+		// boolean flag that restricts results to products with an
+		// active sale price. We accept both strict true and stringy
+		// "true" since JSON-to-PHP boolean handling varies between
+		// REST clients.
+		if ( isset( $filters['on_sale'] ) && ( true === $filters['on_sale'] || 'true' === $filters['on_sale'] ) ) {
+			$params['on_sale'] = true;
+		}
+
+		// Tag filter — parallel to categories but across WC's tag
+		// taxonomy. Same name-to-term-ID resolution logic, same
+		// unresolved-warning emission for agent feedback. Tags
+		// surface cross-cutting discovery signals (e.g. "eco-friendly",
+		// "summer") that are orthogonal to hierarchical categories.
+		if ( isset( $filters['tags'] ) && is_array( $filters['tags'] ) ) {
+			$tag_result = self::resolve_tag_term_ids( $filters['tags'] );
+			if ( ! empty( $tag_result['ids'] ) ) {
+				$params['tag'] = implode( ',', $tag_result['ids'] );
+			}
+			foreach ( $tag_result['unresolved'] as $index => $bad ) {
+				$messages[] = [
+					'type'     => 'warning',
+					'code'     => 'tag_not_found',
+					'severity' => 'advisory',
+					'path'     => '$.filters.tags[' . $index . ']',
+					'content'  => sprintf(
+						/* translators: %s is the tag slug/name the agent sent that couldn't be resolved. */
+						__( 'Tag "%s" was not found; filter ignored for this value.', 'woocommerce-ai-syndication' ),
+						$bad
+					),
+				];
+			}
+		}
+
 		return [ $params, $messages ];
 	}
 
@@ -1359,7 +1394,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 * the filter was ignored.
 	 *
 	 * A future release should revisit emitting slugs from
-	 * `WC_AI_Syndication_UCP_Product_Translator::extract_categories()`
+	 * `WC_AI_Syndication_UCP_Product_Translator::extract_taxonomies()`
 	 * so round-tripping doesn't rely on the name fallback here.
 	 *
 	 * @param array<int, mixed> $inputs
@@ -1368,20 +1403,52 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 *         so callers can build JSONPath locators.
 	 */
 	private static function resolve_category_term_ids( array $inputs ): array {
+		return self::resolve_taxonomy_term_ids( $inputs, 'product_cat' );
+	}
+
+	/**
+	 * Resolve UCP tag strings to WC product_tag term IDs.
+	 *
+	 * Parallel to `resolve_category_term_ids` — same slug-first,
+	 * name-fallback lookup strategy, same shape return. Extracted
+	 * via the generic helper below so the category/tag resolution
+	 * stays DRY; if a future filter adds product_brand or another
+	 * taxonomy, it's a one-liner.
+	 *
+	 * @param array<int, mixed> $inputs
+	 * @return array{ids: array<int, int>, unresolved: array<int, string>}
+	 */
+	private static function resolve_tag_term_ids( array $inputs ): array {
+		return self::resolve_taxonomy_term_ids( $inputs, 'product_tag' );
+	}
+
+	/**
+	 * Generic term-resolution helper — slug first, name fallback.
+	 *
+	 * Abstracted from the original `resolve_category_term_ids` so
+	 * new taxonomies (tags, brands if merchants use them) can reuse
+	 * the same round-tripping strategy without copy-pasting the
+	 * skip/lookup/unresolved pattern.
+	 *
+	 * @param array<int, mixed> $inputs
+	 * @param string            $taxonomy The WC taxonomy slug ('product_cat', 'product_tag').
+	 * @return array{ids: array<int, int>, unresolved: array<int, string>}
+	 */
+	private static function resolve_taxonomy_term_ids( array $inputs, string $taxonomy ): array {
 		$ids        = [];
 		$unresolved = [];
 
 		foreach ( $inputs as $index => $input ) {
 			if ( ! is_string( $input ) || '' === $input ) {
 				// Skip non-string/empty inputs silently — they're
-				// malformed enough that `category_not_found` would be
-				// misleading (the agent didn't even spell a category).
+				// malformed enough that a not-found warning would be
+				// misleading (the agent didn't even spell a term).
 				continue;
 			}
 
-			$term = get_term_by( 'slug', $input, 'product_cat' );
+			$term = get_term_by( 'slug', $input, $taxonomy );
 			if ( ! $term || is_wp_error( $term ) ) {
-				$term = get_term_by( 'name', $input, 'product_cat' );
+				$term = get_term_by( 'name', $input, $taxonomy );
 			}
 			if ( $term && ! is_wp_error( $term ) ) {
 				$ids[] = (int) $term->term_id;

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
@@ -287,8 +287,18 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 			if ( '' === $value ) {
 				continue;
 			}
+			// Skip entries missing a human-readable label. Emitting
+			// `{attribute: "", value: "Blue"}` conveys no option axis
+			// to the agent — worse than dropping the entry because it
+			// pollutes the options list with an unlabeled row that
+			// can't be filtered or displayed meaningfully. Parallel to
+			// the empty-value skip above.
+			$label = (string) ( $attribute['name'] ?? '' );
+			if ( '' === $label ) {
+				continue;
+			}
 			$options[] = [
-				'attribute' => (string) ( $attribute['name'] ?? '' ),
+				'attribute' => $label,
 				'value'     => (string) $value,
 			];
 		}

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
@@ -57,14 +57,48 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 			'price'       => self::extract_price( $wc_variation ),
 		];
 
+		// Structured options — the {attribute, value} pairs that
+		// distinguish this variant from siblings (e.g. "Color: Blue,
+		// Size: M"). Already implied by `title` for human display, but
+		// agents that want to filter or match by attribute need them
+		// structured. UCP v2026-04-08 variant schema carries
+		// `options` exactly for this.
+		$options = self::extract_options( $wc_variation );
+		if ( ! empty( $options ) ) {
+			$variant['options'] = $options;
+		}
+
+		// Sale pricing — agents showing "was $X, now $Y" need
+		// compare_at_price alongside the canonical `price`. WC marks
+		// this via the `on_sale` flag plus `prices.regular_price`
+		// (higher) vs `prices.price` (the active/sale value). Only
+		// emit when actually on sale so non-sale variants stay
+		// clean.
+		if ( ! empty( $wc_variation['on_sale'] ) ) {
+			$compare_at = self::extract_compare_at_price( $wc_variation );
+			if ( null !== $compare_at ) {
+				$variant['compare_at_price'] = $compare_at;
+			}
+		}
+
 		// Optional fields. Only emit when present in WC source.
 		if ( ! empty( $wc_variation['sku'] ) ) {
 			$variant['sku'] = $wc_variation['sku'];
 		}
 
-		$variant['availability'] = [
-			'available' => (bool) ( $wc_variation['is_in_stock'] ?? true ),
-		];
+		// Barcodes (GTIN/UPC/EAN/MPN). Sourced from the Store API
+		// extension we register in `WC_AI_Syndication_Store_Api_Extension`
+		// (WC core doesn't expose `global_unique_id` on the Store API
+		// product schema yet — see the WC enhancement request). The
+		// extension surfaces it under `extensions.{namespace}.barcodes`
+		// as an array of `{type, value}` pairs matching the UCP
+		// variant.barcodes shape.
+		$barcodes = self::extract_barcodes( $wc_variation );
+		if ( ! empty( $barcodes ) ) {
+			$variant['barcodes'] = $barcodes;
+		}
+
+		$variant['availability'] = self::extract_availability( $wc_variation );
 
 		return $variant;
 	}
@@ -85,18 +119,35 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 		$id = (int) ( $wc_product['id'] ?? 0 );
 
 		$variant = [
-			'id'           => self::VARIANT_ID_PREFIX . $id . self::DEFAULT_VARIANT_SUFFIX,
-			'title'        => $wc_product['name'] ?? '',
-			'description'  => [ 'plain' => '' ],
-			'price'        => self::extract_price( $wc_product ),
-			'availability' => [
-				'available' => (bool) ( $wc_product['is_in_stock'] ?? true ),
-			],
+			'id'          => self::VARIANT_ID_PREFIX . $id . self::DEFAULT_VARIANT_SUFFIX,
+			'title'       => $wc_product['name'] ?? '',
+			'description' => [ 'plain' => '' ],
+			'price'       => self::extract_price( $wc_product ),
 		];
+
+		// Sale pricing carries through the simple-product path too
+		// (a discounted simple product has on_sale + regular_price
+		// just like a variation).
+		if ( ! empty( $wc_product['on_sale'] ) ) {
+			$compare_at = self::extract_compare_at_price( $wc_product );
+			if ( null !== $compare_at ) {
+				$variant['compare_at_price'] = $compare_at;
+			}
+		}
 
 		if ( ! empty( $wc_product['sku'] ) ) {
 			$variant['sku'] = $wc_product['sku'];
 		}
+
+		// Simple products carry the same Store API extensions.{namespace}
+		// payload the variations do, so `barcodes` routes through the
+		// same helper.
+		$barcodes = self::extract_barcodes( $wc_product );
+		if ( ! empty( $barcodes ) ) {
+			$variant['barcodes'] = $barcodes;
+		}
+
+		$variant['availability'] = self::extract_availability( $wc_product );
 
 		return $variant;
 	}
@@ -168,5 +219,162 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 			'amount'   => (int) ( $prices['price'] ?? 0 ),
 			'currency' => $prices['currency_code'] ?? 'USD',
 		];
+	}
+
+	/**
+	 * Extract the compare-at price (the pre-sale price), or null when
+	 * the variation isn't on sale or the regular_price isn't higher.
+	 *
+	 * WC sale convention: `prices.price` is the currently-charged
+	 * amount (sale price when on_sale is true, regular price otherwise).
+	 * `prices.regular_price` is the "was" value. When on_sale is true
+	 * AND regular > price, we emit `compare_at_price` so agents can
+	 * render "was $X, now $Y" or compute a savings percent.
+	 *
+	 * Defensive against data oddities: if regular_price somehow equals
+	 * or is less than price while on_sale is flagged (inconsistent
+	 * state from third-party plugins), we return null rather than
+	 * emit a nonsensical "was $10, now $10" comparison.
+	 *
+	 * @param array<string, mixed> $wc
+	 * @return array{amount: int, currency: string}|null
+	 */
+	private static function extract_compare_at_price( array $wc ): ?array {
+		$prices  = $wc['prices'] ?? [];
+		$regular = isset( $prices['regular_price'] ) ? (int) $prices['regular_price'] : 0;
+		$current = (int) ( $prices['price'] ?? 0 );
+
+		if ( $regular <= 0 || $regular <= $current ) {
+			return null;
+		}
+
+		return [
+			'amount'   => $regular,
+			'currency' => $prices['currency_code'] ?? 'USD',
+		];
+	}
+
+	/**
+	 * Extract the structured options list from WC variation attributes.
+	 *
+	 * WC Store API returns each variation's attributes as an array of
+	 * objects shaped `{ name, value, taxonomy }`. UCP's `options`
+	 * field expects `[{ attribute, value }]` — one entry per defining
+	 * attribute with the human-readable label and the selected value.
+	 *
+	 * We use `name` (the attribute label) rather than `taxonomy` (the
+	 * slug like `pa_color`) because agents display this to buyers —
+	 * "Color: Blue" is merchant-readable, "pa_color: Blue" is not.
+	 * Empty-value entries are skipped to match the title-extraction
+	 * behavior.
+	 *
+	 * @param array<string, mixed> $wc_variation
+	 * @return array<int, array{attribute: string, value: string}>
+	 */
+	private static function extract_options( array $wc_variation ): array {
+		$attributes = $wc_variation['attributes'] ?? [];
+		$options    = [];
+
+		if ( ! is_array( $attributes ) ) {
+			return $options;
+		}
+
+		foreach ( $attributes as $attribute ) {
+			if ( ! is_array( $attribute ) ) {
+				continue;
+			}
+			$value = $attribute['value'] ?? '';
+			if ( '' === $value ) {
+				continue;
+			}
+			$options[] = [
+				'attribute' => (string) ( $attribute['name'] ?? '' ),
+				'value'     => (string) $value,
+			];
+		}
+
+		return $options;
+	}
+
+	/**
+	 * Extract the UCP availability object from the WC response.
+	 *
+	 * UCP variant.availability has a required `available: bool` plus
+	 * optional `quantity: int`. We emit `quantity` when the Store API
+	 * response carries `low_stock_remaining` — which WC populates only
+	 * when the merchant configured a low-stock threshold AND the
+	 * variation is below it. Otherwise no quantity is emitted, which
+	 * correctly signals "available but exact count unknown" rather
+	 * than misleadingly emitting 0.
+	 *
+	 * @param array<string, mixed> $wc
+	 * @return array{available: bool, quantity?: int}
+	 */
+	private static function extract_availability( array $wc ): array {
+		$availability = [
+			'available' => (bool) ( $wc['is_in_stock'] ?? true ),
+		];
+
+		if ( isset( $wc['low_stock_remaining'] ) && is_numeric( $wc['low_stock_remaining'] ) ) {
+			$quantity = (int) $wc['low_stock_remaining'];
+			if ( $quantity > 0 ) {
+				$availability['quantity'] = $quantity;
+			}
+		}
+
+		return $availability;
+	}
+
+	/**
+	 * Extract barcode entries from the Store API extension payload.
+	 *
+	 * WC core doesn't expose `global_unique_id` on the Store API
+	 * product schema yet. Our plugin registers an extension that
+	 * surfaces it (plus any legacy third-party barcode keys) under
+	 * `extensions.{namespace}.barcodes` as an array of `{type, value}`
+	 * objects. This method copies them through verbatim — the
+	 * extension is responsible for the type mapping (GTIN-13 → `ean`,
+	 * etc.), not the translator.
+	 *
+	 * Returns an empty array when no barcodes are present, so the
+	 * caller's `! empty()` check cleanly omits the `barcodes` key
+	 * from the UCP payload for products without identifiers.
+	 *
+	 * @param array<string, mixed> $wc
+	 * @return array<int, array{type: string, value: string}>
+	 */
+	private static function extract_barcodes( array $wc ): array {
+		$extensions = $wc['extensions'] ?? [];
+		if ( ! is_array( $extensions ) ) {
+			return [];
+		}
+
+		$namespace = WC_AI_Syndication_Store_Api_Extension::NAMESPACE;
+		$entry     = $extensions[ $namespace ] ?? [];
+		if ( ! is_array( $entry ) ) {
+			return [];
+		}
+
+		$barcodes = $entry['barcodes'] ?? [];
+		if ( ! is_array( $barcodes ) ) {
+			return [];
+		}
+
+		$result = [];
+		foreach ( $barcodes as $barcode ) {
+			if ( ! is_array( $barcode ) ) {
+				continue;
+			}
+			$type  = (string) ( $barcode['type'] ?? '' );
+			$value = (string) ( $barcode['value'] ?? '' );
+			if ( '' === $type || '' === $value ) {
+				continue;
+			}
+			$result[] = [
+				'type'  => $type,
+				'value' => $value,
+			];
+		}
+		return $result;
 	}
 }

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
@@ -333,8 +333,9 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 	 * surfaces it (plus any legacy third-party barcode keys) under
 	 * `extensions.{namespace}.barcodes` as an array of `{type, value}`
 	 * objects. This method copies them through verbatim — the
-	 * extension is responsible for the type mapping (GTIN-13 → `ean`,
-	 * etc.), not the translator.
+	 * extension is responsible for emitting the barcode `type` values
+	 * (`gtin8`, `gtin12`, `gtin13`, `gtin14`, or `other`), not the
+	 * translator.
 	 *
 	 * Returns an empty array when no barcodes are present, so the
 	 * caller's `! empty()` check cleanly omits the `barcodes` key

--- a/includes/class-wc-ai-syndication.php
+++ b/includes/class-wc-ai-syndication.php
@@ -91,6 +91,7 @@ class WC_AI_Syndication {
 		require_once $ucp_path . 'class-wc-ai-syndication-ucp-product-translator.php';
 		require_once $ucp_path . 'class-wc-ai-syndication-ucp-variant-translator.php';
 		require_once $ucp_path . 'class-wc-ai-syndication-ucp-store-api-filter.php';
+		require_once $ucp_path . 'class-wc-ai-syndication-store-api-extension.php';
 		require_once $ucp_path . 'class-wc-ai-syndication-ucp-rest-controller.php';
 
 		require_once WC_AI_SYNDICATION_PLUGIN_PATH . '/includes/admin/class-wc-ai-syndication-admin-controller.php';
@@ -132,6 +133,16 @@ class WC_AI_Syndication {
 		// See class docblock for scope rationale.
 		$store_api_filter = new WC_AI_Syndication_UCP_Store_API_Filter();
 		$store_api_filter->init();
+
+		// Store API extension — surfaces WC core's `global_unique_id`
+		// (GTIN/UPC/EAN/MPN) in the product response under
+		// `extensions.{namespace}.barcodes`, which the UCP variant
+		// translator reads from. WC core's Store API schema doesn't
+		// expose `global_unique_id` yet; see the filed enhancement
+		// request in woocommerce/woocommerce for the proposal to
+		// remove this extension once core picks it up.
+		$store_api_extension = new WC_AI_Syndication_Store_Api_Extension();
+		$store_api_extension->init();
 	}
 
 	/**

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-19T12:16:07+00:00\n"
+"POT-Creation-Date: 2026-04-19T13:57:04+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -50,6 +50,18 @@ msgstr ""
 #: includes/ai-syndication/class-wc-ai-syndication-jsonld.php:215
 #: client/settings/ai-syndication/product-selection.js:489
 msgid "Products"
+msgstr ""
+
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:156
+msgid "Product identifiers (GTIN, UPC, EAN, MPN, ISBN). Each entry is a typed barcode."
+msgstr ""
+
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:168
+msgid "Barcode type (gtin8, gtin12, gtin13, gtin14, other)."
+msgstr ""
+
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:175
+msgid "The barcode value as stored by the merchant."
 msgstr ""
 
 #: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:219
@@ -119,39 +131,45 @@ msgstr ""
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1743
+#. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1368
+#, php-format
+msgid "Tag \"%s\" was not found; filter ignored for this value."
+msgstr ""
+
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1810
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1747
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1814
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1751
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1818
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1753
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1820
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1755
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1822
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1759
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1826
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1761
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1828
 msgid "Line item could not be processed."
 msgstr ""
 
-#: includes/class-wc-ai-syndication.php:246
-#: includes/class-wc-ai-syndication.php:247
-#: includes/class-wc-ai-syndication.php:259
+#: includes/class-wc-ai-syndication.php:257
+#: includes/class-wc-ai-syndication.php:258
+#: includes/class-wc-ai-syndication.php:270
 msgid "AI Syndication"
 msgstr ""
 
@@ -344,12 +362,12 @@ msgid "Limits are applied per AI crawler (identified by user-agent string) using
 msgstr ""
 
 #: client/settings/ai-syndication/endpoint-info.js:963
-#: client/settings/ai-syndication/product-selection.js:648
+#: client/settings/ai-syndication/product-selection.js:647
 msgid "Saving…"
 msgstr ""
 
 #: client/settings/ai-syndication/endpoint-info.js:964
-#: client/settings/ai-syndication/product-selection.js:649
+#: client/settings/ai-syndication/product-selection.js:648
 msgid "Save Changes"
 msgstr ""
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -41,6 +41,7 @@ require_once $ucp_rest_path . 'class-wc-ai-syndication-ucp-envelope.php';
 require_once $ucp_rest_path . 'class-wc-ai-syndication-ucp-product-translator.php';
 require_once $ucp_rest_path . 'class-wc-ai-syndication-ucp-variant-translator.php';
 require_once $ucp_rest_path . 'class-wc-ai-syndication-ucp-store-api-filter.php';
+require_once $ucp_rest_path . 'class-wc-ai-syndication-store-api-extension.php';
 require_once $ucp_rest_path . 'class-wc-ai-syndication-ucp-rest-controller.php';
 
 // Admin REST controller. Covers admin-surface endpoints (settings,

--- a/tests/php/unit/StoreApiExtensionTest.php
+++ b/tests/php/unit/StoreApiExtensionTest.php
@@ -1,0 +1,213 @@
+<?php
+/**
+ * Tests for WC_AI_Syndication_Store_Api_Extension.
+ *
+ * The extension surfaces WC core's `global_unique_id` product field
+ * (GTIN/UPC/EAN/MPN/ISBN) on the Store API `/products` response
+ * under `extensions.com-woocommerce-ai-syndication.barcodes`.
+ *
+ * WC core's Store API schema doesn't include `global_unique_id` yet
+ * (enhancement request filed against woocommerce/woocommerce). Until
+ * it does, this extension is the bridge: it reads the native
+ * WC_Product field server-side and emits a typed `{type, value}`
+ * pair that our UCP variant translator consumes.
+ *
+ * @package WooCommerce_AI_Syndication
+ */
+
+use Brain\Monkey;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+class StoreApiExtensionTest extends \PHPUnit\Framework\TestCase {
+	use MockeryPHPUnitIntegration;
+
+	private WC_AI_Syndication_Store_Api_Extension $extension;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+		// i18n functions are stubbed as passthroughs — the extension uses
+		// __() for schema descriptions, but those strings aren't under test.
+		Monkey\Functions\when( '__' )->returnArg();
+		$this->extension = new WC_AI_Syndication_Store_Api_Extension();
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// Namespace constant
+	// ------------------------------------------------------------------
+
+	public function test_namespace_matches_extension_capability(): void {
+		// The namespace is shared with the UCP extension capability
+		// we publish in the manifest — keeps the "namespace" concept
+		// consistent across surfaces (Store API extension + UCP
+		// product.extensions + llms.txt attribution table).
+		//
+		// This is a hyphenated variant of the UCP
+		// `com.woocommerce.ai_syndication` namespace because Store
+		// API namespace values are used as URL path segments in
+		// some response shapes and shouldn't contain dots.
+		$this->assertSame(
+			'com-woocommerce-ai-syndication',
+			WC_AI_Syndication_Store_Api_Extension::NAMESPACE
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// get_product_data: the per-product callback
+	// ------------------------------------------------------------------
+
+	public function test_returns_empty_barcodes_for_non_product_input(): void {
+		// Defensive: Store API invokes the data_callback with the
+		// product object, but if something else ever calls it with
+		// null or a plain array we should return the empty shape,
+		// not fatal.
+		$result = $this->extension->get_product_data( null );
+
+		$this->assertSame( [ 'barcodes' => [] ], $result );
+	}
+
+	public function test_returns_empty_barcodes_when_product_lacks_global_unique_id_method(): void {
+		// Older WC versions (< 9.4) don't implement get_global_unique_id().
+		// We guard via method_exists so older installs produce empty
+		// barcodes rather than fatal.
+		$old_product = new class() extends \WC_Product {};
+
+		$result = $this->extension->get_product_data( $old_product );
+
+		$this->assertSame( [ 'barcodes' => [] ], $result );
+	}
+
+	public function test_emits_gtin13_for_13_digit_value(): void {
+		$product = $this->make_product_with_gtin( '1234567890123' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertCount( 1, $result['barcodes'] );
+		$this->assertSame( 'gtin13', $result['barcodes'][0]['type'] );
+		$this->assertSame( '1234567890123', $result['barcodes'][0]['value'] );
+	}
+
+	public function test_emits_gtin8_for_8_digit_value(): void {
+		$product = $this->make_product_with_gtin( '12345678' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( 'gtin8', $result['barcodes'][0]['type'] );
+	}
+
+	public function test_emits_gtin12_for_12_digit_value(): void {
+		$product = $this->make_product_with_gtin( '123456789012' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( 'gtin12', $result['barcodes'][0]['type'] );
+	}
+
+	public function test_emits_gtin14_for_14_digit_value(): void {
+		$product = $this->make_product_with_gtin( '12345678901234' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( 'gtin14', $result['barcodes'][0]['type'] );
+	}
+
+	public function test_emits_other_for_non_numeric_value(): void {
+		// MPN or custom identifier — not a digit-only GTIN sub-type.
+		// Agents can still match on the raw value; we just don't
+		// make a false type claim.
+		$product = $this->make_product_with_gtin( 'MPN-ABC-123' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( 'other', $result['barcodes'][0]['type'] );
+		$this->assertSame( 'MPN-ABC-123', $result['barcodes'][0]['value'] );
+	}
+
+	public function test_emits_other_for_non_standard_digit_length(): void {
+		// An 11-digit numeric string isn't a standard GTIN sub-type.
+		// Type `other` is honest; emitting gtin12 would misrepresent
+		// the identifier.
+		$product = $this->make_product_with_gtin( '12345678901' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( 'other', $result['barcodes'][0]['type'] );
+	}
+
+	public function test_emits_empty_barcodes_when_value_is_empty_string(): void {
+		$product = $this->make_product_with_gtin( '' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( [], $result['barcodes'] );
+	}
+
+	// ------------------------------------------------------------------
+	// Schema callback
+	// ------------------------------------------------------------------
+
+	public function test_schema_callback_returns_valid_barcodes_schema(): void {
+		$schema = $this->extension->get_schema();
+
+		$this->assertArrayHasKey( 'barcodes', $schema );
+		$this->assertSame( 'array', $schema['barcodes']['type'] );
+		$this->assertTrue( $schema['barcodes']['readonly'] );
+		$this->assertArrayHasKey( 'items', $schema['barcodes'] );
+		$this->assertSame( 'object', $schema['barcodes']['items']['type'] );
+
+		// The items shape must include type + value — that's what
+		// the variant translator reads.
+		$item_props = $schema['barcodes']['items']['properties'];
+		$this->assertArrayHasKey( 'type', $item_props );
+		$this->assertArrayHasKey( 'value', $item_props );
+	}
+
+	// ------------------------------------------------------------------
+	// init: hook registration
+	// ------------------------------------------------------------------
+
+	public function test_init_registers_on_woocommerce_blocks_loaded(): void {
+		// Invariant: the extension registration MUST be gated on
+		// `woocommerce_blocks_loaded` per WC's documented extension
+		// lifecycle. Running earlier risks the Store API plumbing
+		// not being ready; running later risks missing the first
+		// request.
+		$hooks = [];
+		\Brain\Monkey\Functions\when( 'add_action' )->alias(
+			static function ( $hook, $callback ) use ( &$hooks ) {
+				$hooks[] = $hook;
+			}
+		);
+
+		$this->extension->init();
+
+		$this->assertContains( 'woocommerce_blocks_loaded', $hooks );
+	}
+
+	// ------------------------------------------------------------------
+	// Helpers
+	// ------------------------------------------------------------------
+
+	/**
+	 * Build an anonymous WC_Product subclass whose `get_global_unique_id`
+	 * returns the configured value.
+	 */
+	private function make_product_with_gtin( string $gtin ): \WC_Product {
+		return new class( $gtin ) extends \WC_Product {
+			private string $gtin;
+
+			public function __construct( string $gtin ) {
+				$this->gtin = $gtin;
+			}
+
+			public function get_global_unique_id() {
+				return $this->gtin;
+			}
+		};
+	}
+}

--- a/tests/php/unit/StoreApiExtensionTest.php
+++ b/tests/php/unit/StoreApiExtensionTest.php
@@ -147,6 +147,31 @@ class StoreApiExtensionTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( [], $result['barcodes'] );
 	}
 
+	public function test_emits_empty_barcodes_when_value_is_whitespace_only(): void {
+		// Regression: merchants occasionally paste GTINs with trailing
+		// whitespace. A "   " value would pass a naive `!== ''` check
+		// and emit {type: "other", value: "   "} — meaningless and
+		// misleading. Trim should collapse whitespace-only values to
+		// empty before the emptiness check.
+		$product = $this->make_product_with_gtin( "   \n\t" );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( [], $result['barcodes'] );
+	}
+
+	public function test_trims_whitespace_around_gtin_before_type_detection(): void {
+		// A 13-digit GTIN with surrounding whitespace should still
+		// detect as gtin13 (trim applied before length-based type
+		// detection) and emit the trimmed value.
+		$product = $this->make_product_with_gtin( '  1234567890123  ' );
+
+		$result = $this->extension->get_product_data( $product );
+
+		$this->assertSame( 'gtin13', $result['barcodes'][0]['type'] );
+		$this->assertSame( '1234567890123', $result['barcodes'][0]['value'] );
+	}
+
 	// ------------------------------------------------------------------
 	// Schema callback
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -97,10 +97,24 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		$terms = &$this->fake_terms;
 		Functions\when( 'get_term_by' )->alias(
 			static function ( string $field, string $value, string $taxonomy ) use ( &$terms ) {
-				if ( 'product_cat' !== $taxonomy ) {
+				// Both product_cat and product_tag go through the
+				// same stubbed lookup — `seed_term` keys by
+				// `taxonomy:field:value` so the tag filter tests
+				// can seed independently from the category ones.
+				if ( ! in_array( $taxonomy, [ 'product_cat', 'product_tag' ], true ) ) {
 					return false;
 				}
-				return $terms[ "{$field}:{$value}" ] ?? false;
+				$key = "{$taxonomy}:{$field}:{$value}";
+				if ( isset( $terms[ $key ] ) ) {
+					return $terms[ $key ];
+				}
+				// Back-compat with earlier tests that seeded under
+				// the un-namespaced `field:value` key — those are
+				// implicitly product_cat.
+				if ( 'product_cat' === $taxonomy ) {
+					return $terms[ "{$field}:{$value}" ] ?? false;
+				}
+				return false;
 			}
 		);
 
@@ -126,7 +140,7 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 					// the canned product list. 1.6.0 added `page` +
 					// `per_page` to the captured list for pagination
 					// mapping assertions.
-					foreach ( [ 'search', 'category', 'min_price', 'max_price', 'page', 'per_page' ] as $key ) {
+					foreach ( [ 'search', 'category', 'min_price', 'max_price', 'page', 'per_page', 'tag', 'on_sale' ] as $key ) {
 						$val = $request->get_param( $key );
 						if ( null !== $val ) {
 							$captured_params[ $key ] = $val;
@@ -191,7 +205,9 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	/**
-	 * Register a fake term that `get_term_by` lookups will resolve.
+	 * Register a fake product_cat term that `get_term_by` lookups
+	 * will resolve. Historical un-namespaced keys preserved for
+	 * back-compat with the original pre-1.8 tests.
 	 */
 	private function seed_term( int $term_id, string $slug, string $name ): void {
 		$term                              = (object) [
@@ -201,6 +217,22 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		];
 		$this->fake_terms[ "slug:{$slug}" ] = $term;
 		$this->fake_terms[ "name:{$name}" ] = $term;
+	}
+
+	/**
+	 * Register a fake product_tag term that `get_term_by` lookups
+	 * against the `product_tag` taxonomy will resolve. Namespaced
+	 * by taxonomy so cat and tag lookups don't collide when the
+	 * same slug is used in both taxonomies (merchants do this).
+	 */
+	private function seed_tag_term( int $term_id, string $slug, string $name ): void {
+		$term                                                 = (object) [
+			'term_id' => $term_id,
+			'slug'    => $slug,
+			'name'    => $name,
+		];
+		$this->fake_terms[ "product_tag:slug:{$slug}" ]      = $term;
+		$this->fake_terms[ "product_tag:name:{$name}" ]      = $term;
 	}
 
 	/**
@@ -384,6 +416,81 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertEquals( '42', $this->captured_store_params['category'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.8.0: Tag filter mapping
+	// ------------------------------------------------------------------
+
+	public function test_tag_slug_resolves_and_forwards_to_store_api(): void {
+		$this->seed_tag_term( 55, 'summer', 'Summer' );
+
+		$this->successful_search(
+			[ 'filters' => [ 'tags' => [ 'summer' ] ] ]
+		);
+
+		$this->assertEquals( '55', $this->captured_store_params['tag'] );
+	}
+
+	public function test_multiple_tags_comma_separate(): void {
+		$this->seed_tag_term( 11, 'summer', 'Summer' );
+		$this->seed_tag_term( 12, 'eco', 'Eco' );
+
+		$this->successful_search(
+			[ 'filters' => [ 'tags' => [ 'summer', 'eco' ] ] ]
+		);
+
+		$this->assertEquals( '11,12', $this->captured_store_params['tag'] );
+	}
+
+	public function test_unresolvable_tag_produces_tag_not_found_warning(): void {
+		// Symmetric with the category_not_found warning behavior —
+		// agents must see a signal that their filter was ignored.
+		$this->seed_tag_term( 11, 'summer', 'Summer' );
+
+		$body = $this->successful_search(
+			[ 'filters' => [ 'tags' => [ 'summer', 'winter' ] ] ]
+		);
+
+		$not_found = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'tag_not_found' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $not_found );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.8.0: on_sale filter
+	// ------------------------------------------------------------------
+
+	public function test_on_sale_filter_forwards_boolean_true(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'on_sale' => true ] ]
+		);
+
+		$this->assertTrue( $this->captured_store_params['on_sale'] );
+	}
+
+	public function test_on_sale_filter_accepts_string_true_from_json(): void {
+		// Some REST clients (historically, the WP REST API itself)
+		// pass booleans as strings; accepting "true" keeps the API
+		// forgiving without losing the opt-in intent.
+		$this->successful_search(
+			[ 'filters' => [ 'on_sale' => 'true' ] ]
+		);
+
+		$this->assertTrue( $this->captured_store_params['on_sale'] );
+	}
+
+	public function test_on_sale_filter_false_does_not_forward(): void {
+		// `on_sale: false` is the equivalent of "don't filter" — WC
+		// Store API treats an absent param as "return everything,"
+		// so we don't forward an explicit false.
+		$this->successful_search(
+			[ 'filters' => [ 'on_sale' => false ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'on_sale', $this->captured_store_params );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -505,6 +505,22 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'Just plain text', $result['description']['plain'] );
 	}
 
+	public function test_translate_omits_description_html_when_source_has_entities_but_no_tags(): void {
+		// Regression: entity-decoding was being used as the "has markup"
+		// detector, so `"Fish &amp; Chips"` decoded to `"Fish & Chips"`
+		// and false-positive'd into emitting `html`. HTML emission
+		// should be about preserving structural markup (tags), not
+		// entity glyphs — the decoded plain form conveys those
+		// losslessly.
+		$fixture                      = $this->simple_product_fixture();
+		$fixture['short_description'] = 'Fish &amp; Chips';
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayNotHasKey( 'html', $result['description'] );
+		$this->assertSame( 'Fish & Chips', $result['description']['plain'] );
+	}
+
 	public function test_translate_emits_tags_as_second_taxonomy_in_categories(): void {
 		$fixture         = $this->simple_product_fixture();
 		$fixture['tags'] = [

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -505,6 +505,23 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'Just plain text', $result['description']['plain'] );
 	}
 
+	public function test_translate_omits_description_html_when_source_has_trailing_whitespace(): void {
+		// Regression: wp_strip_all_tags() trims surrounding whitespace
+		// as a side effect, so comparing the stripped form to the raw
+		// form would false-positive on plain text with trailing
+		// newlines/spaces — treating a whitespace difference as
+		// "source had markup" and emitting a redundant `html` field.
+		// The fix compares against `trim( $raw )` so whitespace-only
+		// differences don't trigger html emission.
+		$fixture                      = $this->simple_product_fixture();
+		$fixture['short_description'] = "Just plain text\n\n";
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayNotHasKey( 'html', $result['description'] );
+		$this->assertSame( 'Just plain text', $result['description']['plain'] );
+	}
+
 	public function test_translate_omits_description_html_when_source_has_entities_but_no_tags(): void {
 		// Regression: entity-decoding was being used as the "has markup"
 		// detector, so `"Fish &amp; Chips"` decoded to `"Fish & Chips"`

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -479,4 +479,115 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 1, $result['variants'] );
 		$this->assertEquals( 'var_123_default', $result['variants'][0]['id'] );
 	}
+
+	// ------------------------------------------------------------------
+	// 1.8.0: description.html, tags, product attributes, ratings
+	// ------------------------------------------------------------------
+
+	public function test_translate_emits_description_html_when_source_has_markup(): void {
+		$fixture                      = $this->simple_product_fixture();
+		$fixture['short_description'] = '<ul><li>Waterproof</li><li>Light</li></ul>';
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayHasKey( 'html', $result['description'] );
+		$this->assertSame( '<ul><li>Waterproof</li><li>Light</li></ul>', $result['description']['html'] );
+		$this->assertSame( 'WaterproofLight', $result['description']['plain'] );
+	}
+
+	public function test_translate_omits_description_html_when_plain(): void {
+		$fixture                      = $this->simple_product_fixture();
+		$fixture['short_description'] = 'Just plain text';
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayNotHasKey( 'html', $result['description'] );
+		$this->assertSame( 'Just plain text', $result['description']['plain'] );
+	}
+
+	public function test_translate_emits_tags_as_second_taxonomy_in_categories(): void {
+		$fixture         = $this->simple_product_fixture();
+		$fixture['tags'] = [
+			[ 'id' => 5, 'name' => 'summer', 'slug' => 'summer' ],
+			[ 'id' => 6, 'name' => 'eco-friendly', 'slug' => 'eco-friendly' ],
+		];
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertContains(
+			[ 'value' => 'summer', 'taxonomy' => 'tag' ],
+			$result['categories']
+		);
+		$this->assertContains(
+			[ 'value' => 'eco-friendly', 'taxonomy' => 'tag' ],
+			$result['categories']
+		);
+	}
+
+	public function test_translate_emits_product_attributes_excluding_variation_defining(): void {
+		$fixture               = $this->simple_product_fixture();
+		$fixture['attributes'] = [
+			[
+				'name'           => 'Material',
+				'taxonomy'       => 'pa_material',
+				'has_variations' => false,
+				'terms'          => [
+					[ 'id' => 10, 'name' => 'Cotton', 'slug' => 'cotton' ],
+					[ 'id' => 11, 'name' => 'Organic', 'slug' => 'organic' ],
+				],
+			],
+			[
+				// Variation-defining attribute — belongs on variant options, NOT here.
+				'name'           => 'Size',
+				'taxonomy'       => 'pa_size',
+				'has_variations' => true,
+				'terms'          => [
+					[ 'id' => 20, 'name' => 'M', 'slug' => 'm' ],
+				],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayHasKey( 'attributes', $result );
+		$this->assertCount( 1, $result['attributes'] );
+		$this->assertSame( 'Material', $result['attributes'][0]['name'] );
+		$this->assertSame( [ 'Cotton', 'Organic' ], $result['attributes'][0]['values'] );
+	}
+
+	public function test_translate_omits_attributes_when_source_has_none(): void {
+		$fixture = $this->simple_product_fixture();
+		unset( $fixture['attributes'] );
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayNotHasKey( 'attributes', $result );
+	}
+
+	public function test_translate_emits_ratings_under_extension_when_reviews_exist(): void {
+		$fixture                   = $this->simple_product_fixture();
+		$fixture['average_rating'] = '4.67';
+		$fixture['review_count']   = 42;
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayHasKey( 'extensions', $result );
+		$this->assertArrayHasKey(
+			'com.woocommerce.ai_syndication',
+			$result['extensions']
+		);
+		$ratings = $result['extensions']['com.woocommerce.ai_syndication']['ratings'];
+		$this->assertSame( 4.67, $ratings['average'] );
+		$this->assertSame( 42, $ratings['count'] );
+	}
+
+	public function test_translate_omits_ratings_extension_when_no_reviews(): void {
+		$fixture                   = $this->simple_product_fixture();
+		$fixture['average_rating'] = '0';
+		$fixture['review_count']   = 0;
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertArrayNotHasKey( 'extensions', $result );
+	}
 }

--- a/tests/php/unit/UcpVariantTranslatorTest.php
+++ b/tests/php/unit/UcpVariantTranslatorTest.php
@@ -245,6 +245,30 @@ class UcpVariantTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertArrayNotHasKey( 'options', $result );
 	}
 
+	public function test_translate_skips_option_entries_without_attribute_label(): void {
+		// Regression: an attribute entry with a present value but
+		// missing `name` would emit `{attribute: "", value: "Blue"}`
+		// — an unlabeled axis the agent can't filter or present.
+		// Drop those, parallel to the empty-value skip.
+		$fixture = [
+			'id'         => 501,
+			'name'       => 'Mixed attribute shapes',
+			'prices'     => [ 'price' => '2500', 'currency_code' => 'USD' ],
+			'attributes' => [
+				[ 'name' => 'Color', 'value' => 'Blue' ],
+				[ 'value' => 'no-label-here' ],
+				[ 'name' => '', 'value' => 'also-no-label' ],
+				[ 'name' => 'Size', 'value' => 'M' ],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertCount( 2, $result['options'] );
+		$this->assertSame( 'Color', $result['options'][0]['attribute'] );
+		$this->assertSame( 'Size', $result['options'][1]['attribute'] );
+	}
+
 	public function test_translate_emits_compare_at_price_when_on_sale(): void {
 		$fixture = [
 			'id'      => 601,

--- a/tests/php/unit/UcpVariantTranslatorTest.php
+++ b/tests/php/unit/UcpVariantTranslatorTest.php
@@ -206,6 +206,202 @@ class UcpVariantTranslatorTest extends \PHPUnit\Framework\TestCase {
 	// Zero-decimal and non-2-decimal currency handling
 	// ------------------------------------------------------------------
 
+	// ------------------------------------------------------------------
+	// 1.8.0: structured options, sale pricing, stock quantity, barcodes
+	// ------------------------------------------------------------------
+
+	public function test_translate_emits_structured_options_from_attributes(): void {
+		$fixture = [
+			'id'         => 501,
+			'name'       => 'Polo shirt',
+			'prices'     => [ 'price' => '2500', 'currency_code' => 'USD' ],
+			'attributes' => [
+				[ 'name' => 'Color', 'value' => 'Blue', 'taxonomy' => 'pa_color' ],
+				[ 'name' => 'Size', 'value' => 'Medium', 'taxonomy' => 'pa_size' ],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayHasKey( 'options', $result );
+		$this->assertSame(
+			[
+				[ 'attribute' => 'Color', 'value' => 'Blue' ],
+				[ 'attribute' => 'Size', 'value' => 'Medium' ],
+			],
+			$result['options']
+		);
+	}
+
+	public function test_translate_omits_options_when_attributes_empty(): void {
+		$fixture = [
+			'id'     => 501,
+			'name'   => 'Variant with no attrs',
+			'prices' => [ 'price' => '2500', 'currency_code' => 'USD' ],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayNotHasKey( 'options', $result );
+	}
+
+	public function test_translate_emits_compare_at_price_when_on_sale(): void {
+		$fixture = [
+			'id'      => 601,
+			'name'    => 'Sale item',
+			'on_sale' => true,
+			'prices'  => [
+				'price'         => '1500',
+				'regular_price' => '2000',
+				'currency_code' => 'USD',
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayHasKey( 'compare_at_price', $result );
+		$this->assertSame( 2000, $result['compare_at_price']['amount'] );
+		$this->assertSame( 'USD', $result['compare_at_price']['currency'] );
+		$this->assertSame( 1500, $result['price']['amount'] );
+	}
+
+	public function test_translate_omits_compare_at_price_when_not_on_sale(): void {
+		$fixture = [
+			'id'      => 602,
+			'name'    => 'Regular item',
+			'on_sale' => false,
+			'prices'  => [
+				'price'         => '2000',
+				'regular_price' => '2000',
+				'currency_code' => 'USD',
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayNotHasKey( 'compare_at_price', $result );
+	}
+
+	public function test_translate_omits_compare_at_price_on_inconsistent_state(): void {
+		// on_sale: true but regular_price <= price — rather than
+		// emit nonsensical "was $10, now $10" we skip it. Third-
+		// party plugins occasionally produce this state.
+		$fixture = [
+			'id'      => 603,
+			'name'    => 'Flag on but no discount',
+			'on_sale' => true,
+			'prices'  => [
+				'price'         => '2000',
+				'regular_price' => '2000',
+				'currency_code' => 'USD',
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayNotHasKey( 'compare_at_price', $result );
+	}
+
+	public function test_translate_emits_availability_quantity_from_low_stock(): void {
+		$fixture = [
+			'id'                  => 701,
+			'name'                => 'Almost gone',
+			'prices'              => [ 'price' => '1000', 'currency_code' => 'USD' ],
+			'is_in_stock'         => true,
+			'low_stock_remaining' => 3,
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertTrue( $result['availability']['available'] );
+		$this->assertSame( 3, $result['availability']['quantity'] );
+	}
+
+	public function test_translate_omits_availability_quantity_when_not_provided(): void {
+		$fixture = [
+			'id'          => 702,
+			'name'        => 'Plenty',
+			'prices'      => [ 'price' => '1000', 'currency_code' => 'USD' ],
+			'is_in_stock' => true,
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertTrue( $result['availability']['available'] );
+		$this->assertArrayNotHasKey( 'quantity', $result['availability'] );
+	}
+
+	public function test_translate_emits_barcodes_from_store_api_extension(): void {
+		$fixture = [
+			'id'         => 801,
+			'name'       => 'Barcoded product',
+			'prices'     => [ 'price' => '2000', 'currency_code' => 'USD' ],
+			'extensions' => [
+				WC_AI_Syndication_Store_Api_Extension::NAMESPACE => [
+					'barcodes' => [
+						[ 'type' => 'gtin13', 'value' => '1234567890123' ],
+					],
+				],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayHasKey( 'barcodes', $result );
+		$this->assertSame( 'gtin13', $result['barcodes'][0]['type'] );
+		$this->assertSame( '1234567890123', $result['barcodes'][0]['value'] );
+	}
+
+	public function test_translate_skips_malformed_barcode_entries(): void {
+		$fixture = [
+			'id'         => 802,
+			'name'       => 'Malformed',
+			'prices'     => [ 'price' => '2000', 'currency_code' => 'USD' ],
+			'extensions' => [
+				WC_AI_Syndication_Store_Api_Extension::NAMESPACE => [
+					'barcodes' => [
+						[ 'type' => '', 'value' => '123' ],
+						[ 'type' => 'gtin13', 'value' => '' ],
+						[ 'type' => 'gtin13', 'value' => 'ok' ],
+					],
+				],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertCount( 1, $result['barcodes'] );
+		$this->assertSame( 'ok', $result['barcodes'][0]['value'] );
+	}
+
+	public function test_synthesize_default_also_carries_new_fields(): void {
+		$fixture = [
+			'id'                  => 901,
+			'name'                => 'Simple on sale',
+			'on_sale'             => true,
+			'is_in_stock'         => true,
+			'low_stock_remaining' => 5,
+			'prices'              => [
+				'price'         => '1500',
+				'regular_price' => '2000',
+				'currency_code' => 'USD',
+			],
+			'extensions'          => [
+				WC_AI_Syndication_Store_Api_Extension::NAMESPACE => [
+					'barcodes' => [
+						[ 'type' => 'gtin13', 'value' => '9876543210987' ],
+					],
+				],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::synthesize_default( $fixture );
+
+		$this->assertSame( 2000, $result['compare_at_price']['amount'] );
+		$this->assertSame( 5, $result['availability']['quantity'] );
+		$this->assertSame( '9876543210987', $result['barcodes'][0]['value'] );
+	}
+
 	public function test_jpy_integer_amount_preserved_without_math(): void {
 		// JPY has currency_minor_unit = 0 (no cents). WC returns
 		// `prices.price = "5000"` meaning 5000 JPY. A hardcoded *100


### PR DESCRIPTION
## Summary

Rollup of the Store API coverage audit. Eight concrete UCP catalog-data gaps identified + a Store API extension that surfaces WC core's native `global_unique_id` (GTIN/UPC/EAN/MPN/ISBN) field, which Store API doesn't yet expose natively.

## What's new

### Variant-level
- **Structured `options`** from variation attributes — `[{attribute, value}]` pairs so agents can filter and display axes without parsing the title.
- **`compare_at_price`** when `on_sale` is true — crossed-out original for deal presentation.
- **`availability.quantity`** from Store API's `low_stock_remaining` — the only quantity signal Store API exposes publicly; omitted when absent rather than faked.
- **`barcodes`** from the Store API extension below.

### Product-level
- **`description.html`** when source has markup — previously we always stripped to plain text.
- **Tags** as second-class taxonomy entries in `categories` with `taxonomy: "tag"` — parallel to merchant categories.
- **Product-level `attributes`** (excluding variation-defining axes — those live on variants).
- **`extensions.com.woocommerce.ai_syndication.ratings`** — average + count, gated on `review_count > 0`.

### Search filters
- **`filters.on_sale: true|"true"`** → Store API `on_sale` param. Accepts stringy "true" for JSON-client flexibility.
- **`filters.tags[]`** → name/slug resolution to term IDs (parallel to categories). Unresolvable tags emit `tag_not_found` warnings matching the `category_not_found` contract.

### Store API extension (NEW)
`WC_AI_Syndication_Store_Api_Extension` registers a `barcodes` field under the `com-woocommerce-ai-syndication` namespace on the `/products` endpoint via `woocommerce_store_api_register_endpoint_data()`.

- Reads WC core's native `global_unique_id` (WC 9.4+).
- Emits `[{type, value}]` with digit-length-based type detection (`gtin8`/`gtin12`/`gtin13`/`gtin14`/`other`).
- `method_exists` guard for WC < 9.4 stores.
- Namespace uses hyphens (not dots like UCP `extensions` keys) because Store API namespace values appear in URL-adjacent contexts.

Filed as a WC core enhancement request separately — once core ships `global_unique_id` on the Store API `/products` schema natively, we can retire this extension.

## Test plan

- [x] PHPUnit: 421 tests pass (+34 new cases across 4 files)
- [x] PHPCS clean
- [x] PHPStan strict clean
- [x] lint:js clean
- [x] test:js clean (47 tests pass)
- [x] webpack build clean
- [x] make-pot regenerated

### Manual verification (post-merge, in staging)
- [ ] Variable product variant payload contains `options[]`, and title is reconstructed correctly from those axes
- [ ] Product on sale shows `compare_at_price` > `price` on each variant
- [ ] Product with `low_stock_remaining` shows `availability.quantity`
- [ ] Product with `global_unique_id` set to a 13-digit value exposes `barcodes: [{type: "gtin13", value: ...}]`
- [ ] Product description with markup emits both `plain` and `html`; plain-text products omit `html`
- [ ] Product with tags surfaces them alongside categories under the `categories` array
- [ ] Search with `filters.on_sale: true` only returns on-sale products
- [ ] Search with `filters.tags: ["summer"]` returns tagged products; unknown tag emits `tag_not_found` warning