### PR TITLE
Add spec-expected metadata fields (status, timestamps, seller, expires_at)

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-ucp.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-ucp.php
@@ -402,9 +402,17 @@ class WC_AI_Syndication_Ucp {
 	 * @return array The store context block.
 	 */
 	private function build_store_context() {
-		$country = null;
-		if ( function_exists( 'WC' ) && WC() && method_exists( WC(), 'countries' ) && WC()->countries ) {
-			$country = WC()->countries->get_base_country();
+		// `countries` is a PROPERTY on the WooCommerce singleton (an
+		// instance of WC_Countries), not a method — a `method_exists`
+		// check would always return false. Guard via `isset()` on the
+		// property to pick up the country when WC is fully loaded
+		// and fall through gracefully otherwise (tests, early boot,
+		// WC-deactivated state). Same pattern as build_seller() in
+		// the REST controller — kept in sync deliberately.
+		$country     = null;
+		$woocommerce = function_exists( 'WC' ) ? WC() : null;
+		if ( $woocommerce && isset( $woocommerce->countries ) && is_object( $woocommerce->countries ) ) {
+			$country = $woocommerce->countries->get_base_country();
 		}
 
 		// `get_locale()` returns ICU format (e.g. `en_US`). BCP 47

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-product-translator.php
@@ -55,9 +55,14 @@ class WC_AI_Syndication_UCP_Product_Translator {
 	 * @param array<int, array<string, mixed>> $wc_variations Optional pre-fetched Store API
 	 *                                                        variation responses. Empty = fall
 	 *                                                        back to synthesized default.
+	 * @param array<string, mixed>|null        $seller        Optional seller block to copy onto
+	 *                                                        every product. Same for every product
+	 *                                                        in a request, so the controller
+	 *                                                        computes it once and passes it in —
+	 *                                                        keeps the translator WP-unaware.
 	 * @return array<string, mixed>                           UCP product shape.
 	 */
-	public static function translate( array $wc_product, array $wc_variations = [] ): array {
+	public static function translate( array $wc_product, array $wc_variations = [], ?array $seller = null ): array {
 		$id = (int) ( $wc_product['id'] ?? 0 );
 
 		$product = [
@@ -67,6 +72,34 @@ class WC_AI_Syndication_UCP_Product_Translator {
 			'price_range' => self::extract_price_range( $wc_product ),
 			'variants'    => self::extract_variants( $wc_product, $wc_variations ),
 		];
+
+		// Spec metadata fields — additive, non-breaking.
+		//
+		// `status` is a fixed literal "published": our catalog handlers
+		// only emit products returned by the Store API, which already
+		// filters to published (we don't syndicate drafts/private).
+		// Emitting the key anyway communicates the posture to agents
+		// so "why didn't I find product X?" is traceable back to
+		// "its status isn't in your result set".
+		$product['status'] = 'published';
+
+		// `published_at` / `updated_at` — ISO 8601 timestamps from the
+		// Store API. Older WC versions emit a `{raw, format_to_edit}`
+		// object; 9.5+ emits the ISO string directly. Coerce both.
+		$timestamps = self::extract_timestamps( $wc_product );
+		if ( isset( $timestamps['published_at'] ) ) {
+			$product['published_at'] = $timestamps['published_at'];
+		}
+		if ( isset( $timestamps['updated_at'] ) ) {
+			$product['updated_at'] = $timestamps['updated_at'];
+		}
+
+		// Seller — controller-computed once per request (same for every
+		// product in a single-merchant store). Spec-expected even for
+		// single-merchant plugins; omitting it fails strict validators.
+		if ( null !== $seller && ! empty( $seller ) ) {
+			$product['seller'] = $seller;
+		}
 
 		// Optional fields — only emit when source has a non-empty value.
 		if ( ! empty( $wc_product['slug'] ) ) {
@@ -158,6 +191,54 @@ class WC_AI_Syndication_UCP_Product_Translator {
 		return [
 			WC_AI_Syndication_UCP_Variant_Translator::synthesize_default( $wc_product ),
 		];
+	}
+
+	/**
+	 * Extract `published_at` / `updated_at` ISO 8601 timestamps from a
+	 * WC Store API product response.
+	 *
+	 * Shape drift across WC versions:
+	 *   - WC 9.5+ emits `date_created` / `date_modified` as ISO 8601
+	 *     strings directly (e.g. `"2026-04-20T10:00:00"`).
+	 *   - Older WC versions (≤ 9.4 on some configurations) emit an
+	 *     object `{raw: "...", format_to_edit: "..."}` where `raw`
+	 *     carries the MySQL datetime. Not ISO 8601, but close enough
+	 *     that agents parsing it with a lenient date parser won't break.
+	 *
+	 * We accept both shapes and return the best representation available.
+	 * Agents get whichever form the source emits — if the `raw` variant
+	 * is MySQL datetime (space-separated), it's still monotonically
+	 * comparable for "is this newer than my last sync?", which is the
+	 * primary use case.
+	 *
+	 * Returns an array with keys `published_at` / `updated_at` only
+	 * when the corresponding source field is present and non-empty.
+	 *
+	 * @param array<string, mixed> $wc_product
+	 * @return array{published_at?: string, updated_at?: string}
+	 */
+	private static function extract_timestamps( array $wc_product ): array {
+		$map = [
+			'date_created'  => 'published_at',
+			'date_modified' => 'updated_at',
+		];
+
+		$out = [];
+		foreach ( $map as $wc_key => $ucp_key ) {
+			$raw = $wc_product[ $wc_key ] ?? null;
+
+			// Object form — prefer `raw` (MySQL datetime), fall back
+			// to `format_to_edit` which is the same value formatted.
+			if ( is_array( $raw ) ) {
+				$raw = $raw['raw'] ?? ( $raw['format_to_edit'] ?? null );
+			}
+
+			if ( is_string( $raw ) && '' !== $raw ) {
+				$out[ $ucp_key ] = $raw;
+			}
+		}
+
+		return $out;
 	}
 
 	/**

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -494,8 +494,15 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			),
 		];
 
-		if ( function_exists( 'WC' ) && WC() && method_exists( WC(), 'countries' ) && WC()->countries ) {
-			$country = WC()->countries->get_base_country();
+		// `countries` is a PROPERTY on the WooCommerce singleton (an
+		// instance of WC_Countries), not a method — `method_exists`
+		// would always return false here. Guard via `isset()` on the
+		// property so we correctly pick up the country when WC is
+		// fully loaded, and fall through gracefully when it isn't
+		// (tests, early-boot paths, WC plugin-deactivated state).
+		$woocommerce = function_exists( 'WC' ) ? WC() : null;
+		if ( $woocommerce && isset( $woocommerce->countries ) && is_object( $woocommerce->countries ) ) {
+			$country = $woocommerce->countries->get_base_country();
 			if ( $country ) {
 				$seller['country'] = $country;
 			}

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -338,6 +338,13 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			);
 		}
 
+		// Compute the seller block once per request — it's identical
+		// for every product in a single-merchant store, and we don't
+		// want to re-read get_bloginfo() / WC()->countries on every
+		// product. Built here (not the translator) to keep the
+		// translator WP-unaware and testable without WP globals.
+		$seller = self::build_seller();
+
 		$products         = [];
 		$variant_messages = [];
 		foreach ( $wc_products as $wc_product ) {
@@ -353,7 +360,8 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			}
 			$products[] = WC_AI_Syndication_UCP_Product_Translator::translate(
 				$wc_product,
-				$variation_fetch['variations']
+				$variation_fetch['variations'],
+				$seller
 			);
 		}
 
@@ -447,6 +455,53 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		}
 
 		return $pagination;
+	}
+
+	/**
+	 * Build the `seller` block stamped on every emitted product.
+	 *
+	 * UCP core's `product.seller` is spec-expected even for single-
+	 * merchant stores — strict validators will reject a product
+	 * without it. For this plugin (single-merchant by posture), the
+	 * seller is the same for every product in a request, so we
+	 * compute it once and thread it through the translator rather
+	 * than re-reading WP globals per-product.
+	 *
+	 * Shape:
+	 *   - `name`    — `get_bloginfo('name')` stripped + entity-decoded
+	 *                  (same normalization the JSON-LD @graph uses so
+	 *                  the two surfaces agree on merchant display name)
+	 *   - `country` — ISO 3166-1 alpha-2 from WC's base country, or
+	 *                  omitted when not configured. Mirrors the
+	 *                  store_context.country logic exactly.
+	 *
+	 * Why not add an `id` — the UCP core shape allows seller.id but
+	 * we have no namespace-stable seller identifier (site URL could
+	 * work but changes with migrations; plugin is single-merchant
+	 * anyway so a distinguishing ID adds cost without value). If
+	 * this plugin ever grows multi-vendor support, seller.id becomes
+	 * required and the per-request compute-once pattern here
+	 * becomes per-product.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function build_seller(): array {
+		$seller = [
+			'name' => html_entity_decode(
+				wp_strip_all_tags( get_bloginfo( 'name' ) ),
+				ENT_QUOTES,
+				'UTF-8'
+			),
+		];
+
+		if ( function_exists( 'WC' ) && WC() && method_exists( WC(), 'countries' ) && WC()->countries ) {
+			$country = WC()->countries->get_base_country();
+			if ( $country ) {
+				$seller['country'] = $country;
+			}
+		}
+
+		return $seller;
 	}
 
 	/**
@@ -584,6 +639,10 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		$products = [];
 		$messages = [];
 
+		// Same single-merchant seller block as the search handler —
+		// computed once, stamped on every product (see handle_catalog_search).
+		$seller = self::build_seller();
+
 		foreach ( $ids as $index => $raw_id ) {
 			$wc_id = self::parse_ucp_id_to_wc_int( $raw_id );
 
@@ -614,7 +673,8 @@ class WC_AI_Syndication_UCP_REST_Controller {
 
 			$products[] = WC_AI_Syndication_UCP_Product_Translator::translate(
 				$wc_product,
-				$variation_fetch['variations']
+				$variation_fetch['variations'],
+				$seller
 			);
 		}
 
@@ -955,6 +1015,19 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			'line_items' => $response_line_items,
 			'totals'     => $response_totals,
 			'links'      => $links,
+
+			// Explicit `null` — not omission — because the UCP spec
+			// carries an optional `session.expires_at` field. Omitting
+			// it could be misread as either "I don't know the TTL" or
+			// "there's a bug here"; emitting `null` is the correct
+			// semantic for "this session has no TTL because it's
+			// stateless — no server-side state exists to expire".
+			// Every checkout-sessions POST is a fresh computation
+			// with no persistence, so there's no session lifetime to
+			// advertise. Strict UCP consumers key on the field's
+			// presence to distinguish stateless from stateful
+			// implementations.
+			'expires_at' => null,
 		];
 
 		if ( ! empty( $messages ) ) {

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-20T20:03:43+00:00\n"
+"POT-Creation-Date: 2026-04-20T20:33:45+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -65,8 +65,8 @@ msgid "The barcode value as stored by the merchant."
 msgstr ""
 
 #: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:247
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:535
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:700
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:590
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:760
 msgid "AI Syndication is not currently enabled on this store."
 msgstr ""
 
@@ -75,133 +75,133 @@ msgstr ""
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:548
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:603
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:558
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:613
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:576
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:631
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:711
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:771
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:721
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:781
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:865
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:925
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:884
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:944
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:922
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:982
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1488
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1561
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1559
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1632
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1575
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1648
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1602
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1675
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1635
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1708
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1671
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1744
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1697
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1770
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1742
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1815
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1767
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1840
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1844
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:1917
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2368
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2441
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2519
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2592
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2523
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2596
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2527
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2600
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2529
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2602
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2531
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2604
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2535
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2608
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2537
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php:2610
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -52,6 +52,14 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 			static fn( string $single, string $plural, int $number ): string => $number === 1 ? $single : $plural
 		);
 
+		// Default stub for `seller.name` in the seller block every
+		// product emits (see build_seller()). `wp_strip_all_tags` is
+		// covered by the bootstrap polyfill; `html_entity_decode` is
+		// a native PHP function that runs fine on the stubbed name.
+		Functions\when( 'get_bloginfo' )->alias(
+			static fn( string $key = '' ): string => 'name' === $key ? 'Example Store' : ''
+		);
+
 		// Stub the catalog_envelope dependency's PROTOCOL_VERSION
 		// access — UcpEnvelope reads WC_AI_Syndication_Ucp::PROTOCOL_VERSION,
 		// which is a const defined on the class and resolves fine at test

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -94,6 +94,16 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		);
 		Functions\when( 'wc_get_price_decimals' )->justReturn( 2 );
 
+		// Default stub for the `seller.name` in the seller block that
+		// every product emits (see build_seller()). `wp_strip_all_tags`
+		// and `html_entity_decode` aren't stubbed — the bootstrap
+		// polyfill covers the former, and html_entity_decode is a
+		// native PHP function that runs fine on the stubbed name.
+		// Tests that care about seller content can override in-body.
+		Functions\when( 'get_bloginfo' )->alias(
+			static fn( string $key = '' ): string => 'name' === $key ? 'Example Store' : ''
+		);
+
 		// Simplified sanitize_title stub with a slightly-stricter
 		// character class than default WP: we collapse underscores
 		// AND whitespace AND other non-alphanumerics to dashes. WP
@@ -317,6 +327,25 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 			'dev.ucp.shopping.catalog.search',
 			$body['ucp']['capabilities']
 		);
+	}
+
+	public function test_search_stamps_seller_name_on_every_product(): void {
+		// Integration test for the build_seller() thread-through:
+		// the controller computes seller once and passes it into
+		// each translate() call. We assert every product carries
+		// the same seller block — catching a regression where the
+		// threading accidentally drops or diverges across the loop.
+		$this->fake_product_list = [
+			$this->make_simple_product( 1, 'Alpha' ),
+			$this->make_simple_product( 2, 'Beta' ),
+		];
+
+		$body = $this->successful_search( [] );
+
+		foreach ( $body['products'] as $product ) {
+			$this->assertArrayHasKey( 'seller', $product );
+			$this->assertSame( 'Example Store', $product['seller']['name'] );
+		}
 	}
 
 	public function test_empty_result_returns_200_with_empty_products_array(): void {

--- a/tests/php/unit/UcpCheckoutSessionsTest.php
+++ b/tests/php/unit/UcpCheckoutSessionsTest.php
@@ -1592,6 +1592,42 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringNotContainsString( 'Array', $msg['content'] );
 	}
 
+	// ------------------------------------------------------------------
+	// Session metadata (PR G)
+	// ------------------------------------------------------------------
+
+	public function test_checkout_session_response_includes_expires_at_null(): void {
+		// Every checkout-sessions POST is stateless — no server-side
+		// state exists to expire. UCP's `session.expires_at` is
+		// spec-optional, but emitting `null` explicitly tells strict
+		// consumers "this implementation is stateless, not buggy".
+		// Omission would leave them guessing between the two.
+		$this->seed_simple_product( 111, 2500 );
+
+		$result = $this->call_handler(
+			[ 'line_items' => [ [ 'item' => [ 'id' => 'prod_111' ], 'quantity' => 1 ] ] ]
+		);
+
+		$this->assertArrayHasKey( 'expires_at', $result['data'] );
+		$this->assertNull( $result['data']['expires_at'] );
+	}
+
+	public function test_checkout_session_expires_at_null_on_invalid_requests_too(): void {
+		// Even on the `incomplete` branch (no valid items, or below-
+		// minimum totals) we still emit `expires_at: null` — the
+		// statelessness property is a structural invariant of the
+		// handler, not a feature of the happy path only. A strict
+		// consumer inspecting failure responses shouldn't have to
+		// branch on status to parse the envelope.
+		$result = $this->call_handler(
+			[ 'line_items' => [ [ 'item' => [ 'id' => 'prod_9999' ], 'quantity' => 1 ] ] ]
+		);
+
+		$this->assertSame( 'incomplete', $result['data']['status'] );
+		$this->assertArrayHasKey( 'expires_at', $result['data'] );
+		$this->assertNull( $result['data']['expires_at'] );
+	}
+
 	public function test_locale_boundary_lengths(): void {
 		// Regex: `^[A-Za-z]{2,8}(?:[-_][A-Za-z0-9]{1,8})*$` + 35-char cap.
 		// Boundaries worth pinning so a future refactor doesn't

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -655,4 +655,114 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertArrayNotHasKey( 'extensions', $result );
 	}
+
+	// ------------------------------------------------------------------
+	// Spec metadata fields (PR G)
+	// ------------------------------------------------------------------
+
+	public function test_translate_always_emits_status_published(): void {
+		// The handler upstream filters out draft/private products at
+		// the Store API layer, so anything we translate is by
+		// definition published. Emitting the `status` key explicitly
+		// communicates that posture to agents — otherwise they'd
+		// have no way to know whether missing products are drafts
+		// vs. out-of-stock vs. excluded-by-permission.
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[]
+		);
+
+		$this->assertSame( 'published', $result['status'] );
+	}
+
+	public function test_translate_emits_iso_timestamps_when_source_has_them(): void {
+		// WC 9.5+ emits ISO 8601 strings for date_created / date_modified.
+		// Pass them through verbatim — agents diff them against their
+		// last-sync cursor to skip unchanged products on re-crawl.
+		$fixture                  = $this->simple_product_fixture();
+		$fixture['date_created']  = '2026-01-15T10:30:00';
+		$fixture['date_modified'] = '2026-04-20T14:22:31';
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertSame( '2026-01-15T10:30:00', $result['published_at'] );
+		$this->assertSame( '2026-04-20T14:22:31', $result['updated_at'] );
+	}
+
+	public function test_translate_handles_older_wc_raw_date_object_shape(): void {
+		// Older WC versions emit `{raw, format_to_edit}` object form
+		// instead of a plain string. Accept both so the plugin works
+		// across the 9.x spread without gating on a minimum version.
+		// The `raw` key carries MySQL datetime (space-separated, not
+		// ISO 8601) — still monotonically comparable, which is all
+		// agents need for "has this changed?" checks.
+		$fixture                  = $this->simple_product_fixture();
+		$fixture['date_created']  = [ 'raw' => '2026-01-15 10:30:00', 'format_to_edit' => '2026-01-15 10:30:00' ];
+		$fixture['date_modified'] = [ 'raw' => '2026-04-20 14:22:31' ];
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate( $fixture, [] );
+
+		$this->assertSame( '2026-01-15 10:30:00', $result['published_at'] );
+		$this->assertSame( '2026-04-20 14:22:31', $result['updated_at'] );
+	}
+
+	public function test_translate_omits_timestamps_when_source_lacks_them(): void {
+		// Store API should always emit these, but the fixture-free
+		// translator is pure — don't synthesize fake timestamps if
+		// the input happens to lack them (e.g. a mocked response in
+		// a caller's integration test). Omission is valid per spec.
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[]
+		);
+
+		$this->assertArrayNotHasKey( 'published_at', $result );
+		$this->assertArrayNotHasKey( 'updated_at', $result );
+	}
+
+	public function test_translate_stamps_seller_when_passed(): void {
+		// Seller is computed once per request in the REST controller
+		// and threaded through. Same for every product in a single-
+		// merchant store, so passing via arg (not re-reading WP
+		// globals per product) keeps translation pure and fast.
+		$seller = [
+			'name'    => 'Example Store',
+			'country' => 'US',
+		];
+
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			$seller
+		);
+
+		$this->assertSame( $seller, $result['seller'] );
+	}
+
+	public function test_translate_omits_seller_when_not_passed(): void {
+		// Backward-compat — existing callers without the $seller arg
+		// keep working, just without seller emission. The REST
+		// controller now always passes it; this guards the public
+		// signature against accidental requirement-tightening.
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[]
+		);
+
+		$this->assertArrayNotHasKey( 'seller', $result );
+	}
+
+	public function test_translate_omits_seller_when_passed_empty(): void {
+		// An empty seller array behaves the same as omitting the arg.
+		// Covers the edge case where the controller's build_seller()
+		// returns [] (no site name set, no WC available) — we'd rather
+		// skip the key than emit `seller: {}`.
+		$result = WC_AI_Syndication_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			[]
+		);
+
+		$this->assertArrayNotHasKey( 'seller', $result );
+	}
 }


### PR DESCRIPTION
## Summary

Additive, non-breaking. Adds five spec-expected optional fields across catalog and checkout surfaces that strict UCP consumers look for but we weren't emitting. No existing agent integration breaks; new capabilities open up (stale-catalog diff via `updated_at`, stateless-session clarity via `expires_at: null`).

Queued as the first half of the UCP-alignment follow-up split we decided on — this is PR G (additive, 1.x), PR F (breaking rename migration, 2.0.0) follows next.

## What changes

### Product (catalog.search + catalog.lookup)

| Field | Source | Notes |
|---|---|---|
| `status` | Literal `"published"` | We only surface Store-API-published products anyway; advertising the filter posture prevents "why is product X missing?" confusion |
| `published_at` | `wc_product['date_created']` | ISO 8601 from Store API; accepts both 9.5+ string form and older `{raw, format_to_edit}` shape |
| `updated_at` | `wc_product['date_modified']` | Same shape handling |
| `seller` | `{name, country?}` | New `build_seller()` helper in the REST controller; computed once per request, threaded through translator |

### Checkout (create response)

| Field | Value |
|---|---|
| `expires_at` | `null` (explicit, not omitted) |

Emitted on both `requires_escalation` and `incomplete` branches — statelessness is a structural property of the handler, not a happy-path feature.

## Why these five

All spec-optional, but each has an agent-side consequence:

- **`updated_at`** → enables agents to skip unchanged products on re-sync. Without it, every crawl pays full catalog cost.
- **`status`** → communicates posture. An agent asking "why does WC say product ID 42 exists but your catalog doesn't?" can now see it's filtered-by-publish-status.
- **`seller`** → spec-required by strict validators even for single-merchant. Cheap to emit.
- **`published_at`** → paired with `updated_at` for time-windowed queries ("products new in the last 30 days").
- **`expires_at: null`** → disambiguates our stateless design from "bug in response envelope" for strict consumers.

## Signature extension

`Product_Translator::translate()` gains an optional third arg `$seller`:

```php
public static function translate( array $wc_product, array $wc_variations = [], ?array $seller = null ): array
```

Backward-compat — existing direct callers (no `$seller`) keep working; output just omits the `seller` key. Production call sites in the REST controller thread it through.

## `build_seller()` — why in the controller, not the translator

The translator is pure (no WP globals) by design — keeps it testable without stubbing WP's REST infrastructure. Seller data needs `get_bloginfo()` + `WC()->countries`, so it lives in the REST controller where WP context is already assumed. Computed once per request, not per product, since it's identical across a single-merchant store's catalog.

## Test plan
- [x] `composer test` — 519 tests (+10 new), 1514 assertions, all pass
- [x] `vendor/bin/phpcs` — clean (after `phpcbf` pass)
- [x] `vendor/bin/phpstan analyse` — no errors
- [x] `./bin/make-pot.sh` regenerated
- [ ] CI green on all jobs
- [ ] Verify `date_created` / `date_modified` shape on a live WC 9.5+ Store API response (string vs object)

## Tests added (10)

Translator (`UcpProductTranslatorTest`):
- `test_translate_always_emits_status_published`
- `test_translate_emits_iso_timestamps_when_source_has_them`
- `test_translate_handles_older_wc_raw_date_object_shape`
- `test_translate_omits_timestamps_when_source_lacks_them`
- `test_translate_stamps_seller_when_passed`
- `test_translate_omits_seller_when_not_passed`
- `test_translate_omits_seller_when_passed_empty`

Search handler (`UcpCatalogSearchTest`):
- `test_search_stamps_seller_name_on_every_product` (integration: controller threads seller through the translate loop)

Checkout handler (`UcpCheckoutSessionsTest`):
- `test_checkout_session_response_includes_expires_at_null`
- `test_checkout_session_expires_at_null_on_invalid_requests_too` (incomplete branch too)

## Follow-ups queued (not in this PR)

- **Runtime-verify Store API tag filter param** — same curl exercise as the brand verification. Our code handles `filters.tags[]` as first-class already; needs confirming that Store API's param name is `tag` (singular) to match our assumption.
- **PR F** (breaking, v2.0.0) — the rename migrations: `extensions.ratings` → core `product.rating`, `categories[{taxonomy:"tag"}]` → core `product.tags[]`, `attributes[]` → `options[]` + `metadata.attributes`, `variant.shipping_attributes` → `variant.metadata.shipping`, `variant.price` → `variant.list_price`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)