### PR TITLE
Catalog filters + per-variant media: in_stock, featured, min_rating, attributes, sort

### DIFF
--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1519,6 +1519,16 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	private static function build_attribute_filter_params( array $attribute_map ): array {
 		$result = [];
 		foreach ( $attribute_map as $key => $values ) {
+			// Skip numeric keys — a malformed list-shaped input like
+			// `filters.attributes: [["red"]]` produces integer keys
+			// (0, 1, ...) which would cast to strings and forward as
+			// `pa_0`, `pa_1` taxonomies. Those match no real attribute
+			// and silently restrict the catalog to zero results with
+			// no signal. Attribute axes are named; numeric keys are
+			// always a shape bug.
+			if ( ! is_string( $key ) ) {
+				continue;
+			}
 			if ( ! is_array( $values ) || empty( $values ) ) {
 				continue;
 			}
@@ -1529,7 +1539,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			// with no signal their input was malformed. `sanitize_title`
 			// canonicalizes "Light Blue" → "light-blue" rather than the
 			// naive strtolower → "light blue" (which is an invalid slug).
-			$raw_key = trim( (string) $key );
+			$raw_key = trim( $key );
 			if ( '' === $raw_key ) {
 				continue;
 			}

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1502,13 +1502,39 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			if ( ! is_array( $values ) || empty( $values ) ) {
 				continue;
 			}
-			$taxonomy = (string) $key;
-			if ( 0 !== strpos( $taxonomy, 'pa_' ) ) {
-				$taxonomy = 'pa_' . strtolower( $taxonomy );
+
+			// Normalize the taxonomy key. Reject empty/whitespace-only
+			// keys up front — forwarding taxonomy `pa_` (or empty) to
+			// Store API silently returns no results, leaving the agent
+			// with no signal their input was malformed. `sanitize_title`
+			// canonicalizes "Light Blue" → "light-blue" rather than the
+			// naive strtolower → "light blue" (which is an invalid slug).
+			$raw_key = trim( (string) $key );
+			if ( '' === $raw_key ) {
+				continue;
 			}
+			$taxonomy = 0 === strpos( $raw_key, 'pa_' )
+				? $raw_key
+				: 'pa_' . sanitize_title( $raw_key );
+			// After sanitize_title a whitespace-only-after-trim input
+			// (or a stringy-object cast) can still collapse to just
+			// `pa_`. That's not a valid taxonomy — drop it rather than
+			// forward a semantically-empty filter.
+			if ( 'pa_' === $taxonomy ) {
+				continue;
+			}
+
+			// Normalize slug values. Reject non-string/non-numeric
+			// entries — a nested array coerces to "Array" via (string)
+			// cast, which would silently forward as a bogus slug.
+			// sanitize_title keeps the WP-canonical slug form and
+			// matches how WC stores attribute term slugs in the DB.
 			$slugs = [];
 			foreach ( $values as $v ) {
-				$slug = strtolower( (string) $v );
+				if ( ! is_string( $v ) && ! is_numeric( $v ) ) {
+					continue;
+				}
+				$slug = sanitize_title( (string) $v );
 				if ( '' !== $slug ) {
 					$slugs[] = $slug;
 				}
@@ -1516,6 +1542,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			if ( empty( $slugs ) ) {
 				continue;
 			}
+
 			$result[] = [
 				'attribute' => $taxonomy,
 				'slug'      => array_values( array_unique( $slugs ) ),

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1217,8 +1217,11 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 * returned messages array so agents learn their filter didn't
 	 * apply (instead of silently receiving the unfiltered catalog).
 	 *
-	 * @return array{0: array<string, string|int|bool>, 1: array<int, array<string, mixed>>}
-	 *         [params, messages]
+	 * @return array{0: array<string, mixed>, 1: array<int, array<string, mixed>>}
+	 *         [params, messages]. `params` values are heterogeneous:
+	 *         scalars for simple filters (search, category, on_sale,
+	 *         orderby), integer arrays for rating, string arrays for
+	 *         stock_status, and an array-of-objects for attributes.
 	 */
 	private static function map_ucp_search_to_store_api( WP_REST_Request $request ): array {
 		$params   = [];
@@ -1302,6 +1305,55 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		$params['per_page'] = $limit;
 		$params['page']     = $page;
 
+		// Sort order — top-level `sort: {field, direction}`, not under
+		// filters because it's an ordering concern rather than a
+		// result-set restriction. Maps to Store API's `orderby` + `order`.
+		// Unknown fields emit an `invalid_sort_field` warning rather
+		// than fall through silently: a mistyped sort that returns
+		// default ordering is worse than returning default-with-a-hint,
+		// because agents otherwise assume their sort took effect.
+		$sort = $request->get_param( 'sort' );
+		if ( is_array( $sort ) ) {
+			$field     = isset( $sort['field'] ) ? strtolower( (string) $sort['field'] ) : '';
+			$direction = isset( $sort['direction'] ) ? strtolower( (string) $sort['direction'] ) : 'asc';
+
+			// UCP-friendly names → Store API orderby values. `newest`
+			// is an alias for date-desc — more human-intuitive than
+			// Store API's `date` + `order=desc` but we still
+			// translate here so agents have one sort vocabulary.
+			$orderby_map = [
+				'price'      => 'price',
+				'title'      => 'title',
+				'date'       => 'date',
+				'newest'     => 'date',
+				'popularity' => 'popularity',
+				'rating'     => 'rating',
+				'menu_order' => 'menu_order',
+			];
+			if ( isset( $orderby_map[ $field ] ) ) {
+				$params['orderby'] = $orderby_map[ $field ];
+				$params['order']   = ( 'desc' === $direction ) ? 'desc' : 'asc';
+				// `newest` implies desc regardless of caller intent
+				// — "newest ascending" is a contradiction we normalize
+				// rather than silently honor.
+				if ( 'newest' === $field ) {
+					$params['order'] = 'desc';
+				}
+			} elseif ( '' !== $field ) {
+				$messages[] = [
+					'type'     => 'warning',
+					'code'     => 'invalid_sort_field',
+					'severity' => 'advisory',
+					'path'     => '$.sort.field',
+					'content'  => sprintf(
+						/* translators: %s is the unsupported sort field the agent sent. */
+						__( 'Sort field "%s" is not supported; using default ordering.', 'woocommerce-ai-syndication' ),
+						(string) $sort['field']
+					),
+				];
+			}
+		}
+
 		$filters = $request->get_param( 'filters' );
 		if ( ! is_array( $filters ) ) {
 			return [ $params, $messages ];
@@ -1372,7 +1424,105 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			}
 		}
 
+		// In-stock filter — agents transacting in real time shouldn't
+		// pitch products they can't actually deliver. Store API's
+		// stock_status param takes an array enum (instock/outofstock/
+		// onbackorder); when an agent opts in with `in_stock: true` we
+		// restrict to `["instock"]`. Not forwarding when the caller
+		// passes false or omits the filter, so the default remains
+		// "whatever the merchant configured for frontend visibility".
+		if ( isset( $filters['in_stock'] ) && ( true === $filters['in_stock'] || 'true' === $filters['in_stock'] ) ) {
+			$params['stock_status'] = [ 'instock' ];
+		}
+
+		// Featured filter — merchandising signal. Merchants flag hero
+		// products via WC's native "featured" toggle; agents surfacing
+		// a "staff picks" or "popular now" carousel can request only
+		// those with `featured: true`.
+		if ( isset( $filters['featured'] ) && ( true === $filters['featured'] || 'true' === $filters['featured'] ) ) {
+			$params['featured'] = true;
+		}
+
+		// Min rating filter — agents seeking quality ("4+ stars only")
+		// map to Store API's `rating` param, which takes an array of
+		// acceptable integer ratings (1–5). We expand `min_rating: N`
+		// to `[N, N+1, ..., 5]` — Store API's shape is a set-inclusion
+		// filter, not a floor. Clamping to [1,5] keeps the array
+		// non-empty and the semantics coherent.
+		if ( isset( $filters['min_rating'] ) && is_numeric( $filters['min_rating'] ) ) {
+			$min     = max( 1, min( 5, (int) $filters['min_rating'] ) );
+			$ratings = [];
+			for ( $r = $min; $r <= 5; $r++ ) {
+				$ratings[] = $r;
+			}
+			$params['rating'] = $ratings;
+		}
+
+		// Attribute filters — `filters.attributes: {color: ["red"], size: ["M"]}`.
+		// WC uses `pa_*` taxonomies for custom product attributes;
+		// agents typically don't know the `pa_` convention, so we
+		// prepend it when the caller's key doesn't already have it.
+		// The Store API `attributes` param is an array of objects with
+		// `attribute` (taxonomy), `slug[]` (term slugs), and `operator`.
+		// Unlike categories/tags we don't resolve to term IDs first —
+		// Store API accepts slugs directly for attributes, and
+		// invalid slugs produce empty results rather than errors.
+		if ( isset( $filters['attributes'] ) && is_array( $filters['attributes'] ) ) {
+			$attribute_params = self::build_attribute_filter_params( $filters['attributes'] );
+			if ( ! empty( $attribute_params ) ) {
+				$params['attributes'] = $attribute_params;
+			}
+		}
+
 		return [ $params, $messages ];
+	}
+
+	/**
+	 * Build the Store API `attributes` filter array from a UCP-shaped
+	 * attributes map.
+	 *
+	 * Input : `{color: ["red", "blue"], size: ["M"], pa_brand: ["nike"]}`
+	 * Output: `[
+	 *   {attribute: "pa_color", slug: ["red","blue"], operator: "in"},
+	 *   {attribute: "pa_size",  slug: ["m"],          operator: "in"},
+	 *   {attribute: "pa_brand", slug: ["nike"],       operator: "in"},
+	 * ]`
+	 *
+	 * Keys already prefixed with `pa_` pass through unchanged; bare
+	 * labels get prefixed. Values are lowercased to match WC's slug
+	 * convention. Empty arrays and non-array values are skipped so
+	 * a malformed entry doesn't poison the whole filter list.
+	 *
+	 * @param array<mixed, mixed> $attribute_map
+	 * @return array<int, array{attribute: string, slug: array<int, string>, operator: string}>
+	 */
+	private static function build_attribute_filter_params( array $attribute_map ): array {
+		$result = [];
+		foreach ( $attribute_map as $key => $values ) {
+			if ( ! is_array( $values ) || empty( $values ) ) {
+				continue;
+			}
+			$taxonomy = (string) $key;
+			if ( 0 !== strpos( $taxonomy, 'pa_' ) ) {
+				$taxonomy = 'pa_' . strtolower( $taxonomy );
+			}
+			$slugs = [];
+			foreach ( $values as $v ) {
+				$slug = strtolower( (string) $v );
+				if ( '' !== $slug ) {
+					$slugs[] = $slug;
+				}
+			}
+			if ( empty( $slugs ) ) {
+				continue;
+			}
+			$result[] = [
+				'attribute' => $taxonomy,
+				'slug'      => array_values( array_unique( $slugs ) ),
+				'operator'  => 'in',
+			];
+		}
+		return $result;
 	}
 
 	/**

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1314,43 +1314,63 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		// because agents otherwise assume their sort took effect.
 		$sort = $request->get_param( 'sort' );
 		if ( is_array( $sort ) ) {
-			$field     = isset( $sort['field'] ) ? strtolower( (string) $sort['field'] ) : '';
-			$direction = isset( $sort['direction'] ) ? strtolower( (string) $sort['direction'] ) : 'asc';
+			// Defensive: non-scalar field/direction (e.g. an agent
+			// sending `{sort: {field: []}}`) would coerce to "Array"
+			// via (string) cast and trigger a misleading
+			// `invalid_sort_field` warning with value "array".
+			// Require string inputs; anything else surfaces as a
+			// dedicated `invalid_sort_shape` warning so agents can
+			// distinguish "unknown field" from "malformed input."
+			$raw_field     = $sort['field'] ?? '';
+			$raw_direction = $sort['direction'] ?? 'asc';
 
-			// UCP-friendly names → Store API orderby values. `newest`
-			// is an alias for date-desc — more human-intuitive than
-			// Store API's `date` + `order=desc` but we still
-			// translate here so agents have one sort vocabulary.
-			$orderby_map = [
-				'price'      => 'price',
-				'title'      => 'title',
-				'date'       => 'date',
-				'newest'     => 'date',
-				'popularity' => 'popularity',
-				'rating'     => 'rating',
-				'menu_order' => 'menu_order',
-			];
-			if ( isset( $orderby_map[ $field ] ) ) {
-				$params['orderby'] = $orderby_map[ $field ];
-				$params['order']   = ( 'desc' === $direction ) ? 'desc' : 'asc';
-				// `newest` implies desc regardless of caller intent
-				// — "newest ascending" is a contradiction we normalize
-				// rather than silently honor.
-				if ( 'newest' === $field ) {
-					$params['order'] = 'desc';
-				}
-			} elseif ( '' !== $field ) {
+			if ( ! is_string( $raw_field ) || ! is_string( $raw_direction ) ) {
 				$messages[] = [
 					'type'     => 'warning',
-					'code'     => 'invalid_sort_field',
+					'code'     => 'invalid_sort_shape',
 					'severity' => 'advisory',
-					'path'     => '$.sort.field',
-					'content'  => sprintf(
-						/* translators: %s is the unsupported sort field the agent sent. */
-						__( 'Sort field "%s" is not supported; using default ordering.', 'woocommerce-ai-syndication' ),
-						(string) $sort['field']
-					),
+					'path'     => '$.sort',
+					'content'  => __( 'sort.field and sort.direction must be strings; using default ordering.', 'woocommerce-ai-syndication' ),
 				];
+			} else {
+				$field     = strtolower( trim( $raw_field ) );
+				$direction = strtolower( trim( $raw_direction ) );
+
+				// UCP-friendly names → Store API orderby values. `newest`
+				// is an alias for date-desc — more human-intuitive than
+				// Store API's `date` + `order=desc` but we still
+				// translate here so agents have one sort vocabulary.
+				$orderby_map = [
+					'price'      => 'price',
+					'title'      => 'title',
+					'date'       => 'date',
+					'newest'     => 'date',
+					'popularity' => 'popularity',
+					'rating'     => 'rating',
+					'menu_order' => 'menu_order',
+				];
+				if ( isset( $orderby_map[ $field ] ) ) {
+					$params['orderby'] = $orderby_map[ $field ];
+					$params['order']   = ( 'desc' === $direction ) ? 'desc' : 'asc';
+					// `newest` implies desc regardless of caller intent
+					// — "newest ascending" is a contradiction we normalize
+					// rather than silently honor.
+					if ( 'newest' === $field ) {
+						$params['order'] = 'desc';
+					}
+				} elseif ( '' !== $field ) {
+					$messages[] = [
+						'type'     => 'warning',
+						'code'     => 'invalid_sort_field',
+						'severity' => 'advisory',
+						'path'     => '$.sort.field',
+						'content'  => sprintf(
+							/* translators: %s is the unsupported sort field the agent sent. */
+							__( 'Sort field "%s" is not supported; using default ordering.', 'woocommerce-ai-syndication' ),
+							$raw_field
+						),
+					];
+				}
 			}
 		}
 

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
@@ -100,6 +100,18 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 
 		$variant['availability'] = self::extract_availability( $wc_variation );
 
+		// Per-variant media — WC lets merchants set a different image
+		// per variation (the red shirt gets the red photo, the blue
+		// shirt the blue one). Store API returns those under the
+		// variation's own `images[]` array. Emitting them at variant
+		// level lets agents present the right visual for each option;
+		// when a variation doesn't have its own image we simply omit
+		// the field and the product-level media carries the default.
+		$media = self::extract_media( $wc_variation );
+		if ( ! empty( $media ) ) {
+			$variant['media'] = $media;
+		}
+
 		return $variant;
 	}
 
@@ -177,6 +189,42 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 		}
 
 		return $wc_variation['name'] ?? '';
+	}
+
+	/**
+	 * Map WC variation image objects to UCP media entries.
+	 *
+	 * UCP media shape: `{type, url, alt_text}`. Mirrors the product
+	 * translator's `extract_media` (image-only for v1; video/3D model
+	 * types stay reserved for future expansion). Kept local to the
+	 * variant translator rather than shared with the product
+	 * translator so the two classes have independent call sites and
+	 * can evolve their shape rules independently — variant-specific
+	 * images often have different cropping/alt-text conventions.
+	 *
+	 * @param array<string, mixed> $wc_variation
+	 * @return array<int, array<string, string>>
+	 */
+	private static function extract_media( array $wc_variation ): array {
+		$images = $wc_variation['images'] ?? [];
+		if ( ! is_array( $images ) ) {
+			return [];
+		}
+		$result = [];
+		foreach ( $images as $image ) {
+			if ( ! is_array( $image ) || empty( $image['src'] ) ) {
+				continue;
+			}
+			$media = [
+				'type' => 'image',
+				'url'  => (string) $image['src'],
+			];
+			if ( ! empty( $image['alt'] ) ) {
+				$media['alt_text'] = (string) $image['alt'];
+			}
+			$result[] = $media;
+		}
+		return $result;
 	}
 
 	/**

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-19T14:35:49+00:00\n"
+"POT-Creation-Date: 2026-04-19T15:17:22+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -52,15 +52,15 @@ msgstr ""
 msgid "Products"
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:159
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:166
 msgid "Product identifiers (GTIN, UPC, EAN, MPN, ISBN). Each entry is a typed barcode."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:171
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:178
 msgid "Barcode type (gtin8, gtin12, gtin13, gtin14, other)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:178
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:185
 msgid "The barcode value as stored by the merchant."
 msgstr ""
 
@@ -125,51 +125,55 @@ msgstr ""
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1333
+msgid "sort.field and sort.direction must be strings; using default ordering."
+msgstr ""
+
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1350
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1369
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1375
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1395
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1420
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1440
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1960
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2017
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1964
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2021
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1968
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2025
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1970
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2027
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1972
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2029
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1976
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2033
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1978
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2035
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-19T13:57:04+00:00\n"
+"POT-Creation-Date: 2026-04-19T14:35:49+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -52,15 +52,15 @@ msgstr ""
 msgid "Products"
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:156
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:159
 msgid "Product identifiers (GTIN, UPC, EAN, MPN, ISBN). Each entry is a typed barcode."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:168
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:171
 msgid "Barcode type (gtin8, gtin12, gtin13, gtin14, other)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:175
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:178
 msgid "The barcode value as stored by the merchant."
 msgstr ""
 
@@ -111,59 +111,65 @@ msgid_plural "%1$d variations of product %2$d are not included in the variants l
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1254
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1257
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1270
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1273
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1297
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1300
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
+#. translators: %s is the unsupported sort field the agent sent.
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1350
+#, php-format
+msgid "Sort field \"%s\" is not supported; using default ordering."
+msgstr ""
+
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1323
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1375
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1368
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1420
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1810
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1960
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1814
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1964
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1818
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1968
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1820
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1970
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1822
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1972
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1826
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1976
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1828
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1978
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -854,6 +854,58 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'asc', $this->captured_store_params['order'] );
 	}
 
+	public function test_sort_non_scalar_field_emits_invalid_sort_shape_warning(): void {
+		// Regression: a non-scalar `sort.field` (e.g. an array) would
+		// coerce to "Array" via (string) cast and trigger a misleading
+		// `invalid_sort_field` warning with value "array". The shape
+		// check now catches this early and emits `invalid_sort_shape`
+		// so agents can distinguish "unknown field" from "malformed
+		// input".
+		$body = $this->successful_search(
+			[ 'sort' => [ 'field' => [ 'price' ], 'direction' => 'asc' ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'orderby', $this->captured_store_params );
+		$warnings = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'invalid_sort_shape' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $warnings );
+	}
+
+	public function test_sort_non_scalar_direction_emits_invalid_sort_shape_warning(): void {
+		$body = $this->successful_search(
+			[ 'sort' => [ 'field' => 'price', 'direction' => [ 'asc' ] ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'orderby', $this->captured_store_params );
+		$warnings = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'invalid_sort_shape' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $warnings );
+	}
+
+	public function test_sort_invalid_sort_field_content_uses_original_raw_value(): void {
+		// When emitting the `invalid_sort_field` warning content for an
+		// unrecognized but legitimately-scalar field, we echo back the
+		// original string (preserving case/whitespace the agent sent)
+		// rather than the trimmed/lowercased form we used for lookup.
+		// Makes the warning easier to correlate with the agent's
+		// source input.
+		$body = $this->successful_search(
+			[ 'sort' => [ 'field' => '  BoGuS  ', 'direction' => 'asc' ] ]
+		);
+
+		$warnings = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'invalid_sort_field' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $warnings );
+		$warning = array_values( $warnings )[0];
+		$this->assertStringContainsString( '  BoGuS  ', $warning['content'] );
+	}
+
 	// ------------------------------------------------------------------
 	// Price mapping (minor units → presentment units)
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -94,6 +94,18 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		);
 		Functions\when( 'wc_get_price_decimals' )->justReturn( 2 );
 
+		// Simplified sanitize_title stub — good enough for the
+		// attribute-slug normalization the mapper relies on. The real
+		// WP function does more (entity stripping, accent folding, etc.)
+		// but those code paths aren't exercised by current tests.
+		Functions\when( 'sanitize_title' )->alias(
+			static function ( $title ): string {
+				$title = strtolower( trim( (string) $title ) );
+				$title = preg_replace( '/[^a-z0-9_]+/', '-', $title );
+				return trim( (string) $title, '-' );
+			}
+		);
+
 		$terms = &$this->fake_terms;
 		Functions\when( 'get_term_by' )->alias(
 			static function ( string $field, string $value, string $taxonomy ) use ( &$terms ) {
@@ -558,6 +570,17 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		$this->assertArrayNotHasKey( 'featured', $this->captured_store_params );
 	}
 
+	public function test_featured_filter_accepts_string_true(): void {
+		// Symmetric with on_sale / in_stock — stringy "true" from
+		// JSON-to-PHP round trips should be honored so the contract
+		// is consistent across boolean-flag filters.
+		$this->successful_search(
+			[ 'filters' => [ 'featured' => 'true' ] ]
+		);
+
+		$this->assertTrue( $this->captured_store_params['featured'] );
+	}
+
 	// ------------------------------------------------------------------
 	// 1.9.0: min_rating filter
 	// ------------------------------------------------------------------
@@ -675,6 +698,106 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertSame( [ 'red' ], $this->captured_store_params['attributes'][0]['slug'] );
+	}
+
+	public function test_attribute_filter_skips_non_scalar_slug_values(): void {
+		// Defensive: a client sending a nested array as a slug value
+		// would coerce to "Array" via (string) cast and silently
+		// forward as a bogus slug. Skip non-scalar entries entirely.
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'color' => [ 'red', [ 'nested' ], null, 'blue' ],
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[ 'red', 'blue' ],
+			$this->captured_store_params['attributes'][0]['slug']
+		);
+	}
+
+	public function test_attribute_filter_skips_empty_taxonomy_key(): void {
+		// Empty/whitespace-only keys would collapse to taxonomy `pa_`
+		// which Store API silently accepts as unknown and returns no
+		// results — leaving the agent with no signal that their input
+		// was malformed. Drop the axis entirely.
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						''    => [ 'red' ],
+						' '   => [ 'blue' ],
+						'size' => [ 'M' ],
+					],
+				],
+			]
+		);
+
+		$this->assertCount( 1, $this->captured_store_params['attributes'] );
+		$this->assertSame( 'pa_size', $this->captured_store_params['attributes'][0]['attribute'] );
+	}
+
+	public function test_attribute_filter_skips_bare_pa_prefix_key(): void {
+		// A key of exactly "pa_" is either a typo or a crafted
+		// poison input — either way it's not a real taxonomy and
+		// shouldn't be forwarded.
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'pa_' => [ 'red' ],
+					],
+				],
+			]
+		);
+
+		$this->assertArrayNotHasKey( 'attributes', $this->captured_store_params );
+	}
+
+	public function test_attribute_filter_sanitize_title_normalizes_multiword_slugs(): void {
+		// Multi-word attribute values like "Light Blue" should
+		// collapse to the WP-canonical slug "light-blue" (the form
+		// WC stores in the DB), not the naive strtolower "light blue"
+		// which is an invalid slug.
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'color' => [ 'Light Blue', 'Navy Blue' ],
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			[ 'light-blue', 'navy-blue' ],
+			$this->captured_store_params['attributes'][0]['slug']
+		);
+	}
+
+	public function test_attribute_filter_sanitize_title_normalizes_multiword_taxonomy_keys(): void {
+		// Same as slug normalization but for the taxonomy key — a
+		// merchant label like "Fabric Type" should produce
+		// `pa_fabric-type`, not `pa_fabric type` (invalid) or
+		// `pa_Fabric Type` (case-sensitive mismatch).
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'Fabric Type' => [ 'cotton' ],
+					],
+				],
+			]
+		);
+
+		$this->assertSame(
+			'pa_fabric-type',
+			$this->captured_store_params['attributes'][0]['attribute']
+		);
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -741,6 +741,30 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'pa_size', $this->captured_store_params['attributes'][0]['attribute'] );
 	}
 
+	public function test_attribute_filter_skips_numeric_keys_from_list_shaped_input(): void {
+		// Regression: a malformed list-shaped input like
+		// `filters.attributes: [["red"], ["M"]]` has integer keys
+		// (0, 1, ...) which would cast to strings and forward as
+		// taxonomies `pa_0`, `pa_1`. Those match nothing and would
+		// silently restrict the catalog to zero results. Drop
+		// numeric keys entirely since attribute axes are always
+		// named strings.
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						0       => [ 'red' ],
+						1       => [ 'M' ],
+						'color' => [ 'blue' ],
+					],
+				],
+			]
+		);
+
+		$this->assertCount( 1, $this->captured_store_params['attributes'] );
+		$this->assertSame( 'pa_color', $this->captured_store_params['attributes'][0]['attribute'] );
+	}
+
 	public function test_attribute_filter_skips_bare_pa_prefix_key(): void {
 		// A key of exactly "pa_" is either a typo or a crafted
 		// poison input — either way it's not a real taxonomy and

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -140,7 +140,24 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 					// the canned product list. 1.6.0 added `page` +
 					// `per_page` to the captured list for pagination
 					// mapping assertions.
-					foreach ( [ 'search', 'category', 'min_price', 'max_price', 'page', 'per_page', 'tag', 'on_sale' ] as $key ) {
+					foreach (
+						[
+							'search',
+							'category',
+							'min_price',
+							'max_price',
+							'page',
+							'per_page',
+							'tag',
+							'on_sale',
+							'stock_status',
+							'featured',
+							'rating',
+							'attributes',
+							'orderby',
+							'order',
+						] as $key
+					) {
 						$val = $request->get_param( $key );
 						if ( null !== $val ) {
 							$captured_params[ $key ] = $val;
@@ -491,6 +508,227 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertArrayNotHasKey( 'on_sale', $this->captured_store_params );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.9.0: in_stock filter
+	// ------------------------------------------------------------------
+
+	public function test_in_stock_filter_forwards_instock_stock_status(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'in_stock' => true ] ]
+		);
+
+		$this->assertSame( [ 'instock' ], $this->captured_store_params['stock_status'] );
+	}
+
+	public function test_in_stock_filter_accepts_string_true(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'in_stock' => 'true' ] ]
+		);
+
+		$this->assertSame( [ 'instock' ], $this->captured_store_params['stock_status'] );
+	}
+
+	public function test_in_stock_filter_false_does_not_forward(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'in_stock' => false ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'stock_status', $this->captured_store_params );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.9.0: featured filter
+	// ------------------------------------------------------------------
+
+	public function test_featured_filter_forwards_boolean_true(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'featured' => true ] ]
+		);
+
+		$this->assertTrue( $this->captured_store_params['featured'] );
+	}
+
+	public function test_featured_filter_false_does_not_forward(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'featured' => false ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'featured', $this->captured_store_params );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.9.0: min_rating filter
+	// ------------------------------------------------------------------
+
+	public function test_min_rating_4_expands_to_ratings_4_and_5(): void {
+		// Store API's `rating` param is an array of acceptable
+		// ratings (set inclusion), not a floor. `min_rating: 4`
+		// must expand to [4, 5] for "4 stars and above."
+		$this->successful_search(
+			[ 'filters' => [ 'min_rating' => 4 ] ]
+		);
+
+		$this->assertSame( [ 4, 5 ], $this->captured_store_params['rating'] );
+	}
+
+	public function test_min_rating_1_expands_to_full_range(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'min_rating' => 1 ] ]
+		);
+
+		$this->assertSame( [ 1, 2, 3, 4, 5 ], $this->captured_store_params['rating'] );
+	}
+
+	public function test_min_rating_out_of_range_is_clamped(): void {
+		// Values above 5 clamp to 5 (produces [5]); values below 1
+		// clamp to 1 (full range). Keeps the array non-empty and
+		// the filter semantically coherent.
+		$this->successful_search(
+			[ 'filters' => [ 'min_rating' => 99 ] ]
+		);
+
+		$this->assertSame( [ 5 ], $this->captured_store_params['rating'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.9.0: attribute filters
+	// ------------------------------------------------------------------
+
+	public function test_attribute_filter_prefixes_bare_labels_with_pa(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'attributes' => [ 'color' => [ 'red' ] ] ] ]
+		);
+
+		$this->assertSame(
+			[
+				[
+					'attribute' => 'pa_color',
+					'slug'      => [ 'red' ],
+					'operator'  => 'in',
+				],
+			],
+			$this->captured_store_params['attributes']
+		);
+	}
+
+	public function test_attribute_filter_preserves_pa_prefix_when_already_present(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'attributes' => [ 'pa_brand' => [ 'nike' ] ] ] ]
+		);
+
+		$this->assertSame( 'pa_brand', $this->captured_store_params['attributes'][0]['attribute'] );
+	}
+
+	public function test_attribute_filter_lowercases_slug_values(): void {
+		$this->successful_search(
+			[ 'filters' => [ 'attributes' => [ 'size' => [ 'M', 'XL' ] ] ] ]
+		);
+
+		$this->assertSame( [ 'm', 'xl' ], $this->captured_store_params['attributes'][0]['slug'] );
+	}
+
+	public function test_attribute_filter_emits_multiple_taxonomy_entries(): void {
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'color' => [ 'red' ],
+						'size'  => [ 'M' ],
+					],
+				],
+			]
+		);
+
+		$this->assertCount( 2, $this->captured_store_params['attributes'] );
+	}
+
+	public function test_attribute_filter_skips_empty_arrays(): void {
+		// Malformed input — one axis has values, another is empty.
+		// The empty axis should be dropped rather than poison the
+		// whole filter list.
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'color' => [ 'red' ],
+						'size'  => [],
+					],
+				],
+			]
+		);
+
+		$this->assertCount( 1, $this->captured_store_params['attributes'] );
+		$this->assertSame( 'pa_color', $this->captured_store_params['attributes'][0]['attribute'] );
+	}
+
+	public function test_attribute_filter_deduplicates_slugs(): void {
+		$this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'color' => [ 'red', 'RED', 'Red' ],
+					],
+				],
+			]
+		);
+
+		$this->assertSame( [ 'red' ], $this->captured_store_params['attributes'][0]['slug'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.9.0: sort order
+	// ------------------------------------------------------------------
+
+	public function test_sort_price_asc_forwards_orderby_and_order(): void {
+		$this->successful_search(
+			[ 'sort' => [ 'field' => 'price', 'direction' => 'asc' ] ]
+		);
+
+		$this->assertSame( 'price', $this->captured_store_params['orderby'] );
+		$this->assertSame( 'asc', $this->captured_store_params['order'] );
+	}
+
+	public function test_sort_newest_maps_to_date_desc_regardless_of_direction(): void {
+		// `newest` is an alias that implies descending. Even if the
+		// caller passes `direction: asc` we normalize to desc — the
+		// concept "newest ascending" is self-contradicting.
+		$this->successful_search(
+			[ 'sort' => [ 'field' => 'newest', 'direction' => 'asc' ] ]
+		);
+
+		$this->assertSame( 'date', $this->captured_store_params['orderby'] );
+		$this->assertSame( 'desc', $this->captured_store_params['order'] );
+	}
+
+	public function test_sort_popularity_is_supported(): void {
+		$this->successful_search(
+			[ 'sort' => [ 'field' => 'popularity', 'direction' => 'desc' ] ]
+		);
+
+		$this->assertSame( 'popularity', $this->captured_store_params['orderby'] );
+	}
+
+	public function test_sort_unknown_field_emits_warning_and_does_not_forward(): void {
+		$body = $this->successful_search(
+			[ 'sort' => [ 'field' => 'bogus', 'direction' => 'asc' ] ]
+		);
+
+		$this->assertArrayNotHasKey( 'orderby', $this->captured_store_params );
+		$warnings = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'invalid_sort_field' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $warnings );
+	}
+
+	public function test_sort_defaults_direction_to_asc_when_unspecified(): void {
+		$this->successful_search(
+			[ 'sort' => [ 'field' => 'title' ] ]
+		);
+
+		$this->assertSame( 'asc', $this->captured_store_params['order'] );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpVariantTranslatorTest.php
+++ b/tests/php/unit/UcpVariantTranslatorTest.php
@@ -398,6 +398,96 @@ class UcpVariantTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'ok', $result['barcodes'][0]['value'] );
 	}
 
+	// ------------------------------------------------------------------
+	// 1.9.0: Per-variant media
+	// ------------------------------------------------------------------
+
+	public function test_translate_emits_media_from_variation_images(): void {
+		// WC variations can have their own image (red shirt → red
+		// photo). Store API returns it under the variation's `images`
+		// array; we emit it at variant level so agents can present the
+		// right visual for each option.
+		$fixture = [
+			'id'          => 555,
+			'name'        => 'Red / M',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+			'images'      => [
+				[ 'src' => 'https://store.example/red.jpg', 'alt' => 'Red shirt' ],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertCount( 1, $result['media'] );
+		$this->assertSame( 'image', $result['media'][0]['type'] );
+		$this->assertSame( 'https://store.example/red.jpg', $result['media'][0]['url'] );
+		$this->assertSame( 'Red shirt', $result['media'][0]['alt_text'] );
+	}
+
+	public function test_translate_omits_media_when_variation_has_no_images(): void {
+		// When a merchant hasn't set a variation-specific image, we
+		// don't emit `media` at variant level — the product-level
+		// media still carries the default, and omitting the key keeps
+		// the variant payload lean.
+		$fixture = [
+			'id'          => 555,
+			'name'        => 'Default / One',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayNotHasKey( 'media', $result );
+	}
+
+	public function test_translate_omits_media_alt_text_when_empty(): void {
+		$fixture = [
+			'id'          => 555,
+			'name'        => 'Red / M',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+			'images'      => [
+				[ 'src' => 'https://store.example/red.jpg', 'alt' => '' ],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayNotHasKey( 'alt_text', $result['media'][0] );
+	}
+
+	public function test_translate_skips_image_entries_without_src(): void {
+		$fixture = [
+			'id'          => 555,
+			'name'        => 'Red / M',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+			'images'      => [
+				[ 'src' => '', 'alt' => 'broken' ],
+				[ 'src' => 'https://store.example/red.jpg' ],
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertCount( 1, $result['media'] );
+		$this->assertSame( 'https://store.example/red.jpg', $result['media'][0]['url'] );
+	}
+
 	public function test_synthesize_default_also_carries_new_fields(): void {
 		$fixture = [
 			'id'                  => 901,


### PR DESCRIPTION
## Summary

Closes the HIGH/MEDIUM gaps identified in the post-#38 catalog coverage audit. Stacked on top of #38 so the diff here shows only this PR's work; auto-retargets to main when #38 merges.

## Search filters (new)

| UCP input | Store API output | Purpose |
|-----------|------------------|---------|
| `filters.in_stock: true\|"true"` | `stock_status: ["instock"]` | Agents transacting in real time shouldn't pitch unavailable items |
| `filters.featured: true\|"true"` | `featured: true` | WC merchandising flag for "staff picks" / "popular now" |
| `filters.min_rating: 4` | `rating: [4, 5]` | Expands to set-inclusion range (Store API's `rating` isn't a floor) |
| `filters.attributes: {color: ["red"], size: ["M"]}` | `attributes: [{attribute, slug[], operator}]` | Unlocks variant-axis filtering ("red size-M shirts") |
| `sort: {field, direction}` | `orderby` + `order` | Supports price/title/date/popularity/rating/menu_order + `newest` alias |

### Attribute filter behavior
- Bare labels (`color`) auto-prefix with `pa_` (WC's custom-attribute taxonomy convention)
- Keys already prefixed (`pa_brand`) pass through unchanged
- Slug values lowercased + deduplicated
- Malformed axes (empty values, non-arrays) silently dropped rather than erroring

### Sort behavior
- `newest` is an alias for `date` + `order=desc` — normalizes "newest ascending" which is self-contradicting
- Unknown `sort.field` emits an `invalid_sort_field` warning so agents don't assume their sort took effect silently

## Per-variant media

`WC_AI_Syndication_UCP_Variant_Translator::translate()` now emits `media[]` when a variation has its own `images[]`. Same `{type, url, alt_text}` shape as product-level media. Omitted when the variation has no images of its own — product-level `media` carries the default.

The `extract_media` helper is local to the variant translator (not shared with the product translator) so the two call sites can evolve independently.

## Test plan

- [x] PHPUnit: 446 tests pass (+27 new cases across 2 files)
- [x] PHPCS clean
- [x] PHPStan strict clean (docblock widened for `map_ucp_search_to_store_api` return)
- [x] lint:js clean
- [x] test:js clean (47 tests pass)
- [x] webpack build clean
- [x] make-pot regenerated

### Manual verification (post-merge, in staging)
- [ ] `filters.in_stock: true` excludes out-of-stock products from results
- [ ] `filters.featured: true` returns only WC-featured products
- [ ] `filters.min_rating: 4` returns only 4+ star products
- [ ] `filters.attributes: {color: ["red"]}` returns only red-variant products on a store with `pa_color` attribute
- [ ] `sort: {field: "price", direction: "asc"}` returns results sorted cheapest-first
- [ ] `sort: {field: "newest"}` returns results sorted newest-first regardless of direction
- [ ] `sort: {field: "bogus"}` emits `invalid_sort_field` warning in `messages[]`
- [ ] Variable product with variation-specific images emits `media` on the matching variants
- [ ] Variable product without variation images has no `media` field on variants (product-level still present)

## What's still pending (future PR D)

From the post-#38 gap list:
- Brand at product level (#7) — `product_brand` taxonomy (WC 9.5+) extraction parallel to categories/tags
- Variant weight + dimensions (#9) — for shipping-aware agents
- Google Merchant-adjacent fields: condition, gender, age_group, material (#10)
- Shipping info at product level (#11)
- Pagination `total_pages` if UCP spec confirms requirement
- File WC core issue for `global_unique_id` in Store API