### PR TITLE
Cut llms.txt scope creep: Featured Products + URL-patterns

### DIFF
--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -258,15 +258,19 @@ class WC_AI_Syndication_Llms_Txt {
 
 		// API access. This plugin does NOT expose its own authenticated
 		// API — AI agents use WooCommerce's public Store API directly.
-		// The UCP manifest describes purchase URL templates and checkout
-		// policy in machine-readable form; agents that want structured
-		// data fetch that document.
+		// The UCP manifest describes capabilities + store_context in
+		// machine-readable form; agents that want structured data
+		// fetch that document.
+		//
+		// Description text kept tight — "purchase URL templates" was
+		// dropped from the manifest in 1.6.5, so advertising them here
+		// would be stale.
 		$lines[]   = '## API Access';
 		$lines[]   = '';
 		$store_api = rest_url( 'wc/store/v1' );
 		$ucp_url   = $site_url . '.well-known/ucp';
 		$lines[]   = "- **Store API**: `{$store_api}` — public WooCommerce Store API for product search and cart operations (no authentication required)";
-		$lines[]   = "- **Commerce Protocol Manifest**: `{$ucp_url}` — declares capabilities, checkout policy, and purchase URL templates";
+		$lines[]   = "- **Commerce Protocol Manifest**: `{$ucp_url}` — declares capabilities, checkout policy, and store_context (currency, locale, country, tax/shipping posture)";
 		$lines[]   = '';
 
 		// Sitemaps section. Surfaces exhaustive URL enumeration
@@ -308,20 +312,15 @@ class WC_AI_Syndication_Llms_Txt {
 			$lines[] = '';
 		}
 
-		// Featured/popular products.
-		$product_data = $this->get_featured_products( $settings );
-		if ( ! empty( $product_data['products'] ) ) {
-			$section_title   = $product_data['is_featured'] ? 'Featured Products' : 'Popular Products';
-			$lines[]         = "## {$section_title}";
-			$lines[]         = '';
-			$currency_symbol = html_entity_decode( get_woocommerce_currency_symbol(), ENT_QUOTES, 'UTF-8' );
-			foreach ( $product_data['products'] as $product ) {
-				$product_name = html_entity_decode( wp_strip_all_tags( $product->get_name() ), ENT_QUOTES, 'UTF-8' );
-				$price        = $currency_symbol . $product->get_price();
-				$lines[]      = "- [{$product_name}](" . $product->get_permalink() . ") - {$price}";
-			}
-			$lines[] = '';
-		}
+		// Featured/popular products section was removed in 2.0.1:
+		// a 5-product marketing teaser in a machine-readable agent
+		// document was scope creep — agents wanting products use the
+		// Store API (documented in `## API Access` above). Stale
+		// prices between llms.txt regenerations and edge cases like
+		// "Request a Quote" products (no numeric price → rendered as
+		// bare "$") made the section fragile for near-zero agent
+		// value. If we ever bring it back, it should be sourced from
+		// the Store API with a note about freshness expectations.
 
 		// Checkout policy declaration. Makes explicit the merchant-
 		// only-checkout posture that the UCP manifest already
@@ -427,72 +426,29 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = 'If your agent\'s hostname is missing and you\'d like a specific brand name applied, open an issue on the plugin\'s [GitHub repository](https://github.com/pierorocca/woocommerce-ai-syndication/issues) — additions are a single constant entry plus a test row.';
 		$lines[] = '';
 
-		$lines[] = 'If you must construct a checkout URL client-side (legacy or non-UCP-aware flow), append these parameters for order attribution:';
-		$lines[] = '';
-		$lines[] = '- `utm_source`: Your agent identifier (e.g. `ChatGPT`, `Gemini`, `Claude`, `Perplexity`, `Copilot`)';
-		$lines[] = '- `utm_medium`: `ai_agent`';
-		$lines[] = '- `utm_campaign`: Optional campaign name';
-		$lines[] = '- `ai_session_id`: The current conversation/session ID';
-		$lines[] = '';
-		$lines[] = 'These map to standard WooCommerce Order Attribution fields.';
-		$lines[] = '';
-
-		// URL-structure reference. Previously this section pointed
-		// readers at WooCommerce's public docs for URL construction
-		// patterns; that's one more fetch for every agent evaluating
-		// the store. Since the patterns are stable and short, inline
-		// them here so the llms.txt document is self-contained — one
-		// fetch, all the guidance. The templates use concrete
-		// placeholders (`{site_url}`, `{product_id}`, etc.) so
-		// string-replace-based URL construction works directly.
-		$lines[] = '### URL patterns for client-side construction';
-		$lines[] = '';
-		$lines[] = 'Two URL shapes work. The **Shareable Checkout URL** (`/checkout-link/`) is strongly preferred — it takes the buyer straight to checkout with the items pre-loaded, matching the UCP `continue_url` semantic. The legacy `?add-to-cart=` pattern adds to cart but still requires the buyer to navigate to checkout manually, and is only documented here as a compatibility fallback.';
-		$lines[] = '';
-		$lines[] = '**Shareable Checkout URL — single product:**';
-		$lines[] = '';
-		$lines[] = '```';
-		$lines[] = '{site_url}/checkout-link/?products={product_id}&utm_source={agent_name}&utm_medium=ai_agent';
-		$lines[] = '```';
-		$lines[] = '';
-		$lines[] = '**Shareable Checkout URL — product with quantity (format `{id}:{qty}`):**';
-		$lines[] = '';
-		$lines[] = '```';
-		$lines[] = '{site_url}/checkout-link/?products={product_id}:{quantity}&utm_source={agent_name}&utm_medium=ai_agent';
-		$lines[] = '```';
-		$lines[] = '';
-		$lines[] = '**Shareable Checkout URL — multiple products (comma-separated):**';
-		$lines[] = '';
-		$lines[] = '```';
-		$lines[] = '{site_url}/checkout-link/?products={id_a}:{qty_a},{id_b}:{qty_b}&utm_source={agent_name}&utm_medium=ai_agent';
-		$lines[] = '```';
-		$lines[] = '';
-		$lines[] = '**Shareable Checkout URL — with coupon code:**';
-		$lines[] = '';
-		$lines[] = '```';
-		$lines[] = '{site_url}/checkout-link/?products={product_id}:{quantity}&coupon={coupon_code}&utm_source={agent_name}&utm_medium=ai_agent';
-		$lines[] = '```';
-		$lines[] = '';
-		$lines[] = '**Legacy add-to-cart URL — simple product:**';
-		$lines[] = '';
-		$lines[] = '```';
-		$lines[] = '{site_url}/?add-to-cart={product_id}&quantity={quantity}&utm_source={agent_name}&utm_medium=ai_agent';
-		$lines[] = '```';
-		$lines[] = '';
-		$lines[] = '**Legacy add-to-cart URL — variable product (use the VARIATION id, not the parent product id):**';
-		$lines[] = '';
-		$lines[] = '```';
-		$lines[] = '{site_url}/?add-to-cart={variation_id}&quantity={quantity}&utm_source={agent_name}&utm_medium=ai_agent';
-		$lines[] = '```';
-		$lines[] = '';
-		$lines[] = 'Notes:';
-		$lines[] = '';
-		$lines[] = '- Substitute `{site_url}` with this store\'s home URL (see Store Information above).';
-		$lines[] = '- `{product_id}` / `{variation_id}` are integers from the catalog (UCP `product.id`, after stripping the `prod_` / `var_` prefix).';
-		$lines[] = '- `{quantity}` defaults to `1` when omitted on `/checkout-link/` — include it on `?add-to-cart=` for anything other than 1.';
-		$lines[] = '- URL-encode `{agent_name}` if it contains spaces or special characters. Brand names from the attribution mapping table above are already URL-safe.';
-		$lines[] = '- `{coupon_code}` is optional; omit the entire `&coupon=` parameter when not using one.';
-		$lines[] = '';
+		// Removed in 2.0.1 — two sections that had drifted out of
+		// scope vs. the v2.0.0 UCP-POST-first posture:
+		//
+		//   1. A `utm_source` / `utm_medium` / `utm_campaign` /
+		//      `ai_session_id` parameter list that encouraged agents
+		//      to build URLs client-side. Redundant now: the POST
+		//      flow attaches UTM values to `continue_url` from the
+		//      `UCP-Agent` header, and spec-aware agents never see
+		//      these keys directly.
+		//
+		//   2. A "URL patterns for client-side construction" block
+		//      (6 variants: `/checkout-link/?products=` × 4 plus
+		//      legacy `?add-to-cart=` × 2). That section predated
+		//      the `/checkout-sessions` endpoint and directly
+		//      contradicted the "MUST redirect to continue_url"
+		//      posture in the Checkout Policy block above. Rather
+		//      than maintain two flows in one document, we commit to
+		//      POST-first: agents that cannot POST should read the
+		//      UCP checkout spec for the canonical fallback, not
+		//      reverse-engineer our per-store URL shapes.
+		//
+		// If non-UCP agents ever need the URL patterns again, they
+		// belong in developer docs (README, wiki), not in llms.txt.
 
 		// UCP merchant-extension docs — referenced from the manifest's
 		// `com.woocommerce.ai_syndication` capability as the `spec`
@@ -640,49 +596,10 @@ class WC_AI_Syndication_Llms_Txt {
 		return is_wp_error( $terms ) ? [] : $terms;
 	}
 
-	/**
-	 * Get featured (or fallback popular) products for the llms.txt listing.
-	 *
-	 * @param array $settings AI syndication settings.
-	 * @return array{products: WC_Product[], is_featured: bool} Products and a flag
-	 *               indicating whether the list came from the featured-products
-	 *               query (true) or the popular-products fallback (false).
-	 */
-	private function get_featured_products( $settings ) {
-		$query_args = [
-			'status'   => 'publish',
-			'limit'    => 10,
-			'orderby'  => 'popularity',
-			'order'    => 'DESC',
-			'featured' => true,
-		];
-
-		$product_mode = $settings['product_selection_mode'] ?? 'all';
-		if ( 'categories' === $product_mode && ! empty( $settings['selected_categories'] ) ) {
-			$query_args['tax_query'] = [
-				[
-					'taxonomy' => 'product_cat',
-					'field'    => 'term_id',
-					'terms'    => array_map( 'absint', $settings['selected_categories'] ),
-				],
-			];
-		} elseif ( 'selected' === $product_mode && ! empty( $settings['selected_products'] ) ) {
-			$query_args['include'] = array_map( 'absint', $settings['selected_products'] );
-			unset( $query_args['featured'] );
-		}
-
-		$products    = wc_get_products( $query_args );
-		$is_featured = ! empty( $products );
-
-		// Fallback to popular if no featured products exist.
-		if ( ! $is_featured ) {
-			unset( $query_args['featured'] );
-			$products = wc_get_products( $query_args );
-		}
-
-		return [
-			'products'    => $products,
-			'is_featured' => $is_featured,
-		];
-	}
+	// `get_featured_products()` was removed in 2.0.1 alongside the
+	// "Featured Products" llms.txt section. See the deletion comment
+	// where the section used to render (around line ~315) for
+	// rationale. If the section is ever reintroduced, prefer sourcing
+	// from the Store API with explicit freshness disclosure rather
+	// than rebuilding this internal `wc_get_products()` path.
 }

--- a/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-llms-txt.php
@@ -312,15 +312,15 @@ class WC_AI_Syndication_Llms_Txt {
 			$lines[] = '';
 		}
 
-		// Featured/popular products section was removed in 2.0.1:
-		// a 5-product marketing teaser in a machine-readable agent
-		// document was scope creep — agents wanting products use the
-		// Store API (documented in `## API Access` above). Stale
-		// prices between llms.txt regenerations and edge cases like
-		// "Request a Quote" products (no numeric price → rendered as
-		// bare "$") made the section fragile for near-zero agent
-		// value. If we ever bring it back, it should be sourced from
-		// the Store API with a note about freshness expectations.
+		// Featured/popular products section removed: an up-to-10-product
+		// marketing teaser in a machine-readable agent document was
+		// scope creep — agents wanting products use the Store API
+		// (documented in `## API Access` above). Stale prices between
+		// llms.txt regenerations and edge cases like "Request a Quote"
+		// products (no numeric price → rendered as bare "$") made the
+		// section fragile for near-zero agent value. If we ever bring
+		// it back, it should be sourced from the Store API with a note
+		// about freshness expectations.
 
 		// Checkout policy declaration. Makes explicit the merchant-
 		// only-checkout posture that the UCP manifest already
@@ -426,8 +426,9 @@ class WC_AI_Syndication_Llms_Txt {
 		$lines[] = 'If your agent\'s hostname is missing and you\'d like a specific brand name applied, open an issue on the plugin\'s [GitHub repository](https://github.com/pierorocca/woocommerce-ai-syndication/issues) — additions are a single constant entry plus a test row.';
 		$lines[] = '';
 
-		// Removed in 2.0.1 — two sections that had drifted out of
-		// scope vs. the v2.0.0 UCP-POST-first posture:
+		// Post-v2.0.0 cleanup — two sections that had drifted out of
+		// scope vs. the UCP-POST-first posture the plugin committed
+		// to at 2.0.0:
 		//
 		//   1. A `utm_source` / `utm_medium` / `utm_campaign` /
 		//      `ai_session_id` parameter list that encouraged agents
@@ -596,7 +597,7 @@ class WC_AI_Syndication_Llms_Txt {
 		return is_wp_error( $terms ) ? [] : $terms;
 	}
 
-	// `get_featured_products()` was removed in 2.0.1 alongside the
+	// `get_featured_products()` was removed alongside the
 	// "Featured Products" llms.txt section. See the deletion comment
 	// where the section used to render (around line ~315) for
 	// rationale. If the section is ever reintroduced, prefer sourcing

--- a/languages/woocommerce-ai-syndication.pot
+++ b/languages/woocommerce-ai-syndication.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce AI Syndication 1.8.0\n"
+"Project-Id-Version: WooCommerce AI Syndication 2.0.0\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-ai-syndication\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-20T22:20:54+00:00\n"
+"POT-Creation-Date: 2026-04-21T08:51:10+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-syndication\n"
@@ -52,23 +52,23 @@ msgstr ""
 msgid "Products"
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:212
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:229
 msgid "Product identifiers (GTIN, UPC, EAN, MPN, ISBN). Each entry is a typed barcode."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:224
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:241
 msgid "Barcode type (gtin8, gtin12, gtin13, gtin14, other)."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:231
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:248
 msgid "The barcode value as stored by the merchant."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:240
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:257
 msgid "RFC 3339 / ISO 8601 timestamp (UTC, `Z`-suffixed) when the product was created. Null when not available. Exposed here because Store API strips product date fields from responses by default; our UCP translator consumes this to populate `product.published_at` per the UCP core shape."
 msgstr ""
 
-#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:249
+#: includes/ai-syndication/ucp-rest/class-wc-ai-syndication-store-api-extension.php:266
 msgid "RFC 3339 / ISO 8601 timestamp (UTC, `Z`-suffixed) of the product's last modification. Null when not available. Consumed by the UCP translator for `product.updated_at`."
 msgstr ""
 

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -166,12 +166,28 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( '.well-known/ucp', $output );
 	}
 
-	public function test_attribution_section_documents_utm_parameters(): void {
+	public function test_attribution_section_does_not_document_client_side_utm_params(): void {
+		// 2.0.1 scope cut. The previous UTM-parameter list
+		// (`utm_source` / `utm_medium` / `utm_campaign` / `ai_session_id`)
+		// encouraged client-side URL construction — which the v2.0.0
+		// UCP-POST-first posture replaced. Removed; this test is the
+		// regression guard for the removal.
+		//
+		// The Attribution narrative still mentions `utm_source` and
+		// `utm_medium` in prose ("server attaches utm_source + utm_medium
+		// to continue_url"), so we specifically guard the BULLETED-LIST
+		// client-construction variants — those are the shape that would
+		// confuse agents into building URLs themselves.
 		$output = $this->llms->generate();
 
-		$this->assertStringContainsString( '`utm_source`', $output );
-		$this->assertStringContainsString( '`utm_medium`: `ai_agent`', $output );
-		$this->assertStringContainsString( '`ai_session_id`', $output );
+		$this->assertStringNotContainsString(
+			'- `ai_session_id`: The current conversation/session ID',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'- `utm_campaign`: Optional campaign name',
+			$output
+		);
 	}
 
 	public function test_checkout_policy_section_explicitly_declares_merchant_only_posture(): void {
@@ -209,65 +225,32 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( 'continue_url', $output );
 	}
 
-	public function test_attribution_still_documents_utm_parameters_for_legacy_flow(): void {
-		// Agents that must construct URLs client-side (non-UCP-aware
-		// or legacy flows) still need the UTM convention documented.
-		// Kept in llms.txt as authoritative human-readable guidance
-		// after 1.6.5 removed the template library from the manifest.
+	public function test_url_patterns_section_not_emitted(): void {
+		// 2.0.1 scope cut. The previous "URL patterns for client-side
+		// construction" block (6 URL variants: `/checkout-link/?products=`
+		// × 4 plus `?add-to-cart=` × 2) contradicted the Checkout
+		// Policy block's "MUST redirect to continue_url from POST
+		// /checkout-sessions" posture. Agents reading one or the other
+		// would end up uncertain which flow the store actually wanted.
+		// v2.0.0 committed to POST-first at the endpoint level; 2.0.1
+		// commits to it in the docs. This test is the regression guard
+		// for the removal.
+		//
+		// If any of the template variables or URL shapes reappears,
+		// this test fires — forcing a conscious re-decision on whether
+		// to reintroduce the client-side-construction path (and if so,
+		// how to reconcile it with the POST-first Checkout Policy).
 		$output = $this->llms->generate();
 
-		$this->assertStringContainsString( 'utm_source', $output );
-		$this->assertStringContainsString( 'utm_medium', $output );
-		$this->assertStringContainsString( 'ai_agent', $output );
-		$this->assertStringContainsString( 'ai_session_id', $output );
-	}
-
-	public function test_attribution_documents_url_patterns_inline(): void {
-		// Post-1.7.0: the URL-pattern guidance lives inline inside
-		// llms.txt rather than pointing at WooCommerce's external
-		// documentation. Rationale: one fetch instead of two for
-		// every agent evaluating the store. Previously we had
-		// templates in the UCP manifest (wrong placement — UCP's
-		// SHOULD directive is continue_url via POST /checkout-sessions);
-		// 1.6.5 moved them out but left an external pointer;
-		// 1.7.0-era change inlines the patterns so llms.txt is
-		// self-contained.
-		$output = $this->llms->generate();
-
-		// Section header present.
-		$this->assertStringContainsString(
+		$this->assertStringNotContainsString(
 			'### URL patterns for client-side construction',
 			$output
 		);
-
-		// Both URL shapes documented.
-		$this->assertStringContainsString( '/checkout-link/?products=', $output );
-		$this->assertStringContainsString( '/?add-to-cart=', $output );
-
-		// The five key template variables are documented so a
-		// string-replace URL construction flow knows what to
-		// substitute.
-		$this->assertStringContainsString( '{site_url}', $output );
-		$this->assertStringContainsString( '{product_id}', $output );
-		$this->assertStringContainsString( '{variation_id}', $output );
-		$this->assertStringContainsString( '{quantity}', $output );
-		$this->assertStringContainsString( '{coupon_code}', $output );
-
-		// Preference for `/checkout-link/` over the legacy add-to-cart
-		// shape is explicit — otherwise agents might ship whichever
-		// they implement first. Preferred path matches UCP's
-		// continue_url semantic.
-		$this->assertMatchesRegularExpression(
-			'/Shareable Checkout URL.*preferred/is',
-			$output
-		);
-
-		// No external-docs pointer remains — the whole point of
-		// inlining is to make llms.txt self-contained.
-		$this->assertStringNotContainsString(
-			'woocommerce.com/document/creating-sharable-checkout-urls',
-			$output
-		);
+		$this->assertStringNotContainsString( '/checkout-link/?products=', $output );
+		$this->assertStringNotContainsString( '/?add-to-cart=', $output );
+		$this->assertStringNotContainsString( '{site_url}', $output );
+		$this->assertStringNotContainsString( '{variation_id}', $output );
+		$this->assertStringNotContainsString( '{coupon_code}', $output );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -167,7 +167,7 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_attribution_section_does_not_document_client_side_utm_params(): void {
-		// 2.0.1 scope cut. The previous UTM-parameter list
+		// Post-v2.0.0 scope cut. The previous UTM-parameter list
 		// (`utm_source` / `utm_medium` / `utm_campaign` / `ai_session_id`)
 		// encouraged client-side URL construction — which the v2.0.0
 		// UCP-POST-first posture replaced. Removed; this test is the
@@ -177,15 +177,26 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		// `utm_medium` in prose ("server attaches utm_source + utm_medium
 		// to continue_url"), so we specifically guard the BULLETED-LIST
 		// client-construction variants — those are the shape that would
-		// confuse agents into building URLs themselves.
+		// confuse agents into building URLs themselves. Guards all four
+		// bullet variants because any one reintroduction is the regression
+		// signal we care about (cutting three but keeping one would be
+		// sneakier than the no-partial-revert rule implies).
 		$output = $this->llms->generate();
 
 		$this->assertStringNotContainsString(
-			'- `ai_session_id`: The current conversation/session ID',
+			'- `utm_source`: Your agent identifier',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'- `utm_medium`: `ai_agent`',
 			$output
 		);
 		$this->assertStringNotContainsString(
 			'- `utm_campaign`: Optional campaign name',
+			$output
+		);
+		$this->assertStringNotContainsString(
+			'- `ai_session_id`: The current conversation/session ID',
 			$output
 		);
 	}
@@ -226,20 +237,24 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_url_patterns_section_not_emitted(): void {
-		// 2.0.1 scope cut. The previous "URL patterns for client-side
-		// construction" block (6 URL variants: `/checkout-link/?products=`
-		// × 4 plus `?add-to-cart=` × 2) contradicted the Checkout
-		// Policy block's "MUST redirect to continue_url from POST
-		// /checkout-sessions" posture. Agents reading one or the other
-		// would end up uncertain which flow the store actually wanted.
-		// v2.0.0 committed to POST-first at the endpoint level; 2.0.1
-		// commits to it in the docs. This test is the regression guard
-		// for the removal.
+		// Post-v2.0.0 scope cut. The previous "URL patterns for
+		// client-side construction" block (6 URL variants:
+		// `/checkout-link/?products=` × 4 plus `?add-to-cart=` × 2)
+		// contradicted the Checkout Policy block's "MUST redirect to
+		// continue_url from POST /checkout-sessions" posture. Agents
+		// reading one or the other would end up uncertain which flow
+		// the store actually wanted. v2.0.0 committed to POST-first
+		// at the endpoint level; this removal commits to it in the
+		// docs. This test is the regression guard.
 		//
 		// If any of the template variables or URL shapes reappears,
 		// this test fires — forcing a conscious re-decision on whether
 		// to reintroduce the client-side-construction path (and if so,
 		// how to reconcile it with the POST-first Checkout Policy).
+		// All five placeholders from the removed section are guarded
+		// explicitly; a partial reintroduction with only the most
+		// common ones (`{product_id}` / `{quantity}`) would otherwise
+		// slip through a narrower negative-assertion set.
 		$output = $this->llms->generate();
 
 		$this->assertStringNotContainsString(
@@ -249,7 +264,9 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringNotContainsString( '/checkout-link/?products=', $output );
 		$this->assertStringNotContainsString( '/?add-to-cart=', $output );
 		$this->assertStringNotContainsString( '{site_url}', $output );
+		$this->assertStringNotContainsString( '{product_id}', $output );
 		$this->assertStringNotContainsString( '{variation_id}', $output );
+		$this->assertStringNotContainsString( '{quantity}', $output );
 		$this->assertStringNotContainsString( '{coupon_code}', $output );
 	}
 


### PR DESCRIPTION
## Summary

Post-v2.0.0 audit of the live `/llms.txt` on my test store surfaced ~60 lines of content that had drifted out of scope vs the UCP-POST-first posture v2.0.0 committed to. This PR commits the docs to that posture.

Net: 183 → ~120 lines on the live output, plus one stale wording fix and one dead-code removal.

## What's cut

| Section | Why |
|---|---|
| Featured Products (~7 lines + `get_featured_products()` method) | Marketing teaser in a machine-readable agent doc. Prices go stale between regenerations; edge cases like "Request a Quote" products render as bare `$`. Agents that want products use the Store API. |
| URL patterns for client-side construction (~48 lines) | Six URL variants (`/checkout-link/?products=` × 4 + legacy `?add-to-cart=` × 2) directly contradicting the Checkout Policy block's "MUST redirect to continue_url from POST /checkout-sessions". A doc that says both "MUST POST" and "here's how to build URLs" leaves agents uncertain which flow the store wants. |
| Bulleted client-construction UTM list (~8 lines) | `utm_source` / `utm_medium` / `utm_campaign` / `ai_session_id` parameter documentation, redundant with the server-side continue_url path where agents never touch these keys. |

## Stale wording fix

`## API Access` described the manifest as declaring "capabilities, checkout policy, and **purchase URL templates**". Purchase URL templates were removed from the manifest in 1.6.5. Updated to describe what it actually carries now: `store_context` (currency, locale, country, tax/shipping posture).

## What stays (intentionally)

- Attribution name-mapping table — single source of truth for the hostname → brand runtime behavior
- Checkout Policy block with programmatic-verification cross-reference
- UCP Extension section (manifest anchor target for `#ucp-extension`)
- Store Information, API Access, Sitemaps, Product Categories

## Tests

**Removed (stale):**
- `test_attribution_section_documents_utm_parameters`
- `test_attribution_still_documents_utm_parameters_for_legacy_flow`
- `test_attribution_documents_url_patterns_inline`

**Added (regression guards for the cuts):**
- `test_attribution_section_does_not_document_client_side_utm_params` — guards the bulleted UTM list staying out
- `test_url_patterns_section_not_emitted` — guards section header + 5 template variables + 2 URL shapes all staying out

If the cut content ever tries to come back, these guards fire and force a conscious re-decision on how to reconcile it with the POST-first Checkout Policy.

## Test plan
- [x] `composer test` — 535 tests (net -1: 3 removed, 2 added), all pass
- [x] `vendor/bin/phpcs` — clean
- [x] `vendor/bin/phpstan analyse` — no errors (PHPStan caught `get_featured_products()` as unused after the section cut, prompting the method removal)
- [x] `./bin/make-pot.sh` regenerated
- [ ] CI green
- [ ] Live-site smoke test post-merge: re-curl `/llms.txt` and confirm ~63-line reduction + narrative no longer self-contradicts

## Version

Not bumped — per project convention (see PR #42, #51), version strings bump in a dedicated release PR. This change bundles into the next release (2.0.1 patch, likely).

🤖 Generated with [Claude Code](https://claude.com/claude-code)