### PR TITLE
Catalog polish: brand taxonomy, variant shipping attributes, attribute_not_found warnings

### DIFF
--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
@@ -278,18 +278,26 @@ class WC_AI_Syndication_UCP_Product_Translator {
 	}
 
 	/**
-	 * Extract the combined taxonomies list (categories + tags).
+	 * Extract the combined taxonomies list (categories + tags + brands).
 	 *
-	 * Both come back as UCP category entries (`{value, taxonomy}`)
-	 * with distinct `taxonomy` slugs: "merchant" for WC categories
-	 * (our pre-existing convention), "tag" for WC tags. Tags are an
-	 * optional cross-cutting discovery signal ("summer",
-	 * "eco-friendly") that's orthogonal to categorical hierarchy;
-	 * merging them into one `categories` list keeps the UCP product
-	 * schema flat while letting agents filter/match on either axis.
+	 * All three come back as UCP category entries (`{value, taxonomy}`)
+	 * with distinct `taxonomy` slugs:
+	 *   - `"merchant"` for WC categories (our pre-existing convention)
+	 *   - `"tag"` for WC tags (cross-cutting discovery signal — "summer",
+	 *     "eco-friendly")
+	 *   - `"brand"` for the WC `product_brand` taxonomy (native in WC 9.5+;
+	 *     previously shipped via the standalone "WooCommerce Brands"
+	 *     plugin)
 	 *
-	 * Tags emit only when present; merchants who don't use tags
+	 * Merging into one `categories` list keeps the UCP product schema
+	 * flat while letting agents filter/match on any axis. Each type
+	 * emits only when present — merchants who don't use tags or brands
 	 * pay zero extra payload.
+	 *
+	 * Brands surface via `brands` on the Store API product response when
+	 * the merchant has the taxonomy registered (either via core or the
+	 * Brands plugin). Shape matches `categories` / `tags` — `[{id, name,
+	 * slug}, ...]` — so extraction is mechanical.
 	 *
 	 * @param array<string, mixed> $wc_product
 	 * @return array<int, array{value: string, taxonomy: string}>
@@ -314,6 +322,17 @@ class WC_AI_Syndication_UCP_Product_Translator {
 					$result[] = [
 						'value'    => (string) $tag['name'],
 						'taxonomy' => 'tag',
+					];
+				}
+			}
+		}
+
+		if ( ! empty( $wc_product['brands'] ) && is_array( $wc_product['brands'] ) ) {
+			foreach ( $wc_product['brands'] as $brand ) {
+				if ( is_array( $brand ) && ! empty( $brand['name'] ) ) {
+					$result[] = [
+						'value'    => (string) $brand['name'],
+						'taxonomy' => 'brand',
 					];
 				}
 			}

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1627,6 +1627,31 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			}
 		}
 
+		// Brand filter — parallel to tags but across the `product_brand`
+		// taxonomy (native in WC 9.5+, previously a plugin). Same
+		// resolution path + unresolved-warning emission. Store API
+		// accepts comma-joined term IDs or slugs on the `brand` param;
+		// we resolve to IDs for consistency with category/tag.
+		if ( isset( $filters['brand'] ) && is_array( $filters['brand'] ) ) {
+			$brand_result = self::resolve_brand_term_ids( $filters['brand'] );
+			if ( ! empty( $brand_result['ids'] ) ) {
+				$params['brand'] = implode( ',', $brand_result['ids'] );
+			}
+			foreach ( $brand_result['unresolved'] as $index => $bad ) {
+				$messages[] = [
+					'type'     => 'warning',
+					'code'     => 'brand_not_found',
+					'severity' => 'advisory',
+					'path'     => '$.filters.brand[' . $index . ']',
+					'content'  => sprintf(
+						/* translators: %s is the brand slug/name the agent sent that couldn't be resolved. */
+						__( 'Brand "%s" was not found; filter ignored for this value.', 'woocommerce-ai-syndication' ),
+						$bad
+					),
+				];
+			}
+		}
+
 		// In-stock filter — agents transacting in real time shouldn't
 		// pitch products they can't actually deliver. Store API's
 		// stock_status param takes an array enum (instock/outofstock/
@@ -1671,9 +1696,22 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		// Store API accepts slugs directly for attributes, and
 		// invalid slugs produce empty results rather than errors.
 		if ( isset( $filters['attributes'] ) && is_array( $filters['attributes'] ) ) {
-			$attribute_params = self::build_attribute_filter_params( $filters['attributes'] );
-			if ( ! empty( $attribute_params ) ) {
-				$params['attributes'] = $attribute_params;
+			$attribute_result = self::build_attribute_filter_params( $filters['attributes'] );
+			if ( ! empty( $attribute_result['filters'] ) ) {
+				$params['attributes'] = $attribute_result['filters'];
+			}
+			foreach ( $attribute_result['unresolved'] as $bad ) {
+				$messages[] = [
+					'type'     => 'warning',
+					'code'     => 'attribute_not_found',
+					'severity' => 'advisory',
+					'path'     => '$.filters.attributes.' . $bad['key'],
+					'content'  => sprintf(
+						/* translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store. */
+						__( 'Attribute taxonomy "%s" was not found on the store; filter ignored for this axis.', 'woocommerce-ai-syndication' ),
+						$bad['taxonomy']
+					),
+				];
 			}
 		}
 
@@ -1701,11 +1739,21 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 * collapse to `pa_` after normalization are skipped so a malformed
 	 * entry doesn't poison the whole filter list.
 	 *
+	 * Taxonomies are validated via `taxonomy_exists()` before
+	 * forwarding. Normalized-but-unknown attribute names produce an
+	 * `attribute_not_found` entry in the returned `unresolved` list so
+	 * the caller can emit the warning, symmetric with how categories
+	 * and tags already surface unresolved filters.
+	 *
 	 * @param array<mixed, mixed> $attribute_map
-	 * @return array<int, array{attribute: string, slug: array<int, string>, operator: string}>
+	 * @return array{
+	 *     filters: array<int, array{attribute: string, slug: array<int, string>, operator: string}>,
+	 *     unresolved: array<int, array{key: string, taxonomy: string}>
+	 * }
 	 */
 	private static function build_attribute_filter_params( array $attribute_map ): array {
-		$result = [];
+		$filters    = [];
+		$unresolved = [];
 		foreach ( $attribute_map as $key => $values ) {
 			// Skip numeric keys — a malformed list-shaped input like
 			// `filters.attributes: [["red"]]` produces integer keys
@@ -1756,6 +1804,22 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			}
 			$taxonomy = 'pa_' . $normalized_key;
 
+			// Validate the taxonomy exists on the store. `taxonomy_exists`
+			// is cheap (in-memory map lookup) and catches typos the
+			// agent can't otherwise distinguish from a valid query
+			// that returned nothing. Unknown taxonomy → record the
+			// original input key + normalized taxonomy name so the
+			// caller can emit an `attribute_not_found` warning with
+			// JSON-path precision, symmetric with `category_not_found`
+			// / `tag_not_found` for the parallel filters.
+			if ( function_exists( 'taxonomy_exists' ) && ! taxonomy_exists( $taxonomy ) ) {
+				$unresolved[] = [
+					'key'      => $raw_key,
+					'taxonomy' => $taxonomy,
+				];
+				continue;
+			}
+
 			// Normalize slug values. Reject non-string/non-numeric
 			// entries — a nested array coerces to "Array" via (string)
 			// cast, which would silently forward as a bogus slug.
@@ -1775,13 +1839,16 @@ class WC_AI_Syndication_UCP_REST_Controller {
 				continue;
 			}
 
-			$result[] = [
+			$filters[] = [
 				'attribute' => $taxonomy,
 				'slug'      => array_values( array_unique( $slugs ) ),
 				'operator'  => 'in',
 			];
 		}
-		return $result;
+		return [
+			'filters'    => $filters,
+			'unresolved' => $unresolved,
+		];
 	}
 
 	/**
@@ -1832,6 +1899,21 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	}
 
 	/**
+	 * Resolve UCP brand strings to WC product_brand term IDs.
+	 *
+	 * Parallel to `resolve_tag_term_ids` but across the
+	 * `product_brand` taxonomy — native in WC 9.5+ and shipped by the
+	 * standalone "WooCommerce Brands" plugin before that. Same
+	 * slug-first / name-fallback resolution path.
+	 *
+	 * @param array<int, mixed> $inputs
+	 * @return array{ids: array<int, int>, unresolved: array<int, string>}
+	 */
+	private static function resolve_brand_term_ids( array $inputs ): array {
+		return self::resolve_taxonomy_term_ids( $inputs, 'product_brand' );
+	}
+
+	/**
 	 * Generic term-resolution helper — slug first, name fallback.
 	 *
 	 * Abstracted from the original `resolve_category_term_ids` so
@@ -1840,7 +1922,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	 * skip/lookup/unresolved pattern.
 	 *
 	 * @param array<int, mixed> $inputs
-	 * @param string            $taxonomy The WC taxonomy slug ('product_cat', 'product_tag').
+	 * @param string            $taxonomy The WC taxonomy slug ('product_cat', 'product_tag', 'product_brand').
 	 * @return array{ids: array<int, int>, unresolved: array<int, string>}
 	 */
 	private static function resolve_taxonomy_term_ids( array $inputs, string $taxonomy ): array {

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1701,11 +1701,25 @@ class WC_AI_Syndication_UCP_REST_Controller {
 				$params['attributes'] = $attribute_result['filters'];
 			}
 			foreach ( $attribute_result['unresolved'] as $bad ) {
-				$messages[] = [
+				// Use JSONPath bracket notation for the key — dot
+				// notation is only valid for identifier-style keys
+				// (letters, digits, underscores). Agent keys like
+				// `"Fabric Type"` (spaces), `"pa-size"` (hyphens), or
+				// `"foo's"` (quotes) need quoted bracket notation to
+				// remain machine-addressable. Escape backslashes
+				// first (else the \' below would end up as the literal
+				// character \\' which terminates the JSONPath string
+				// early) and then single quotes.
+				$escaped_key = str_replace(
+					[ '\\', "'" ],
+					[ '\\\\', "\\'" ],
+					$bad['key']
+				);
+				$messages[]  = [
 					'type'     => 'warning',
 					'code'     => 'attribute_not_found',
 					'severity' => 'advisory',
-					'path'     => '$.filters.attributes.' . $bad['key'],
+					'path'     => sprintf( "\$.filters.attributes['%s']", $escaped_key ),
 					'content'  => sprintf(
 						/* translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store. */
 						__( 'Attribute taxonomy "%s" was not found on the store; filter ignored for this axis.', 'woocommerce-ai-syndication' ),

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
@@ -283,8 +283,8 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 			$result['weight'] = $weight;
 		}
 
-		$dimensions    = $wc_variation['dimensions'] ?? [];
-		$dim_result    = [];
+		$dimensions = $wc_variation['dimensions'] ?? [];
+		$dim_result = [];
 		if ( is_array( $dimensions ) ) {
 			foreach ( [ 'length', 'width', 'height' ] as $key ) {
 				$value = $dimensions[ $key ] ?? '';

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-variant-translator.php
@@ -112,6 +112,19 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 			$variant['media'] = $media;
 		}
 
+		// Weight + dimensions — shipping-aware agents need these to
+		// estimate delivery costs or filter by physical attributes
+		// (fits-in-standard-flatrate, oversize surcharge, etc.).
+		// WC Store API emits them natively under `weight` (string
+		// scalar in merchant-configured unit) and `dimensions`
+		// (object with length/width/height). Only emit when the
+		// merchant has filled them in — empty/omitted values would
+		// produce misleading zeros or fabricated defaults.
+		$shipping = self::extract_shipping_attributes( $wc_variation );
+		if ( ! empty( $shipping ) ) {
+			$variant['shipping_attributes'] = $shipping;
+		}
+
 		return $variant;
 	}
 
@@ -160,6 +173,16 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 		}
 
 		$variant['availability'] = self::extract_availability( $wc_product );
+
+		// Simple products carry the same weight/dimensions shape the
+		// Store API uses for variations, so `shipping_attributes`
+		// routes through the same helper on the synthesized-default
+		// path. Keeps shipping-aware agents unaware of the
+		// simple-vs-variable distinction.
+		$shipping = self::extract_shipping_attributes( $wc_product );
+		if ( ! empty( $shipping ) ) {
+			$variant['shipping_attributes'] = $shipping;
+		}
 
 		return $variant;
 	}
@@ -227,6 +250,53 @@ class WC_AI_Syndication_UCP_Variant_Translator {
 			}
 			$result[] = $media;
 		}
+		return $result;
+	}
+
+	/**
+	 * Extract shipping-relevant physical attributes (weight + dimensions).
+	 *
+	 * WC Store API emits `weight` as a string scalar in the merchant's
+	 * configured weight unit (e.g. `"0.5"` kg) and `dimensions` as an
+	 * object with string `length` / `width` / `height` in the
+	 * merchant's configured dimension unit (e.g. `"10"` cm). We pass
+	 * the values through as strings because the unit lives separately
+	 * — converting to a canonical unit would require store-configuration
+	 * awareness we don't want to duplicate here, and the store context
+	 * already advertises the unit conventions on the manifest.
+	 *
+	 * Emit shape:
+	 *   { weight: "0.5", dimensions: { length: "10", width: "5", height: "2" } }
+	 *
+	 * When none of the fields are set, return an empty array so the
+	 * caller can omit `shipping_attributes` entirely — better than
+	 * emitting a half-empty object agents have to filter through.
+	 *
+	 * @param array<string, mixed> $wc_variation
+	 * @return array<string, mixed>
+	 */
+	private static function extract_shipping_attributes( array $wc_variation ): array {
+		$result = [];
+
+		$weight = $wc_variation['weight'] ?? '';
+		if ( is_string( $weight ) && '' !== trim( $weight ) ) {
+			$result['weight'] = $weight;
+		}
+
+		$dimensions    = $wc_variation['dimensions'] ?? [];
+		$dim_result    = [];
+		if ( is_array( $dimensions ) ) {
+			foreach ( [ 'length', 'width', 'height' ] as $key ) {
+				$value = $dimensions[ $key ] ?? '';
+				if ( is_string( $value ) && '' !== trim( $value ) ) {
+					$dim_result[ $key ] = $value;
+				}
+			}
+		}
+		if ( ! empty( $dim_result ) ) {
+			$result['dimensions'] = $dim_result;
+		}
+
 		return $result;
 	}
 

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce AI Syndication 1.7.0\n"
+"Project-Id-Version: WooCommerce AI Syndication 1.8.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-ai-syndication\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-20T09:00:57+00:00\n"
+"POT-Creation-Date: 2026-04-20T09:27:11+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -157,39 +157,51 @@ msgstr ""
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
+#. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1648
+#, php-format
+msgid "Brand \"%s\" was not found; filter ignored for this value."
+msgstr ""
+
+#. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1711
+#, php-format
+msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
+msgstr ""
+
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2153
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2235
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2304
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2386
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2308
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2390
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2312
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2394
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2314
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2396
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2316
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2398
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2320
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2402
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2322
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2404
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -113,6 +113,19 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 			}
 		);
 
+		// taxonomy_exists stub — default behavior is permissive
+		// (all pa_* taxonomies exist) so attribute filter tests that
+		// don't specifically test the not-found path pass. Tests that
+		// want to exercise `attribute_not_found` override this with
+		// their own Functions\when() call to return false for specific
+		// taxonomy names.
+		Functions\when( 'taxonomy_exists' )->alias(
+			static fn( string $taxonomy ): bool => 0 === strpos( $taxonomy, 'pa_' )
+				|| 'product_cat' === $taxonomy
+				|| 'product_tag' === $taxonomy
+				|| 'product_brand' === $taxonomy
+		);
+
 		$terms = &$this->fake_terms;
 		Functions\when( 'get_term_by' )->alias(
 			static function ( string $field, string $value, string $taxonomy ) use ( &$terms ) {
@@ -120,7 +133,7 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 				// same stubbed lookup — `seed_term` keys by
 				// `taxonomy:field:value` so the tag filter tests
 				// can seed independently from the category ones.
-				if ( ! in_array( $taxonomy, [ 'product_cat', 'product_tag' ], true ) ) {
+				if ( ! in_array( $taxonomy, [ 'product_cat', 'product_tag', 'product_brand' ], true ) ) {
 					return false;
 				}
 				$key = "{$taxonomy}:{$field}:{$value}";
@@ -175,6 +188,7 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 							'attributes',
 							'orderby',
 							'order',
+							'brand',
 						] as $key
 					) {
 						$val = $request->get_param( $key );
@@ -864,6 +878,85 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 			'pa_fabric-type',
 			$this->captured_store_params['attributes'][0]['attribute']
 		);
+	}
+
+	public function test_attribute_filter_unknown_taxonomy_emits_attribute_not_found_warning(): void {
+		// Agent sends a filter on `nonexistent` — no `pa_nonexistent`
+		// taxonomy registered on the store. Symmetric with
+		// `category_not_found` / `tag_not_found`: emit a warning
+		// pointing at the offending axis + drop the filter rather
+		// than forward a nonsense taxonomy that would silently
+		// return zero results.
+		Functions\when( 'taxonomy_exists' )->alias(
+			static fn( string $taxonomy ): bool => 'pa_color' === $taxonomy
+		);
+
+		$body = $this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'color'       => [ 'red' ],
+						'nonexistent' => [ 'anything' ],
+					],
+				],
+			]
+		);
+
+		// Known taxonomy forwarded.
+		$this->assertCount( 1, $this->captured_store_params['attributes'] );
+		$this->assertSame( 'pa_color', $this->captured_store_params['attributes'][0]['attribute'] );
+
+		// Unknown taxonomy surfaces as a warning.
+		$warnings = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'attribute_not_found' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $warnings );
+		$warning = array_values( $warnings )[0];
+		$this->assertStringContainsString( 'pa_nonexistent', $warning['content'] );
+		$this->assertSame( '$.filters.attributes.nonexistent', $warning['path'] );
+	}
+
+	// ------------------------------------------------------------------
+	// 1.9.0: Brand filter
+	// ------------------------------------------------------------------
+
+	public function test_brand_filter_forwards_resolved_term_ids(): void {
+		// Parallel to tags: slug → term ID resolution, comma-joined
+		// when multiple, forwarded as `brand` on the Store API.
+		$term                                      = (object) [
+			'term_id' => 88,
+			'slug'    => 'acme',
+			'name'    => 'ACME',
+		];
+		$this->fake_terms['product_brand:slug:acme'] = $term;
+
+		$this->successful_search(
+			[ 'filters' => [ 'brand' => [ 'acme' ] ] ]
+		);
+
+		$this->assertSame( '88', $this->captured_store_params['brand'] );
+	}
+
+	public function test_brand_filter_unresolvable_produces_brand_not_found_warning(): void {
+		// Symmetric with `category_not_found` / `tag_not_found` —
+		// agents must see a signal that their filter was ignored.
+		$term                                      = (object) [
+			'term_id' => 88,
+			'slug'    => 'acme',
+			'name'    => 'ACME',
+		];
+		$this->fake_terms['product_brand:slug:acme'] = $term;
+
+		$body = $this->successful_search(
+			[ 'filters' => [ 'brand' => [ 'acme', 'unknown-brand' ] ] ]
+		);
+
+		$not_found = array_filter(
+			$body['messages'] ?? [],
+			static fn( array $m ): bool => 'brand_not_found' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $not_found );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -914,7 +914,65 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 1, $warnings );
 		$warning = array_values( $warnings )[0];
 		$this->assertStringContainsString( 'pa_nonexistent', $warning['content'] );
-		$this->assertSame( '$.filters.attributes.nonexistent', $warning['path'] );
+		// JSONPath bracket notation — identifier-style keys still work
+		// with quoted brackets, just more verbose than dot notation.
+		$this->assertSame( "\$.filters.attributes['nonexistent']", $warning['path'] );
+	}
+
+	public function test_attribute_not_found_path_uses_bracket_notation_for_non_identifier_keys(): void {
+		// Regression: dot notation `$.filters.attributes.Fabric Type`
+		// is invalid JSONPath — agents that parse the path
+		// machine-side need bracket notation for keys with spaces,
+		// hyphens, quotes, or other non-identifier characters.
+		Functions\when( 'taxonomy_exists' )->justReturn( false );
+
+		$body = $this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						'Fabric Type' => [ 'cotton' ],
+					],
+				],
+			]
+		);
+
+		$warnings = array_values(
+			array_filter(
+				$body['messages'] ?? [],
+				static fn( array $m ): bool => 'attribute_not_found' === ( $m['code'] ?? '' )
+			)
+		);
+		$this->assertCount( 1, $warnings );
+		$this->assertSame( "\$.filters.attributes['Fabric Type']", $warnings[0]['path'] );
+	}
+
+	public function test_attribute_not_found_path_escapes_single_quotes_in_keys(): void {
+		// Defensive: a key containing a single quote (`"foo's"`) would
+		// break the bracket-notation string without escaping. Escape
+		// backslashes first, then single quotes — standard JSONPath
+		// quoted-string conventions.
+		Functions\when( 'taxonomy_exists' )->justReturn( false );
+
+		$body = $this->successful_search(
+			[
+				'filters' => [
+					'attributes' => [
+						"foo's bar" => [ 'value' ],
+					],
+				],
+			]
+		);
+
+		$warnings = array_values(
+			array_filter(
+				$body['messages'] ?? [],
+				static fn( array $m ): bool => 'attribute_not_found' === ( $m['code'] ?? '' )
+			)
+		);
+		$this->assertCount( 1, $warnings );
+		// The \' is a literal backslash-quote in the JSONPath string,
+		// which resolves back to the original `'` when parsed.
+		$this->assertSame( "\$.filters.attributes['foo\\'s bar']", $warnings[0]['path'] );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -557,6 +557,38 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
+	public function test_translate_emits_brands_as_third_taxonomy_in_categories(): void {
+		// WC 9.5+ `product_brand` taxonomy (and the earlier "WooCommerce
+		// Brands" plugin) surfaces via Store API under `brands[]`. Shape
+		// mirrors categories/tags — emit with `taxonomy: "brand"`.
+		$fixture           = $this->simple_product_fixture();
+		$fixture['brands'] = [
+			[ 'id' => 88, 'name' => 'ACME', 'slug' => 'acme' ],
+		];
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertContains(
+			[ 'value' => 'ACME', 'taxonomy' => 'brand' ],
+			$result['categories']
+		);
+	}
+
+	public function test_translate_omits_brands_when_source_has_none(): void {
+		// Merchants without Brands registered pay zero payload — no
+		// empty `brand` taxonomy entries should appear.
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[]
+		);
+
+		$brand_entries = array_filter(
+			$result['categories'] ?? [],
+			static fn( array $entry ): bool => 'brand' === ( $entry['taxonomy'] ?? '' )
+		);
+		$this->assertEmpty( $brand_entries );
+	}
+
 	public function test_translate_emits_product_attributes_excluding_variation_defining(): void {
 		$fixture               = $this->simple_product_fixture();
 		$fixture['attributes'] = [

--- a/tests/php/unit/UcpVariantTranslatorTest.php
+++ b/tests/php/unit/UcpVariantTranslatorTest.php
@@ -518,6 +518,105 @@ class UcpVariantTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'https://store.example/red-detail.jpg', $result['media'][2]['url'] );
 	}
 
+	// ------------------------------------------------------------------
+	// 1.9.0: Shipping attributes (weight + dimensions)
+	// ------------------------------------------------------------------
+
+	public function test_translate_emits_weight_and_dimensions_from_variation(): void {
+		// Shipping-aware agents need weight + L/W/H to estimate
+		// shipping. WC Store API emits these as string scalars in
+		// the merchant-configured unit; we pass them through verbatim
+		// (unit lives separately in store context).
+		$fixture = [
+			'id'          => 600,
+			'name'        => 'Widget / L',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+			'weight'      => '0.5',
+			'dimensions'  => [
+				'length' => '10',
+				'width'  => '5',
+				'height' => '2',
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertSame( '0.5', $result['shipping_attributes']['weight'] );
+		$this->assertSame( '10', $result['shipping_attributes']['dimensions']['length'] );
+		$this->assertSame( '5', $result['shipping_attributes']['dimensions']['width'] );
+		$this->assertSame( '2', $result['shipping_attributes']['dimensions']['height'] );
+	}
+
+	public function test_translate_omits_shipping_attributes_when_all_empty(): void {
+		// Merchants who haven't filled in physical attributes get
+		// no `shipping_attributes` key — better than a half-empty
+		// object agents have to filter through.
+		$fixture = [
+			'id'          => 600,
+			'name'        => 'Widget / L',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertArrayNotHasKey( 'shipping_attributes', $result );
+	}
+
+	public function test_translate_emits_partial_shipping_attributes(): void {
+		// Weight but no dimensions → emit only weight. Half-full is
+		// still useful (agents doing weight-based rate estimates).
+		$fixture = [
+			'id'          => 600,
+			'name'        => 'Widget / L',
+			'prices'      => [
+				'price'         => '2500',
+				'currency_code' => 'USD',
+			],
+			'is_in_stock' => true,
+			'weight'      => '1.2',
+			'dimensions'  => [
+				'length' => '',
+				'width'  => '',
+				'height' => '',
+			],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::translate( $fixture );
+
+		$this->assertSame( '1.2', $result['shipping_attributes']['weight'] );
+		$this->assertArrayNotHasKey( 'dimensions', $result['shipping_attributes'] );
+	}
+
+	public function test_synthesize_default_emits_shipping_attributes_for_simple_products(): void {
+		// Simple products (synthesize_default path) carry shipping
+		// fields in the same Store API shape — route through the same
+		// extraction helper.
+		$fixture = [
+			'id'          => 700,
+			'name'        => 'Simple Widget',
+			'is_in_stock' => true,
+			'prices'      => [
+				'price'         => '1000',
+				'currency_code' => 'USD',
+			],
+			'weight'      => '2.0',
+			'dimensions'  => [ 'length' => '20', 'width' => '10', 'height' => '5' ],
+		];
+
+		$result = WC_AI_Syndication_UCP_Variant_Translator::synthesize_default( $fixture );
+
+		$this->assertSame( '2.0', $result['shipping_attributes']['weight'] );
+		$this->assertSame( '20', $result['shipping_attributes']['dimensions']['length'] );
+	}
+
 	public function test_synthesize_default_also_carries_new_fields(): void {
 		$fixture = [
 			'id'                  => 901,


### PR DESCRIPTION
## Summary

Second-tier catalog polish after v1.8.0 — closes three MEDIUM gaps from the post-#38 audit.

## Changes

### 🏷️ Brand taxonomy (product-translator + controller)
- **Emit** — WC 9.5+ native `product_brand` taxonomy surfaces in Store API's `brands[]`. Each entry now joins the UCP `categories[]` list with `taxonomy: "brand"`, parallel to `"merchant"` (categories) and `"tag"` (tags).
- **Filter** — `filters.brand: ["nike"]` now resolves through the shared `resolve_taxonomy_term_ids` helper (slug-first, name-fallback). Unresolvable brands emit `brand_not_found` advisory warnings — symmetric with `category_not_found` / `tag_not_found`.

Unlocks agent queries like "show me Nike shoes" as a real taxonomy filter rather than fuzzy name/description matching.

### 📦 Variant shipping attributes (variant-translator)
New `shipping_attributes` field on each variant:

```json
{
  "shipping_attributes": {
    "weight": "0.5",
    "dimensions": { "length": "10", "width": "5", "height": "2" }
  }
}
```

- Pass-through extraction from Store API's native `weight` + `dimensions` fields
- Units stay merchant-configurable (advertised separately via `store_context`)
- Emitted on both real-variation `translate()` and synthesized `synthesize_default()` paths
- Omitted entirely when all fields empty; partially omitted when only weight OR dimensions present

### ⚠️ `attribute_not_found` warnings (controller)
`build_attribute_filter_params` now validates `pa_*` taxonomy existence via `taxonomy_exists()` before forwarding. Unknown attribute axes → `attribute_not_found` advisory with JSON-path precision.

**Internal API change**: helper now returns `{filters, unresolved}` instead of a flat array. All call sites updated; no external consumers.

## Test plan

- [x] 500 PHPUnit tests pass (+9 new from 491 in v1.8.0)
- [x] PHPCS clean
- [x] PHPStan strict clean
- [x] .pot regenerated
- [x] `brand` key captured in the rest_do_request test stub for assertion support

### Manual verification (post-merge, in staging)
- [ ] Store with WC 9.5+ `product_brand` registered: brands appear in `categories[]` with `taxonomy: "brand"`
- [ ] `POST /catalog/search` with `filters.brand: ["nike"]` returns only Nike-branded products
- [ ] Unknown brand name produces `brand_not_found` warning in `messages[]`
- [ ] Variation with weight + dimensions configured shows both in `shipping_attributes`
- [ ] Unknown attribute taxonomy (e.g. `filters.attributes: {nonexistent: ["value"]}`) produces `attribute_not_found` warning