### PR TITLE
Self-hosted spec + schema URLs for the UCP extension capability

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -494,6 +494,56 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = '- `{coupon_code}` is optional; omit the entire `&coupon=` parameter when not using one.';
 		$lines[] = '';
 
+		// UCP merchant-extension docs — referenced from the manifest's
+		// `com.woocommerce.ai_syndication` capability as the `spec`
+		// URL. Self-hosted (here, not on GitHub) so that the docs
+		// always match the running plugin version and respect the
+		// site's own access-control policy. The anchor
+		// `#ucp-extension` lets the manifest point at this section
+		// specifically. Paired with the machine-readable JSON Schema
+		// at `/wp-json/wc/ucp/v1/extension/schema`.
+		$ucp_schema_url = function_exists( 'rest_url' )
+			? rtrim( rest_url( 'wc/ucp/v1/extension/schema' ), '/' )
+			: '/wp-json/wc/ucp/v1/extension/schema';
+
+		$lines[] = '<a id="ucp-extension"></a>';
+		$lines[] = '## UCP Extension: com.woocommerce.ai_syndication';
+		$lines[] = '';
+		$lines[] = 'The UCP manifest at `/.well-known/ucp` advertises a merchant-extension capability `com.woocommerce.ai_syndication` alongside the canonical `dev.ucp.shopping.*` capabilities. It carries commerce context (currency, locale, tax/shipping posture) agents need before calling the catalog or checkout endpoints, plus attribution conventions for crediting agent-driven orders.';
+		$lines[] = '';
+		$lines[] = 'Machine-readable JSON Schema:';
+		$lines[] = '';
+		$lines[] = '`' . $ucp_schema_url . '`';
+		$lines[] = '';
+		$lines[] = '### config.store_context';
+		$lines[] = '';
+		$lines[] = '- **currency** — ISO 4217 currency code. All catalog prices quote in this currency. Agents unable to transact here should decline rather than misrepresent the amount.';
+		$lines[] = '- **locale** — BCP 47 locale tag for default customer-facing content language (e.g. `en-US`, `fr-FR`, `zh-Hant-HK`).';
+		$lines[] = '- **country** — ISO 3166-1 alpha-2 for the merchant base country. `null` when not configured.';
+		$lines[] = '- **prices_include_tax** — `true` (EU-typical) means catalog prices are tax-inclusive; `false` (US-typical) means tax is added at checkout. Agents rendering cart previews use this to decide whether to show a tax line.';
+		$lines[] = '- **shipping_enabled** — `true` when the store collects shipping addresses. `false` means digital-only — skip address-collection prompts.';
+		$lines[] = '';
+		$lines[] = '### config.attribution';
+		$lines[] = '';
+		$lines[] = '- **system** — identifier of the attribution system recording agent-originated orders (currently `woocommerce_order_attribution`).';
+		$lines[] = '- **parameters** — documented UTM-style parameters (`utm_source`, `utm_medium`, etc.) the store recognizes.';
+		$lines[] = '- **usage_note** — preferred attribution path. For this plugin: use `POST /wp-json/wc/ucp/v1/checkout-sessions`; the server injects UTM values server-side based on your `UCP-Agent` header. Manual UTM construction on the agent side is a fallback, not the preferred path.';
+		$lines[] = '';
+		$lines[] = '### Product-level extension payload';
+		$lines[] = '';
+		$lines[] = 'Product responses emit a `ratings` field under this namespace when review data exists:';
+		$lines[] = '';
+		$lines[] = '```json';
+		$lines[] = '"extensions": {';
+		$lines[] = '  "com.woocommerce.ai_syndication": {';
+		$lines[] = '    "ratings": { "average": 4.5, "count": 17 }';
+		$lines[] = '  }';
+		$lines[] = '}';
+		$lines[] = '```';
+		$lines[] = '';
+		$lines[] = 'Note: GTIN/UPC/EAN/MPN barcodes are NOT emitted under this extension. They appear in the canonical `variants[].barcodes` field on the UCP variant shape. Our plugin sources them via a separate Store API extension (internal plumbing, not part of the UCP-facing contract).';
+		$lines[] = '';
+
 		/**
 		 * Filter the llms.txt content lines before rendering.
 		 *

--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -534,9 +534,11 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = 'Product responses emit a `ratings` field under this namespace when review data exists:';
 		$lines[] = '';
 		$lines[] = '```json';
-		$lines[] = '"extensions": {';
-		$lines[] = '  "com.woocommerce.ai_syndication": {';
-		$lines[] = '    "ratings": { "average": 4.5, "count": 17 }';
+		$lines[] = '{';
+		$lines[] = '  "extensions": {';
+		$lines[] = '    "com.woocommerce.ai_syndication": {';
+		$lines[] = '      "ratings": { "average": 4.5, "count": 17 }';
+		$lines[] = '    }';
 		$lines[] = '  }';
 		$lines[] = '}';
 		$lines[] = '```';

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -333,6 +333,28 @@ class WC_AI_Syndication_Ucp {
 						[
 							'version' => self::PROTOCOL_VERSION,
 							'extends' => self::SERVICE_NAME,
+							// Self-hosted docs URLs. The spec + schema
+							// are served from this site (not GitHub) for
+							// three reasons:
+							//   1. Permission parity — if the store
+							//      restricts REST access, the docs
+							//      restrict alongside. No third-party
+							//      leak vector.
+							//   2. Version truth — the schema served
+							//      describes the version of the plugin
+							//      the merchant is running. No drift
+							//      from "latest".
+							//   3. Zero external dependency — a GitHub
+							//      outage or repo visibility change
+							//      can't break agent integrations.
+							// Same self-hosting pattern as the manifest
+							// itself (at /.well-known/ucp) and llms.txt.
+							'spec'    => function_exists( 'home_url' )
+								? home_url( '/llms.txt#ucp-extension' )
+								: '/llms.txt#ucp-extension',
+							'schema'  => function_exists( 'rest_url' )
+								? rest_url( 'wc/ucp/v1/extension/schema' )
+								: '/wp-json/wc/ucp/v1/extension/schema',
 							'config'  => [
 								'store_context' => $this->build_store_context(),
 								'attribution'   => $attribution_config,

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -990,7 +990,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			'description' => 'Schema for the `com.woocommerce.ai_syndication` merchant-extension capability advertised at `capabilities[com.woocommerce.ai_syndication][0].config` in the UCP manifest. Carries commerce context agents need upfront (currency, locale, tax/shipping posture) and attribution conventions for crediting agent-driven orders back to the originating agent.',
 			'type'        => 'object',
 			'properties'  => [
-				'config' => [
+				'config'  => [
 					'type'        => 'object',
 					'description' => 'Extension-scoped configuration.',
 					'properties'  => [
@@ -1037,8 +1037,8 @@ class WC_AI_Syndication_UCP_REST_Controller {
 									'examples'    => [ 'woocommerce_order_attribution' ],
 								],
 								'parameters' => [
-									'type'        => 'object',
-									'description' => 'Named description of each expected UTM-style parameter.',
+									'type'                 => 'object',
+									'description'          => 'Named description of each expected UTM-style parameter.',
 									'additionalProperties' => [ 'type' => 'string' ],
 								],
 								'usage_note' => [

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -122,22 +122,34 @@ class WC_AI_Syndication_UCP_REST_Controller {
 	/**
 	 * Register all UCP REST routes.
 	 *
-	 * All routes are POST — UCP uses request bodies for its capability
-	 * payloads (catalog query, line items) so POST is required even for
-	 * read-shaped operations like catalog/search.
+	 * Two shapes of routes:
+	 *
+	 *   1. Three COMMERCE routes (POST): catalog/search, catalog/lookup,
+	 *      checkout-sessions. UCP uses request bodies for its capability
+	 *      payloads (catalog query, line items) so POST is required even
+	 *      for read-shaped operations like catalog/search. Each handler
+	 *      checks `is_syndication_disabled()` before doing any work and,
+	 *      when disabled, returns a UCP-shaped `WP_REST_Response` with
+	 *      HTTP 503 (via `ucp_catalog_error_response()` /
+	 *      `ucp_checkout_error_response()`).
+	 *
+	 *   2. One DOCS route (GET): extension/schema. Serves a static JSON
+	 *      Schema document describing our merchant-extension capability.
+	 *      NOT gated on `is_syndication_disabled()` — same availability
+	 *      as the UCP manifest itself at `/.well-known/ucp` (both are
+	 *      discovery surfaces; the manifest continues to be served even
+	 *      when syndication is paused, and the schema it points at must
+	 *      resolve to stay consistent).
 	 *
 	 * All routes are public (`permission_callback => '__return_true'`):
 	 * UCP's agent authentication happens at the `UCP-Agent` header
 	 * level and is currently used only for attribution (utm_source in
 	 * checkout handoff) and logging, not for access control. Merchants
-	 * who need to gate access can pause syndication via the admin UI —
-	 * each handler checks `is_syndication_disabled()` before doing any
-	 * work and, when disabled, returns a UCP-shaped `WP_REST_Response`
-	 * with HTTP 503 status (built via `ucp_catalog_error_response()`
-	 * for catalog routes and `ucp_checkout_error_response()` for
-	 * checkout-sessions). Keeping routes registered (versus
-	 * unregistering on disable) avoids rewrite-flush churn every time
-	 * a merchant toggles the setting.
+	 * who need to gate access can pause syndication (commerce routes
+	 * refuse) or use WP's standard REST permission filters.
+	 *
+	 * Keeping routes registered (versus unregistering on disable) avoids
+	 * rewrite-flush churn every time a merchant toggles the setting.
 	 */
 	public function register_routes(): void {
 		register_rest_route(
@@ -986,13 +998,13 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		$schema = [
 			'$schema'     => 'https://json-schema.org/draft/2020-12/schema',
 			'$id'         => $self_id,
-			'title'       => 'WooCommerce AI Syndication UCP Extension',
-			'description' => 'Schema for the `com.woocommerce.ai_syndication` merchant-extension capability advertised at `capabilities[com.woocommerce.ai_syndication][0].config` in the UCP manifest. Carries commerce context agents need upfront (currency, locale, tax/shipping posture) and attribution conventions for crediting agent-driven orders back to the originating agent.',
+			'title'       => 'WooCommerce AI Syndication UCP Extension Contract',
+			'description' => 'Schema for the full `com.woocommerce.ai_syndication` extension contract. The top-level `config` property describes the merchant-extension configuration advertised in the UCP manifest at `capabilities[com.woocommerce.ai_syndication][0].config`. The top-level `ratings` property describes the per-product payload emitted under `extensions[com.woocommerce.ai_syndication].ratings` on UCP product responses. Consumers validate each against the property path matching the location they encountered the data at.',
 			'type'        => 'object',
 			'properties'  => [
 				'config'  => [
 					'type'        => 'object',
-					'description' => 'Extension-scoped configuration.',
+					'description' => 'Merchant-extension configuration advertised at `capabilities[com.woocommerce.ai_syndication][0].config` in the UCP manifest.',
 					'properties'  => [
 						'store_context' => [
 							'type'        => 'object',

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -169,6 +169,22 @@ class WC_AI_Syndication_UCP_REST_Controller {
 				'permission_callback' => '__return_true',
 			]
 		);
+
+		// JSON Schema for our merchant extension capability
+		// (com.woocommerce.ai_syndication). Served per-site so the
+		// schema matches the running plugin version exactly and
+		// respects the merchant's own access-control configuration
+		// (same perms as the rest of the UCP routes). Referenced by
+		// the manifest's extension capability `schema` URL.
+		register_rest_route(
+			self::NAMESPACE,
+			'/extension/schema',
+			[
+				'methods'             => 'GET',
+				'callback'            => [ $this, 'handle_extension_schema' ],
+				'permission_callback' => '__return_true',
+			]
+		);
 	}
 
 	/**
@@ -943,6 +959,122 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			$response_body,
 			$should_redirect ? 201 : 200
 		);
+	}
+
+	/**
+	 * Handler for GET /extension/schema.
+	 *
+	 * Serves the JSON Schema describing the shape of our merchant
+	 * extension capability (`com.woocommerce.ai_syndication`). The
+	 * manifest's extension capability advertises this endpoint under
+	 * its `schema` field; agents that want to validate our
+	 * extension-specific payload fetch it here rather than hardcoding
+	 * the shape.
+	 *
+	 * Self-hosted by design: the schema served matches the version of
+	 * the plugin the merchant is running (no risk of schema/runtime
+	 * drift from a third-party registry), and honors whatever access
+	 * controls the site has on the REST API (same permissions as the
+	 * catalog/checkout endpoints). `$id` is computed from the current
+	 * URL so a static mirror of the schema keeps the right self-reference.
+	 *
+	 * @return WP_REST_Response
+	 */
+	public function handle_extension_schema(): WP_REST_Response {
+		$self_id = rest_url( self::NAMESPACE . '/extension/schema' );
+
+		$schema = [
+			'$schema'     => 'https://json-schema.org/draft/2020-12/schema',
+			'$id'         => $self_id,
+			'title'       => 'WooCommerce AI Syndication UCP Extension',
+			'description' => 'Schema for the `com.woocommerce.ai_syndication` merchant-extension capability advertised at `capabilities[com.woocommerce.ai_syndication][0].config` in the UCP manifest. Carries commerce context agents need upfront (currency, locale, tax/shipping posture) and attribution conventions for crediting agent-driven orders back to the originating agent.',
+			'type'        => 'object',
+			'properties'  => [
+				'config' => [
+					'type'        => 'object',
+					'description' => 'Extension-scoped configuration.',
+					'properties'  => [
+						'store_context' => [
+							'type'        => 'object',
+							'description' => 'Commerce conventions this store operates under — agents pre-filter based on these before calling catalog/checkout.',
+							'properties'  => [
+								'currency'           => [
+									'type'        => 'string',
+									'description' => 'ISO 4217 currency code. Catalog prices quote in this currency; agents unable to transact here should decline rather than misrepresent the amount.',
+									'examples'    => [ 'USD', 'EUR', 'JPY' ],
+								],
+								'locale'             => [
+									'type'        => 'string',
+									'description' => 'BCP 47 locale tag for default customer-facing content language.',
+									'examples'    => [ 'en-US', 'fr-FR', 'zh-Hant-HK' ],
+								],
+								'country'            => [
+									'type'        => [ 'string', 'null' ],
+									'description' => 'ISO 3166-1 alpha-2 for the merchant base country. Nullable when the merchant has not configured a base country in WC settings.',
+								],
+								'prices_include_tax' => [
+									'type'        => 'boolean',
+									'description' => 'When true (EU-typical), catalog prices are tax-inclusive. When false (US-typical), tax is added at checkout. Agents rendering cart previews use this to decide whether to show a tax line.',
+								],
+								'shipping_enabled'   => [
+									'type'        => 'boolean',
+									'description' => 'When true, the store collects shipping addresses. When false, it is digital-only — agents should skip address-collection prompts.',
+								],
+							],
+						],
+						'attribution'   => [
+							'type'        => 'object',
+							'description' => 'How the merchant wants agent-driven orders attributed. Agents should pass these UTM parameters through the `continue_url` on checkout handoff.',
+							'properties'  => [
+								'spec'       => [
+									'type'        => 'string',
+									'format'      => 'uri',
+									'description' => 'URL to the upstream attribution system documentation.',
+								],
+								'system'     => [
+									'type'        => 'string',
+									'description' => 'Identifier of the attribution system recording agent-originated orders.',
+									'examples'    => [ 'woocommerce_order_attribution' ],
+								],
+								'parameters' => [
+									'type'        => 'object',
+									'description' => 'Named description of each expected UTM-style parameter.',
+									'additionalProperties' => [ 'type' => 'string' ],
+								],
+								'usage_note' => [
+									'type'        => 'string',
+									'description' => 'Human-readable guidance on the preferred attribution path (typically: use the UCP `/checkout-sessions` endpoint, which handles UTM injection server-side).',
+								],
+							],
+						],
+					],
+				],
+				'ratings' => [
+					'type'        => 'object',
+					'description' => 'Per-product ratings payload emitted on product responses under `extensions[com.woocommerce.ai_syndication].ratings` when review_count > 0. Shape: `{average: number, count: integer}`.',
+					'properties'  => [
+						'average' => [
+							'type'        => 'number',
+							'minimum'     => 0,
+							'maximum'     => 5,
+							'description' => 'Average rating on a 0-5 scale.',
+						],
+						'count'   => [
+							'type'        => 'integer',
+							'minimum'     => 0,
+							'description' => 'Total number of reviews contributing to the average.',
+						],
+					],
+				],
+			],
+		];
+
+		$response = new WP_REST_Response( $schema, 200 );
+		$response->header( 'Content-Type', 'application/schema+json; charset=utf-8' );
+		// Schema is immutable per plugin version; safe to cache.
+		$response->header( 'Cache-Control', 'public, max-age=3600' );
+
+		return $response;
 	}
 
 	// ------------------------------------------------------------------

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-20T19:35:37+00:00\n"
+"POT-Creation-Date: 2026-04-20T19:54:28+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -64,132 +64,144 @@ msgstr ""
 msgid "The barcode value as stored by the merchant."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:235
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:523
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:688
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:247
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:535
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:700
 msgid "AI Syndication is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:269
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:296
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:281
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:308
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:536
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:548
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:546
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:558
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:564
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:576
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:699
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:711
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:709
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:721
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:853
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:865
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:872
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:884
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:910
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:922
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1501
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1513
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1572
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1584
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1588
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1600
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1615
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1627
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1648
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1660
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1684
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1696
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1710
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1722
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1755
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1767
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
+#. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1792
+#, php-format
+msgid "Brand \"%s\" was not found; filter ignored for this value."
+msgstr ""
+
+#. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1869
+#, php-format
+msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
+msgstr ""
+
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2285
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2393
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2436
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2544
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2440
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2548
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2444
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2552
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2446
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2554
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2448
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2556
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2452
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2560
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2454
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2562
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-20T09:27:11+00:00\n"
+"POT-Creation-Date: 2026-04-20T19:35:37+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -64,144 +64,132 @@ msgstr ""
 msgid "The barcode value as stored by the merchant."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:219
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:507
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:672
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:235
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:523
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:688
 msgid "AI Syndication is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:253
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:280
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:269
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:296
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:520
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:536
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:530
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:546
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:548
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:564
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:683
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:699
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:693
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:709
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:837
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:853
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:856
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:872
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:894
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:910
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1369
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1501
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1440
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1572
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1456
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1588
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1483
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1615
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1516
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1648
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1552
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1684
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1578
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1710
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1623
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1755
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
-#. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1648
-#, php-format
-msgid "Brand \"%s\" was not found; filter ignored for this value."
-msgstr ""
-
-#. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1711
-#, php-format
-msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
-msgstr ""
-
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2235
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2285
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2386
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2436
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2390
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2440
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2394
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2444
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2396
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2446
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2398
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2448
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2402
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2452
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2404
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2454
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -664,6 +664,40 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringNotContainsString( '/news-sitemap.xml', $output );
 	}
 
+	// ------------------------------------------------------------------
+	// UCP extension docs (1.9.0)
+	// ------------------------------------------------------------------
+
+	public function test_llms_txt_includes_ucp_extension_section(): void {
+		// The UCP manifest advertises the merchant-extension capability
+		// with a `spec` URL pointing at `/llms.txt#ucp-extension`. This
+		// test locks in that the anchor is present + the section is
+		// actually rendered so the manifest's URL resolves.
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( '<a id="ucp-extension"></a>', $output );
+		$this->assertStringContainsString( '## UCP Extension: com.woocommerce.ai_syndication', $output );
+	}
+
+	public function test_llms_txt_extension_section_points_at_schema_endpoint(): void {
+		// The human-readable section should reference the machine-
+		// readable schema endpoint so agents that want to validate
+		// the payload can find it from the text docs.
+		$output = $this->llms->generate();
+
+		$this->assertStringContainsString( '/wp-json/wc/ucp/v1/extension/schema', $output );
+	}
+
+	public function test_llms_txt_extension_section_documents_config_fields(): void {
+		// The five store_context fields must each be documented so
+		// agents reading llms.txt understand what the manifest carries.
+		$output = $this->llms->generate();
+
+		foreach ( [ 'currency', 'locale', 'country', 'prices_include_tax', 'shipping_enabled' ] as $field ) {
+			$this->assertStringContainsString( '**' . $field . '**', $output );
+		}
+	}
+
 	public function test_wp_core_sitemap_included_when_non_empty(): void {
 		// `get_sitemap_url( 'index' )` returns WP core's canonical
 		// sitemap URL when the feature is active. That candidate

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -665,7 +665,7 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// UCP extension docs (1.9.0)
+	// UCP extension docs
 	// ------------------------------------------------------------------
 
 	public function test_llms_txt_includes_ucp_extension_section(): void {

--- a/tests/php/unit/UcpCheckoutPostureTest.php
+++ b/tests/php/unit/UcpCheckoutPostureTest.php
@@ -200,16 +200,24 @@ class UcpCheckoutPostureTest extends \PHPUnit\Framework\TestCase {
 	// Runtime-behavior posture invariants
 	// ------------------------------------------------------------------
 
-	public function test_registered_rest_routes_are_exactly_three(): void {
-		// The plugin registers exactly 3 POST routes: catalog/search,
-		// catalog/lookup, checkout-sessions. No Complete Checkout,
-		// no Update Checkout, no GET /checkout-sessions/{id} — those
-		// would either enable programmatic completion or imply
-		// persistent checkout state that the handoff model rejects.
+	public function test_registered_rest_routes_are_the_exact_posture_set(): void {
+		// The plugin registers three commerce POST routes
+		// (catalog/search, catalog/lookup, checkout-sessions) and
+		// one docs GET route (extension/schema). No Complete
+		// Checkout, no Update Checkout, no GET /checkout-sessions/{id},
+		// no cart routes — those would either enable programmatic
+		// completion or imply persistent checkout state that the
+		// handoff model rejects.
 		//
-		// If a future change adds a 4th route, this test fires —
-		// forcing the maintainer to either legitimize the new route
-		// in the posture docs or revert.
+		// `extension/schema` is a read-only JSON Schema endpoint for
+		// the `com.woocommerce.ai_syndication` merchant extension —
+		// serves static documentation content, NOT commerce state. It
+		// is explicitly posture-compatible: no order/cart/payment
+		// semantics.
+		//
+		// If a future change adds any route not in this whitelist,
+		// this test fires — forcing the maintainer to either legitimize
+		// the new route in the posture docs or revert.
 		$registered = [];
 		Functions\when( 'register_rest_route' )->alias(
 			static function ( $namespace, $route ) use ( &$registered ) {
@@ -227,6 +235,7 @@ class UcpCheckoutPostureTest extends \PHPUnit\Framework\TestCase {
 				'wc/ucp/v1/catalog/lookup',
 				'wc/ucp/v1/catalog/search',
 				'wc/ucp/v1/checkout-sessions',
+				'wc/ucp/v1/extension/schema',
 			],
 			$registered
 		);

--- a/tests/php/unit/UcpRestControllerTest.php
+++ b/tests/php/unit/UcpRestControllerTest.php
@@ -82,11 +82,16 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 	// Registration contract
 	// ------------------------------------------------------------------
 
-	public function test_registers_three_routes_under_wc_ucp_v1_namespace(): void {
+	public function test_registers_expected_routes_under_wc_ucp_v1_namespace(): void {
 		$controller = new WC_AI_Syndication_UCP_REST_Controller();
 		$controller->register_routes();
 
-		$this->assertCount( 3, $this->registered_routes );
+		// Three commerce endpoints (catalog/search, catalog/lookup,
+		// checkout-sessions) + one docs endpoint (extension/schema).
+		// The commerce endpoints are the UCP 2026-04-08 surface; the
+		// docs endpoint is our self-hosted JSON Schema for the
+		// `com.woocommerce.ai_syndication` extension.
+		$this->assertCount( 4, $this->registered_routes );
 		foreach ( $this->registered_routes as $call ) {
 			$this->assertEquals( 'wc/ucp/v1', $call['namespace'] );
 		}
@@ -133,6 +138,19 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( 'POST', $route['args']['methods'] );
 	}
 
+	public function test_extension_schema_route_registered(): void {
+		// Self-hosted JSON Schema endpoint for the
+		// com.woocommerce.ai_syndication merchant extension. GET,
+		// not POST — it's read-only static documentation content.
+		$controller = new WC_AI_Syndication_UCP_REST_Controller();
+		$controller->register_routes();
+
+		$route = $this->route_for( '/extension/schema' );
+
+		$this->assertNotNull( $route, 'extension/schema route should be registered' );
+		$this->assertEquals( 'GET', $route['args']['methods'] );
+	}
+
 	public function test_all_routes_are_public(): void {
 		// UCP routes are public by design — agent auth is via the
 		// UCP-Agent header (used for attribution, not access control).
@@ -162,8 +180,97 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
+	// ------------------------------------------------------------------
+	// Extension schema handler (1.9.0)
+	// ------------------------------------------------------------------
+
+	public function test_extension_schema_handler_returns_valid_json_schema(): void {
+		// The handler emits a JSON Schema document describing our
+		// merchant-extension capability config. Required top-level
+		// fields: `$schema` (draft identifier), `$id` (self URL for
+		// re-serialization), `type`, `properties`.
+		\Brain\Monkey\Functions\when( 'rest_url' )->alias(
+			static fn( string $p ): string => 'https://example.com/wp-json/' . ltrim( $p, '/' )
+		);
+
+		$controller = new WC_AI_Syndication_UCP_REST_Controller();
+		$response   = $controller->handle_extension_schema();
+
+		$this->assertInstanceOf( WP_REST_Response::class, $response );
+		$this->assertSame( 200, $response->get_status() );
+
+		$data = $response->get_data();
+		$this->assertIsArray( $data );
+
+		// JSON Schema meta.
+		$this->assertStringContainsString( 'json-schema.org', $data['$schema'] );
+		$this->assertStringContainsString( '/wc/ucp/v1/extension/schema', $data['$id'] );
+		$this->assertSame( 'object', $data['type'] );
+	}
+
+	public function test_extension_schema_documents_store_context_fields(): void {
+		// The schema must document the known config.store_context
+		// fields (currency, locale, country, prices_include_tax,
+		// shipping_enabled) so agents can validate without reading
+		// the plugin source. A regression dropping one silently
+		// would leave agents unable to interpret that field.
+		\Brain\Monkey\Functions\when( 'rest_url' )->alias(
+			static fn( string $p ): string => 'https://example.com/wp-json/' . ltrim( $p, '/' )
+		);
+
+		$controller = new WC_AI_Syndication_UCP_REST_Controller();
+		$response   = $controller->handle_extension_schema();
+		$data       = $response->get_data();
+
+		$store_context = $data['properties']['config']['properties']['store_context']['properties'];
+		$this->assertArrayHasKey( 'currency', $store_context );
+		$this->assertArrayHasKey( 'locale', $store_context );
+		$this->assertArrayHasKey( 'country', $store_context );
+		$this->assertArrayHasKey( 'prices_include_tax', $store_context );
+		$this->assertArrayHasKey( 'shipping_enabled', $store_context );
+	}
+
+	public function test_extension_schema_documents_ratings_payload(): void {
+		// Products emit `ratings` under the extension namespace
+		// (`extensions.com.woocommerce.ai_syndication.ratings`) — the
+		// schema must document its shape so agents can validate.
+		// Barcodes are NOT documented here: they're emitted in the
+		// CORE `variant.barcodes` field per the UCP spec, sourced
+		// from a Store API extension that's purely internal plumbing
+		// and doesn't belong in the UCP-layer extension schema.
+		\Brain\Monkey\Functions\when( 'rest_url' )->alias(
+			static fn( string $p ): string => 'https://example.com/wp-json/' . ltrim( $p, '/' )
+		);
+
+		$controller = new WC_AI_Syndication_UCP_REST_Controller();
+		$response   = $controller->handle_extension_schema();
+		$data       = $response->get_data();
+
+		$this->assertArrayHasKey( 'ratings', $data['properties'] );
+		// Barcodes live on the core UCP variant shape — not here.
+		$this->assertArrayNotHasKey( 'barcodes', $data['properties'] );
+	}
+
+	public function test_extension_schema_response_has_json_schema_content_type(): void {
+		// RFC 7159-ish convention: JSON Schema documents use
+		// `application/schema+json`. Agents and validators sniff the
+		// content type to confirm what they fetched.
+		\Brain\Monkey\Functions\when( 'rest_url' )->alias(
+			static fn( string $p ): string => 'https://example.com/wp-json/' . ltrim( $p, '/' )
+		);
+
+		$controller = new WC_AI_Syndication_UCP_REST_Controller();
+		$response   = $controller->handle_extension_schema();
+
+		$this->assertStringContainsString(
+			'application/schema+json',
+			$response->get_headers()['Content-Type'] ?? ''
+		);
+	}
+
 	// All three handlers are now implemented (tasks 10, 11, 12). Their
 	// behavior tests live in UcpCatalogSearchTest, UcpCatalogLookupTest,
 	// and UcpCheckoutSessionsTest respectively. This file retains only
-	// the route-registration contract tests.
+	// the route-registration contract tests + the 1.9.0 extension
+	// schema handler tests.
 }

--- a/tests/php/unit/UcpRestControllerTest.php
+++ b/tests/php/unit/UcpRestControllerTest.php
@@ -181,7 +181,7 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// Extension schema handler (1.9.0)
+	// Extension schema handler
 	// ------------------------------------------------------------------
 
 	public function test_extension_schema_handler_returns_valid_json_schema(): void {
@@ -268,9 +268,9 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
-	// All three handlers are now implemented (tasks 10, 11, 12). Their
-	// behavior tests live in UcpCatalogSearchTest, UcpCatalogLookupTest,
-	// and UcpCheckoutSessionsTest respectively. This file retains only
-	// the route-registration contract tests + the 1.9.0 extension
-	// schema handler tests.
+	// All three commerce handlers are implemented (tasks 10, 11, 12).
+	// Their behavior tests live in UcpCatalogSearchTest,
+	// UcpCatalogLookupTest, and UcpCheckoutSessionsTest respectively.
+	// This file retains only the route-registration contract tests +
+	// the extension-schema handler tests.
 }

--- a/tests/php/unit/UcpTest.php
+++ b/tests/php/unit/UcpTest.php
@@ -538,10 +538,16 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		//           but at a GitHub directory listing, not a spec doc)
 		//   - 1.6.4: `https://ucp.dev/{VERSION}/...` (pinned at the
 		//           canonical docs site + OpenAPI schema)
+		//   - 1.9.0: merchant-extension capability URLs are
+		//           SELF-HOSTED (on the merchant site, not ucp.dev) —
+		//           they don't fit the version-pin rule because they
+		//           always describe the CURRENT plugin version rather
+		//           than a fixed UCP protocol revision.
 		//
-		// This test locks in the 1.6.4 shape: all external URLs
-		// use `ucp.dev/{PROTOCOL_VERSION}/` so one constant drives
-		// every spec/schema reference in the manifest.
+		// This test locks in the canonical-capability shape: all UCP
+		// `dev.ucp.*` URLs use `ucp.dev/{PROTOCOL_VERSION}/`. Extension
+		// capabilities (anything not under `dev.ucp.*`) are exempted
+		// below and validated by a separate test.
 		$manifest = $this->ucp->generate_manifest( [] );
 		$service  = $manifest['ucp']['services']['dev.ucp.shopping'][0];
 		$version  = WC_AI_Syndication_Ucp::PROTOCOL_VERSION;
@@ -550,9 +556,15 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( "/{$version}/", $service['spec'] );
 		$this->assertStringContainsString( "/{$version}/", $service['schema'] );
 
-		// Capability-level URLs.
+		// Capability-level URLs — canonical (`dev.ucp.*`) capabilities
+		// point at ucp.dev and MUST be version-pinned. Extension
+		// capabilities (our `com.woocommerce.ai_syndication`) are
+		// self-hosted on the merchant site and exempted.
 		$caps = $manifest['ucp']['capabilities'];
 		foreach ( $caps as $name => $bindings ) {
+			if ( 0 !== strpos( $name, 'dev.ucp.' ) ) {
+				continue; // extension capability — skip
+			}
 			foreach ( $bindings as $binding ) {
 				if ( isset( $binding['spec'] ) ) {
 					$this->assertStringContainsString( "/{$version}/", $binding['spec'], "spec URL for $name must be version-pinned" );
@@ -566,6 +578,32 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// Regression guard against the pre-1.6.4 GitHub tree URL.
 		$this->assertStringNotContainsString( '/tree/main/', $service['spec'] );
 		$this->assertStringNotContainsString( 'github.com', $service['spec'] );
+	}
+
+	public function test_extension_capability_urls_are_self_hosted(): void {
+		// The `com.woocommerce.ai_syndication` extension capability's
+		// `spec` + `schema` URLs are served by the merchant site, not
+		// by a third-party registry. This keeps docs always in sync
+		// with the running plugin version, respects the site's own
+		// access-control policy, and eliminates external dependencies.
+		//
+		// `spec` points at the llms.txt anchor; `schema` points at the
+		// dedicated JSON Schema REST route. Both are on the merchant
+		// host, never `ucp.dev` or `github.com`.
+		$manifest = $this->ucp->generate_manifest( [] );
+		$ext      = $manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0];
+
+		$this->assertArrayHasKey( 'spec', $ext );
+		$this->assertArrayHasKey( 'schema', $ext );
+
+		$this->assertStringContainsString( '/llms.txt#ucp-extension', $ext['spec'] );
+		$this->assertStringContainsString( '/wc/ucp/v1/extension/schema', $ext['schema'] );
+
+		// Never third-party hosted.
+		$this->assertStringNotContainsString( 'ucp.dev', $ext['spec'] );
+		$this->assertStringNotContainsString( 'ucp.dev', $ext['schema'] );
+		$this->assertStringNotContainsString( 'github.com', $ext['spec'] );
+		$this->assertStringNotContainsString( 'github.com', $ext['schema'] );
 	}
 
 	public function test_every_canonical_capability_has_spec_and_schema_urls(): void {

--- a/tests/php/unit/UcpTest.php
+++ b/tests/php/unit/UcpTest.php
@@ -538,11 +538,12 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		//           but at a GitHub directory listing, not a spec doc)
 		//   - 1.6.4: `https://ucp.dev/{VERSION}/...` (pinned at the
 		//           canonical docs site + OpenAPI schema)
-		//   - 1.9.0: merchant-extension capability URLs are
-		//           SELF-HOSTED (on the merchant site, not ucp.dev) —
-		//           they don't fit the version-pin rule because they
-		//           always describe the CURRENT plugin version rather
-		//           than a fixed UCP protocol revision.
+		//   - Self-hosted extension (this PR): merchant-extension
+		//           capability URLs are served from the merchant site
+		//           (not ucp.dev) — they don't fit the version-pin
+		//           rule because they always describe the CURRENT
+		//           plugin version rather than a fixed UCP protocol
+		//           revision.
 		//
 		// This test locks in the canonical-capability shape: all UCP
 		// `dev.ucp.*` URLs use `ucp.dev/{PROTOCOL_VERSION}/`. Extension


### PR DESCRIPTION
## Summary

Addresses UCP manifest-validator warnings that our `com.woocommerce.ai_syndication` extension capability lacked discovery URLs. Routes are **self-hosted** (served from the merchant site, not GitHub or a third-party registry) following the same pattern as the manifest itself (`/.well-known/ucp`) and llms.txt (`/llms.txt`).

## Why self-hosted

| Concern | Resolution |
|---------|-----------|
| Schema/runtime drift | Merchant-hosted → the schema always describes the version the site is actually running |
| Permission parity | Merchant access-control applies uniformly — no third-party leak vector |
| External dependency | No GitHub outage / repo-visibility change can break agent integrations |
| Private repos | The plugin repo is private; GitHub URLs would 404 for consuming agents |

## What's new

### 1. REST route: `GET /wp-json/wc/ucp/v1/extension/schema`

Returns a JSON Schema document describing the extension capability shape. Public (same as the other `/wc/ucp/v1/*` routes). Response is `Content-Type: application/schema+json` with a 1-hour cache header.

### 2. `## UCP Extension: com.woocommerce.ai_syndication` in llms.txt

New section (anchored at `#ucp-extension`) documenting:
- `config.store_context` — currency, locale, country, prices_include_tax, shipping_enabled
- `config.attribution` — system, parameters, usage_note
- Product-level `ratings` payload
- Explicit note that `barcodes` is NOT under this extension (it's core UCP variant field)

### 3. Manifest update

Extension capability gains `spec` + `schema` URLs:

```php
'com.woocommerce.ai_syndication' => [[
    'spec'   => home_url( '/llms.txt#ucp-extension' ),
    'schema' => rest_url( 'wc/ucp/v1/extension/schema' ),
    // ... existing fields ...
]]
```

## Separate finding from this audit

While auditing the UCP core schema for this PR, I found we're emitting several fields under custom names that UCP has first-class core support for:

- `variant.compare_at_price` → should be core `variant.list_price`
- `extensions.ratings` → should be core `product.rating` (with `{value, scale_max}` shape)
- `categories[{taxonomy:"tag"}]` → should be core `product.tags[]` (flat array)
- `product.attributes` → should be core `product.options[]`
- `variant.shipping_attributes` → should be core `variant.metadata.shipping_attributes`

**Deferred to a separate PR F** — it's a breaking change warranting its own v2.0.0 release with a deprecation cycle for old field names. This PR stays focused on the extension docs.

## Test plan

- [x] 500 PHPUnit tests pass (+10 new covering route registration, handler output, schema shape, llms.txt section, manifest URLs)
- [x] PHPCS + PHPStan strict clean
- [x] `make-pot` regenerated
- [x] Existing invariants updated: route count (3 → 4), version-pin exception for extension namespace

### Manual verification (post-merge, live site)

- [ ] `curl https://SITE/.well-known/ucp` includes `spec` + `schema` URLs on the extension capability
- [ ] `curl https://SITE/wp-json/wc/ucp/v1/extension/schema` returns a valid JSON Schema document
- [ ] `curl https://SITE/llms.txt` contains `## UCP Extension: com.woocommerce.ai_syndication` section
- [ ] UCP manifest validator warnings for missing spec/schema on extension capability clear