### PR TITLE
Drop `config.attribution` from the UCP merchant extension

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -509,7 +509,7 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = '<a id="ucp-extension"></a>';
 		$lines[] = '## UCP Extension: com.woocommerce.ai_syndication';
 		$lines[] = '';
-		$lines[] = 'The UCP manifest at `/.well-known/ucp` advertises a merchant-extension capability `com.woocommerce.ai_syndication` alongside the canonical `dev.ucp.shopping.*` capabilities. It carries commerce context (currency, locale, tax/shipping posture) agents need before calling the catalog or checkout endpoints, plus attribution conventions for crediting agent-driven orders.';
+		$lines[] = 'The UCP manifest at `/.well-known/ucp` advertises a merchant-extension capability `com.woocommerce.ai_syndication` alongside the canonical `dev.ucp.shopping.*` capabilities. It carries commerce context (currency, locale, tax/shipping posture) agents need before calling the catalog or checkout endpoints. Attribution is handled entirely server-side by our `POST /checkout-sessions` endpoint — see the "Attribution" section earlier in this document for details, no extension field is needed.';
 		$lines[] = '';
 		$lines[] = 'Machine-readable JSON Schema:';
 		$lines[] = '';
@@ -522,12 +522,6 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = '- **country** — ISO 3166-1 alpha-2 for the merchant base country. `null` when not configured.';
 		$lines[] = '- **prices_include_tax** — `true` (EU-typical) means catalog prices are tax-inclusive; `false` (US-typical) means tax is added at checkout. Agents rendering cart previews use this to decide whether to show a tax line.';
 		$lines[] = '- **shipping_enabled** — `true` when the store collects shipping addresses. `false` means digital-only — skip address-collection prompts.';
-		$lines[] = '';
-		$lines[] = '### config.attribution';
-		$lines[] = '';
-		$lines[] = '- **system** — identifier of the attribution system recording agent-originated orders (currently `woocommerce_order_attribution`).';
-		$lines[] = '- **parameters** — documented UTM-style parameters (`utm_source`, `utm_medium`, etc.) the store recognizes.';
-		$lines[] = '- **usage_note** — preferred attribution path. For this plugin: use `POST /wp-json/wc/ucp/v1/checkout-sessions`; the server injects UTM values server-side based on your `UCP-Agent` header. Manual UTM construction on the agent side is a fallback, not the preferred path.';
 		$lines[] = '';
 		$lines[] = '### Product-level extension payload';
 		$lines[] = '';

--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -156,19 +156,12 @@ class WC_AI_Syndication_Ucp {
 	 *     WooCommerce's native Shareable Checkout flow. Merchants
 	 *     keep ownership of payment, tax, fulfillment.
 	 *
-	 * Service-level `config` preserves the purchase-URL templates and
-	 * attribution guidance we emitted pre-1.3.0. Agents that consume
-	 * our UCP endpoints rarely need these — our checkout-sessions
-	 * handler assembles the final URL itself — but the config is
-	 * still useful documentation for merchants and for agents that
-	 * want to construct checkout URLs directly without the UCP round
-	 * trip. UCP schema permits `config` as additionalProperties on
-	 * any entity, so strict consumers ignore it gracefully.
-	 *
-	 * A sibling `store_context` object declares merchant-level
+	 * The merchant extension capability `com.woocommerce.ai_syndication`
+	 * sits alongside the canonical `dev.ucp.shopping.*` capabilities and
+	 * declares a single `config.store_context` block — merchant-level
 	 * context (currency, locale, country, tax/shipping posture) so
 	 * agents know what currency they'll be quoting in and whether
-	 * the catalog price matches the checkout price — without having
+	 * the catalog price matches the checkout price, without having
 	 * to either fetch llms.txt first or call the Store API. Added in
 	 * 1.4.5 in response to cross-agent review feedback that surfaced
 	 * this as the dominant manifest-level gap. See
@@ -191,36 +184,20 @@ class WC_AI_Syndication_Ucp {
 	public function generate_manifest( $settings ) {
 		$ucp_endpoint = rest_url( 'wc/ucp/v1' );
 
-		// Attribution conventions for the WooCommerce Order
-		// Attribution system. Used to document the UTM parameter
-		// contract so merchant analytics segment AI-sourced orders
-		// consistently. Canonical guidance lives in llms.txt (the
-		// human-readable document) per spec-discipline: UCP doesn't
-		// define attribution semantics, so machine-readable hint
-		// here must not pretend to be canonical — it's merchant
-		// metadata, hence the `com.woocommerce.*` extension home.
-		//
-		// Purchase URL templates (checkout_link, add_to_cart) that
-		// lived here before 1.6.5 were removed. The canonical UCP
-		// checkout path is the `POST /checkout-sessions` API: agents
-		// send line items, the server constructs the continue_url
-		// (with these UTM parameters pre-attached from the
-		// UCP-Agent header), and returns `status: requires_escalation`.
-		// Client-side URL construction from templates was the "less
-		// preferred" path per the UCP spec's SHOULD directive on
-		// business-provided continue_url. Spec-strict agents use
-		// the API; legacy path is documented in llms.txt only.
-		$attribution_config = [
-			'spec'       => 'https://woocommerce.com/document/order-attribution-tracking/',
-			'system'     => 'woocommerce_order_attribution',
-			'parameters' => [
-				'utm_source'    => 'Your agent identifier (e.g. chatgpt, gemini, perplexity)',
-				'utm_medium'    => 'Must be set to "ai_agent"',
-				'utm_campaign'  => 'Optional campaign name',
-				'ai_session_id' => 'Conversation/session identifier for tracking',
-			],
-			'usage_note' => 'The UCP /checkout-sessions endpoint adds utm_source + utm_medium automatically from the UCP-Agent header. See llms.txt for the canonical agent-attribution flow.',
-		];
+		// Attribution used to be advertised here as an extension
+		// config block (`config.attribution`) so agents could read
+		// UTM parameter conventions off the manifest. Removed: the
+		// attribution contract is entirely server-side — the
+		// `POST /checkout-sessions` endpoint constructs a
+		// `continue_url` with `utm_source` + `utm_medium=ai_agent`
+		// pre-attached from the `UCP-Agent` header, so agents don't
+		// need to read or replicate the UTM schema to be correctly
+		// attributed. The human-readable attribution flow (including
+		// the hostname→brand mapping table and the fallback URL
+		// templates for non-UCP flows) still lives in llms.txt.
+		// Duplicating it under a machine-readable key encouraged
+		// agents to construct URLs client-side — the exact path the
+		// UCP spec's `continue_url` directive steers away from.
 
 		// Base docs URL for the version-pinned ucp.dev spec site.
 		// All `spec` and `schema` URLs route through the same
@@ -314,9 +291,10 @@ class WC_AI_Syndication_Ucp {
 
 					// Merchant-specific extension capability. Carries
 					// commerce context (currency, locale, tax/shipping
-					// posture) and attribution conventions that UCP
-					// doesn't define but agents benefit from knowing
-					// upfront. Uses the spec-defined extension pattern
+					// posture) that UCP doesn't define but agents benefit
+					// from knowing upfront — currency for price quoting,
+					// tax/shipping posture so quoted totals don't
+					// mislead. Uses the spec-defined extension pattern
 					// (`extends` pointing at a parent service/capability)
 					// rather than a root-level custom field — this
 					// is the idiomatic UCP home for vendor-specific
@@ -357,7 +335,6 @@ class WC_AI_Syndication_Ucp {
 								: '/wp-json/wc/ucp/v1/extension/schema',
 							'config'  => [
 								'store_context' => $this->build_store_context(),
-								'attribution'   => $attribution_config,
 							],
 						],
 					],

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -1034,31 +1034,6 @@ class WC_AI_Syndication_UCP_REST_Controller {
 								],
 							],
 						],
-						'attribution'   => [
-							'type'        => 'object',
-							'description' => 'How the merchant wants agent-driven orders attributed. Agents should pass these UTM parameters through the `continue_url` on checkout handoff.',
-							'properties'  => [
-								'spec'       => [
-									'type'        => 'string',
-									'format'      => 'uri',
-									'description' => 'URL to the upstream attribution system documentation.',
-								],
-								'system'     => [
-									'type'        => 'string',
-									'description' => 'Identifier of the attribution system recording agent-originated orders.',
-									'examples'    => [ 'woocommerce_order_attribution' ],
-								],
-								'parameters' => [
-									'type'                 => 'object',
-									'description'          => 'Named description of each expected UTM-style parameter.',
-									'additionalProperties' => [ 'type' => 'string' ],
-								],
-								'usage_note' => [
-									'type'        => 'string',
-									'description' => 'Human-readable guidance on the preferred attribution path (typically: use the UCP `/checkout-sessions` endpoint, which handles UTM injection server-side).',
-								],
-							],
-						],
 					],
 				],
 				'ratings' => [

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-20T19:54:28+00:00\n"
+"POT-Creation-Date: 2026-04-20T20:03:43+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -114,94 +114,94 @@ msgid "Total excludes tax and shipping, which are calculated at the merchant che
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1513
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1488
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1584
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1559
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1600
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1575
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1627
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1602
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1660
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1635
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1696
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1671
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1722
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1697
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1767
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1742
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1792
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1767
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1869
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1844
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2393
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2368
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2544
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2519
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2548
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2523
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2552
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2527
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2554
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2529
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2556
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2531
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2560
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2535
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2562
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2537
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -698,6 +698,22 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		}
 	}
 
+	public function test_llms_txt_extension_section_does_not_document_attribution_subkey(): void {
+		// Attribution is covered by the main "Attribution for AI
+		// agents" section earlier in the document (hostname→brand
+		// table + fallback URL templates). The extension section
+		// itself should NOT carry a `### config.attribution`
+		// sub-heading — the machine-readable `config.attribution`
+		// block was removed from the manifest because server-side
+		// `continue_url` already injects utm_source + utm_medium,
+		// and duplicating UTM conventions here implied the manifest
+		// was the canonical source when it wasn't. If a future
+		// refactor re-adds this heading, this test fires.
+		$output = $this->llms->generate();
+
+		$this->assertStringNotContainsString( '### config.attribution', $output );
+	}
+
 	public function test_wp_core_sitemap_included_when_non_empty(): void {
 		// `get_sitemap_url( 'index' )` returns WP core's canonical
 		// sitemap URL when the feature is active. That candidate

--- a/tests/php/unit/UcpRestControllerTest.php
+++ b/tests/php/unit/UcpRestControllerTest.php
@@ -230,6 +230,29 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 		$this->assertArrayHasKey( 'shipping_enabled', $store_context );
 	}
 
+	public function test_extension_schema_does_not_document_attribution(): void {
+		// Attribution is handled server-side by the /checkout-sessions
+		// endpoint (utm_source + utm_medium are injected into the
+		// continue_url from the UCP-Agent header). Duplicating that
+		// contract under a machine-readable `config.attribution` key
+		// encouraged agents to construct checkout URLs client-side —
+		// the exact path the UCP spec steers away from. If a future
+		// change re-adds attribution here, this test fires and forces
+		// a re-review: does the new data genuinely need a schema home,
+		// or is it already covered by the runtime contract?
+		\Brain\Monkey\Functions\when( 'rest_url' )->alias(
+			static fn( string $p ): string => 'https://example.com/wp-json/' . ltrim( $p, '/' )
+		);
+
+		$controller = new WC_AI_Syndication_UCP_REST_Controller();
+		$response   = $controller->handle_extension_schema();
+		$data       = $response->get_data();
+
+		$config_props = $data['properties']['config']['properties'];
+		$this->assertArrayNotHasKey( 'attribution', $config_props );
+		$this->assertSame( [ 'store_context' ], array_keys( $config_props ) );
+	}
+
 	public function test_extension_schema_documents_ratings_payload(): void {
 		// Products emit `ratings` under the extension namespace
 		// (`extensions.com.woocommerce.ai_syndication.ratings`) — the

--- a/tests/php/unit/UcpTest.php
+++ b/tests/php/unit/UcpTest.php
@@ -14,9 +14,10 @@
  *   2. Pull-model posture — zero capabilities, zero payment_handlers.
  *      This is the plugin's core product decision (no delegated checkout,
  *      no identity linking, no agent-driven order flows).
- *   3. Plugin-specific config — the purchase_urls and attribution nested
- *      inside service.config. Permissive by design (UCP allows it), but
- *      agents that learn our namespace depend on the shape.
+ *   3. Plugin-specific config — the `store_context` nested inside
+ *      the `com.woocommerce.ai_syndication` extension capability.
+ *      Permissive by design (UCP allows it), but agents that learn
+ *      our namespace depend on the shape.
  *
  * @package WooCommerce_AI_Syndication
  */
@@ -301,8 +302,12 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// which argued against keeping the template library here.
 		//
 		// Post-1.6.5, the checkout capability is canonical UCP only.
-		// Merchant-specific attribution + store_context lives in
-		// the `com.woocommerce.ai_syndication` extension capability.
+		// Merchant-specific `store_context` lives in the
+		// `com.woocommerce.ai_syndication` extension capability;
+		// attribution was subsequently dropped from the extension
+		// too (the server-side `continue_url` injects UTM values
+		// from the UCP-Agent header, making a machine-readable
+		// attribution block redundant with the live contract).
 		$manifest = $this->ucp->generate_manifest( [] );
 		$binding  = $manifest['ucp']['capabilities']['dev.ucp.shopping.checkout'][0];
 
@@ -361,8 +366,8 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		// Regression guard on the exact capability set:
 		//   - 3 canonical UCP capabilities we implement
 		//     (catalog.search, catalog.lookup, checkout)
-		//   - 1 merchant-specific extension carrying store_context +
-		//     attribution (com.woocommerce.ai_syndication)
+		//   - 1 merchant-specific extension carrying store_context
+		//     only (com.woocommerce.ai_syndication)
 		//
 		// Extensions use the `extends` field to link back to the
 		// parent capability/service; canonical capabilities have
@@ -447,13 +452,17 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 	// pointing at a parent). The five store_context contract fields
 	// are unchanged; only the path in the manifest changed.
 	//
-	// The extension also now carries attribution guidance (moved
-	// from the checkout capability's config in the same release).
+	// 1.6.5 also parked an `attribution` config block under the same
+	// extension capability; it was later removed once the server-side
+	// `continue_url` attribution contract was deemed sufficient
+	// (utm_source + utm_medium are injected by the `/checkout-sessions`
+	// endpoint, so agents don't need to read UTM conventions off the
+	// manifest). `store_context` is the sole remaining config key.
 
 	/**
-	 * Resolve the extension's config block for store_context / attribution
-	 * tests. Pre-1.6.5 this was `$manifest['store_context']`; post-1.6.5
-	 * it's `$manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config']['store_context']`.
+	 * Resolve the extension's config.store_context block. Pre-1.6.5
+	 * this was `$manifest['store_context']`; post-1.6.5 it's
+	 * `$manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config']['store_context']`.
 	 */
 	private function get_store_context(): array {
 		$manifest = $this->ucp->generate_manifest( [] );
@@ -633,33 +642,30 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// Layer 3: com.woocommerce.ai_syndication extension — attribution
+	// Layer 3: checkout capability + extension-config posture
 	// ------------------------------------------------------------------
 	//
-	// 1.6.5 structural change rationale:
-	//   - Pre-1.6.5 attribution config lived at
-	//     `capabilities["dev.ucp.shopping.checkout"][0].config.attribution`
-	//   - Post-1.6.5 it lives at
-	//     `capabilities["com.woocommerce.ai_syndication"][0].config.attribution`
+	// Historical sweep:
+	//   - Pre-1.6.5 the checkout capability carried a `config` block
+	//     with purchase-URL templates + attribution guidance. Both
+	//     were moved out in 1.6.5: URL templates went to llms.txt
+	//     only (canonical flow is POST /checkout-sessions), and
+	//     attribution moved into the com.woocommerce.ai_syndication
+	//     extension as `config.attribution`.
+	//   - A later sweep removed extension `config.attribution`
+	//     entirely. The attribution contract is server-side: our
+	//     `/checkout-sessions` endpoint injects utm_source +
+	//     utm_medium into the `continue_url` based on the UCP-Agent
+	//     header, so agents don't need to read UTM conventions
+	//     off the manifest. llms.txt still carries the human-
+	//     readable attribution narrative (hostname→brand table,
+	//     fallback URL templates for non-UCP flows).
 	//
-	// The canonical checkout capability stays pure UCP (no
-	// attribution config). Attribution conventions are merchant-
-	// specific (UCP doesn't define the attribution schema), so
-	// they belong in the extension capability. llms.txt carries
-	// the canonical human-readable guidance; the extension config
-	// is the machine-readable mirror.
-	//
-	// The purchase_urls test suite (11 tests total from 1.3.x)
-	// was removed in 1.6.5 because the URL templates themselves
-	// were removed — the canonical UCP checkout path is now the
-	// POST /checkout-sessions API, and template-based direct URL
-	// construction is documented only in llms.txt for agents that
-	// cannot use the API.
-
-	private function get_attribution(): array {
-		$manifest = $this->ucp->generate_manifest( [] );
-		return $manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config']['attribution'];
-	}
+	// The tests below guard the two resulting invariants:
+	//   - `dev.ucp.shopping.checkout` has no `config` block at all.
+	//   - `com.woocommerce.ai_syndication.config` only carries
+	//      `store_context` — no `attribution`, no UTM schema,
+	//      no purchase URL templates.
 
 	public function test_checkout_capability_has_no_purchase_urls_after_1_6_5(): void {
 		// Regression guard for the 1.6.5 removal. If any future
@@ -673,44 +679,21 @@ class UcpTest extends \PHPUnit\Framework\TestCase {
 		$this->assertArrayNotHasKey( 'config', $binding );
 	}
 
-	public function test_attribution_declares_woocommerce_order_attribution_system(): void {
-		// The plugin's attribution strategy is "use WC's built-in
-		// system" — not a custom invention. The `system` field makes
-		// that explicit for agents that want to verify.
-		$this->assertSame( 'woocommerce_order_attribution', $this->get_attribution()['system'] );
-	}
+	public function test_extension_config_contains_only_store_context(): void {
+		// After dropping `config.attribution`, the only remaining
+		// config key under the extension capability should be
+		// `store_context`. If a future refactor adds another
+		// machine-readable config block here, this test fires and
+		// forces a re-review: does it truly belong under a merchant-
+		// specific extension, or should it go in llms.txt narrative
+		// (the usual home for things UCP doesn't define)? Catches
+		// accidental reintroduction of attribution or sibling blocks
+		// that duplicate server-side contracts.
+		$manifest = $this->ucp->generate_manifest( [] );
+		$config   = $manifest['ucp']['capabilities']['com.woocommerce.ai_syndication'][0]['config'];
 
-	public function test_attribution_exposes_required_utm_parameters(): void {
-		$attr = $this->get_attribution();
-
-		foreach ( [ 'utm_source', 'utm_medium', 'utm_campaign', 'ai_session_id' ] as $required ) {
-			$this->assertArrayHasKey( $required, $attr['parameters'] );
-		}
-	}
-
-	public function test_attribution_utm_medium_documents_required_value(): void {
-		// utm_medium MUST be "ai_agent" for the PHP-side detector to
-		// capture the order. Document that in the param description
-		// so agents know it's not free-form.
-		$this->assertStringContainsString(
-			'ai_agent',
-			$this->get_attribution()['parameters']['utm_medium']
-		);
-	}
-
-	public function test_attribution_spec_points_to_wc_order_attribution_docs(): void {
-		$this->assertSame(
-			'https://woocommerce.com/document/order-attribution-tracking/',
-			$this->get_attribution()['spec']
-		);
-	}
-
-	public function test_attribution_usage_note_points_to_llms_txt_for_canonical_flow(): void {
-		// 1.6.5: the canonical human-readable attribution guidance
-		// lives in llms.txt, not in the UCP manifest. The usage_note
-		// should direct readers there rather than duplicating the
-		// full narrative.
-		$this->assertStringContainsString( 'llms.txt', $this->get_attribution()['usage_note'] );
+		$this->assertSame( [ 'store_context' ], array_keys( $config ) );
+		$this->assertArrayNotHasKey( 'attribution', $config );
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Removes the `config.attribution` block from the `com.woocommerce.ai_syndication` extension capability. Attribution is entirely server-side now — `POST /checkout-sessions` injects `utm_source` (mapped from the `UCP-Agent` header via `KNOWN_AGENT_HOSTS`) and `utm_medium=ai_agent` into the returned `continue_url`, so agents get attributed for free just by redirecting the user to the URL we hand back. No manual UTM construction, no manifest lookup required.

## Why

`config.attribution` duplicated the server-side contract as a machine-readable spec, which:

1. **Implied the manifest was canonical.** It wasn't — the canonical source is whatever `build_continue_url()` actually emits. A merchant reading "parameters: `utm_campaign`" from the manifest might reasonably expect agents to pass it through, but the server-side path never appended `utm_campaign` in the first place.
2. **Pushed agents toward client-side URL construction.** The UCP spec's `continue_url` directive prefers business-provided redirect URLs; advertising a UTM schema encouraged agents to build their own URLs instead of trusting the one the endpoint returns.
3. **Wasn't actionable without code anyway.** `ai_session_id` was documented as an agent-passable param but is read from `$_GET` at checkout-complete time — agents would need plugin-specific knowledge to use it productively, not a schema entry.

`config.store_context` stays — currency/locale/country/prices-include-tax/shipping-enabled are merchant facts agents need BEFORE calling catalog/checkout (to know what currency they'll be quoting in and whether shipping prompts are needed), not reconstructable from any runtime response.

llms.txt still carries the canonical human-readable attribution flow — hostname→brand table, fallback URL templates for non-UCP integrations. That's unchanged.

## Diff shape

```
capabilities:
  com.woocommerce.ai_syndication:
    - version: ...
      extends: dev.ucp.shopping
      spec:    {home}/llms.txt#ucp-extension
      schema:  {rest}/wc/ucp/v1/extension/schema
      config:
-       attribution: { spec, system, parameters, usage_note }
        store_context: { ... }
```

Three surfaces updated in lockstep so the manifest, the human-readable docs, and the JSON Schema all agree:

- `class-wc-ai-syndication-ucp.php` — drop the `$attribution_config` var and the `'attribution' =>` entry from `config`.
- `class-wc-ai-syndication-llms-txt.php` — drop the `### config.attribution` sub-heading from the UCP extension section; update the section intro to note attribution is server-side.
- `class-wc-ai-syndication-ucp-rest-controller.php` — drop the `attribution` property block from `handle_extension_schema()`.

## Regression guards added

Three new tests, one per surface, so this can't drift back:

- `UcpTest::test_extension_config_contains_only_store_context` — asserts `config` keys are exactly `[store_context]` and `attribution` is not present.
- `UcpRestControllerTest::test_extension_schema_does_not_document_attribution` — asserts the JSON Schema for `config.properties` doesn't carry `attribution`.
- `LlmsTxtTest::test_llms_txt_extension_section_does_not_document_attribution_subkey` — asserts the generated llms.txt doesn't contain `### config.attribution`.

## Test plan
- [x] `composer test` — 509 tests, 1491 assertions, all pass
- [x] `vendor/bin/phpcs` — clean (no errors, no warnings)
- [x] `vendor/bin/phpstan analyse` — clean
- [x] `./bin/make-pot.sh` regenerated
- [ ] CI green on all jobs
- [ ] Manifest still validates against UCP `business_profile` schema

🤖 Generated with [Claude Code](https://claude.com/claude-code)