### PR TITLE
Emit inputs[] + deduplicate request IDs in catalog.lookup

### DIFF
--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -646,13 +646,21 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		$products = [];
 		$messages = [];
 
+		// Deduplicate + normalize before fetching. `wc_ids` is the
+		// work list (one per unique input, aligned positionally
+		// with `inputs`); `inputs` is the echo array we return to
+		// the agent so they can reconcile what they sent against
+		// what we processed. See `normalize_and_dedupe_lookup_ids`
+		// for the dedup semantics.
+		$normalized = self::normalize_and_dedupe_lookup_ids( $ids );
+		$inputs     = $normalized['inputs'];
+		$wc_ids     = $normalized['wc_ids'];
+
 		// Same single-merchant seller block as the search handler —
 		// computed once, stamped on every product (see handle_catalog_search).
 		$seller = self::build_seller();
 
-		foreach ( $ids as $index => $raw_id ) {
-			$wc_id = self::parse_ucp_id_to_wc_int( $raw_id );
-
+		foreach ( $wc_ids as $index => $wc_id ) {
 			if ( $wc_id <= 0 ) {
 				$messages[] = self::not_found_message( (int) $index );
 				continue;
@@ -687,6 +695,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 
 		$response_body = [
 			'ucp'      => WC_AI_Syndication_UCP_Envelope::catalog_envelope( $capability ),
+			'inputs'   => $inputs,
 			'products' => $products,
 		];
 
@@ -1516,8 +1525,15 @@ class WC_AI_Syndication_UCP_REST_Controller {
 
 	/**
 	 * Build a UCP `not_found` error message for the ID at position
-	 * `$index` in the request's `ids` array. The JSONPath-style
+	 * `$index` in the response's `inputs` array. The JSONPath-style
 	 * `path` lets agents localize which specific ID failed.
+	 *
+	 * Note: the path references `$.inputs[...]`, not `$.ids[...]`.
+	 * After request-side deduplication (see
+	 * `normalize_and_dedupe_lookup_ids`), the original `ids[]` is
+	 * collapsed into a deduped `inputs[]` echoed in the response.
+	 * Messages address positions in that echoed array so agents can
+	 * map failures to the processed (not raw-requested) set.
 	 *
 	 * @return array<string, string>
 	 */
@@ -1525,8 +1541,122 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		return [
 			'type'     => 'error',
 			'code'     => 'not_found',
-			'path'     => '$.ids[' . $index . ']',
+			'path'     => '$.inputs[' . $index . ']',
 			'severity' => 'unrecoverable',
+		];
+	}
+
+	/**
+	 * Normalize + deduplicate the raw `ids[]` submitted to
+	 * catalog.lookup. Two agent semantics we enforce:
+	 *
+	 *   1. **Idempotence**: `["123","123"]` fetches/translates once.
+	 *      Downstream work is O(unique) not O(request). This also
+	 *      matters for `fetch_store_api_product` which dispatches an
+	 *      internal REST request per ID — duplicates doubled the
+	 *      work for no benefit.
+	 *
+	 *   2. **Prefix-form collapsing**: `"woo-p-123"` and bare `"123"`
+	 *      parse to the same WC product id. We dedupe on the parsed
+	 *      int so an agent sending both forms gets one product and
+	 *      one inputs entry. First-occurrence wins for the raw echo.
+	 *
+	 * Malformed inputs (non-string, empty-after-strip, non-numeric)
+	 * are preserved in `inputs[]` so the response faithfully echoes
+	 * what the agent sent, with a per-raw-value dedup so the same
+	 * garbage string doesn't produce N not_found messages. They
+	 * surface as `not_found` messages downstream.
+	 *
+	 * Non-string inputs (numbers, booleans, arrays, null, etc.) are
+	 * coerced to a stable string form for the echo but their
+	 * `wc_id` is set to 0 — i.e. treated as not_found. The UCP spec
+	 * requires IDs to be strings; we enforce that strictly at the
+	 * resolution step even though we echo the raw form back so the
+	 * agent can see what we received.
+	 *
+	 * @param array<int, mixed> $raw_ids
+	 *
+	 * @return array{
+	 *     inputs: array<int, string>,
+	 *     wc_ids: array<int, int>
+	 * }
+	 */
+	private static function normalize_and_dedupe_lookup_ids( array $raw_ids ): array {
+		$inputs = [];
+		$wc_ids = [];
+		$seen   = [];
+
+		foreach ( $raw_ids as $raw ) {
+			// Non-scalar inputs (arrays/objects/null) can't resolve
+			// to a WC product, but we still echo a stable,
+			// distinguishable string form so agents see what kind of
+			// invalid entry they sent AND so different invalid
+			// values dedupe separately. An earlier version echoed
+			// everything to `""`, which merged distinct entries
+			// (e.g. `[null, []]`) into a single inputs slot — that
+			// shifted message paths and hid the agent's real
+			// payload. Prefer JSON for arrays/objects so nested
+			// structure is preserved in the echo; fall back to a
+			// type tag only if wp_json_encode fails (e.g. on a
+			// resource or circular reference).
+			if ( ! is_scalar( $raw ) ) {
+				if ( null === $raw ) {
+					$echo = 'null';
+				} elseif ( is_array( $raw ) ) {
+					$encoded = wp_json_encode( $raw );
+					$echo    = ( is_string( $encoded ) && '' !== $encoded ) ? $encoded : '[array]';
+				} elseif ( is_object( $raw ) ) {
+					$encoded = wp_json_encode( $raw );
+					$echo    = ( is_string( $encoded ) && '' !== $encoded ) ? $encoded : '[object]';
+				} else {
+					// Resources, anything else non-scalar. Unlikely
+					// in JSON payloads but keep the enumeration
+					// exhaustive so nothing falls through silently.
+					$echo = '[invalid]';
+				}
+				$wc_id = 0;
+			} elseif ( is_string( $raw ) ) {
+				$echo  = $raw;
+				$wc_id = self::parse_ucp_id_to_wc_int( $raw );
+				if ( $wc_id < 0 ) {
+					$wc_id = 0;
+				}
+			} elseif ( is_bool( $raw ) ) {
+				// Booleans need an explicit branch: `(string) false`
+				// is `""`, which is NOT distinguishable from a
+				// genuinely-empty string id — the two would share a
+				// dedup key and collapse into one inputs entry,
+				// hiding what the agent actually sent. Emit
+				// "true"/"false" so each remains uniquely addressable.
+				$echo  = $raw ? 'true' : 'false';
+				$wc_id = 0;
+			} else {
+				// Remaining non-string scalars (int, float). The spec
+				// requires string IDs and `parse_ucp_id_to_wc_int`
+				// already returns 0 for non-string input — keeping
+				// resolution logic in one place prevents drift
+				// between parser and handler.
+				$echo  = (string) $raw;
+				$wc_id = 0;
+			}
+
+			// Dedup key: valid IDs collapse by parsed int (so prefix
+			// variants fold together); invalid IDs dedupe only
+			// against identical raw echoes so `["abc","abc"]` stays
+			// a single entry while `["abc","xyz"]` stays two.
+			$key = $wc_id > 0 ? 'id:' . $wc_id : 'raw:' . $echo;
+
+			if ( isset( $seen[ $key ] ) ) {
+				continue;
+			}
+			$seen[ $key ] = true;
+			$inputs[]     = $echo;
+			$wc_ids[]     = $wc_id;
+		}
+
+		return [
+			'inputs' => $inputs,
+			'wc_ids' => $wc_ids,
 		];
 	}
 

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -37,6 +37,15 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 	 */
 	private array $fake_store_api = [];
 
+	/**
+	 * Per-product-id count of rest_do_request dispatches. Lets
+	 * dedup tests assert that a duplicate-ID payload maps to a
+	 * single Store API round-trip rather than N.
+	 *
+	 * @var array<int, int>
+	 */
+	private array $store_api_dispatch_counts = [];
+
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
@@ -45,7 +54,8 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// leak. Stub defaults to `enabled => yes`.
 		WC_AI_Syndication::$test_settings = [];
 
-		$this->fake_store_api = [];
+		$this->fake_store_api            = [];
+		$this->store_api_dispatch_counts = [];
 
 		Functions\when( '__' )->returnArg();
 		Functions\when( '_n' )->alias(
@@ -68,9 +78,10 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// Route rest_do_request through our fake_store_api map. The
 		// controller only calls this for `GET /wc/store/v1/products/{id}`,
 		// so parsing the route for the trailing int is sufficient.
-		$api = &$this->fake_store_api;
+		$api    = &$this->fake_store_api;
+		$counts = &$this->store_api_dispatch_counts;
 		Functions\when( 'rest_do_request' )->alias(
-			static function ( WP_REST_Request $request ) use ( &$api ) {
+			static function ( WP_REST_Request $request ) use ( &$api, &$counts ) {
 				$route = $request->get_route();
 				if ( ! preg_match( '#/wc/store/v1/products/(\d+)$#', $route, $m ) ) {
 					// Unexpected route — return a 500-ish response so the
@@ -78,7 +89,9 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 					return new WP_REST_Response( null, 500 );
 				}
 
-				$id = (int) $m[1];
+				$id              = (int) $m[1];
+				$counts[ $id ]   = ( $counts[ $id ] ?? 0 ) + 1;
+
 				if ( ! array_key_exists( $id, $api ) || null === $api[ $id ] ) {
 					return new WP_REST_Response(
 						[ 'code' => 'woocommerce_rest_product_invalid_id' ],
@@ -327,6 +340,144 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
+	// inputs[] echo + deduplication (PR K)
+	// ------------------------------------------------------------------
+
+	public function test_response_echoes_inputs_array_for_happy_path(): void {
+		// UCP spec requires the lookup response to echo the
+		// (normalized, deduped) request IDs in an `inputs` array so
+		// agents can map products back to what they requested even
+		// after dedup/normalization.
+		$this->seed_simple_product( 100, 'Alpha' );
+		$this->seed_simple_product( 200, 'Beta' );
+
+		$body = $this->successful_lookup(
+			[ 'ids' => [ 'prod_100', 'prod_200' ] ]
+		);
+
+		$this->assertArrayHasKey( 'inputs', $body );
+		$this->assertEquals( [ 'prod_100', 'prod_200' ], $body['inputs'] );
+	}
+
+	public function test_duplicate_ids_are_deduplicated_to_single_fetch_and_product(): void {
+		// `rest_do_request` is the expensive step — a repeated ID
+		// should not cause us to dispatch the same Store API call
+		// twice. Assert on both the observable output (1 input +
+		// 1 product) AND the internal dispatch count — the latter
+		// guards against a future refactor that dedupes *after*
+		// fetching (which would fix outputs while regressing the
+		// performance goal of O(unique) not O(request)).
+		$this->seed_simple_product( 123, 'Widget' );
+
+		$body = $this->successful_lookup(
+			[ 'ids' => [ 'prod_123', 'prod_123', 'prod_123' ] ]
+		);
+
+		$this->assertEquals( [ 'prod_123' ], $body['inputs'] );
+		$this->assertCount( 1, $body['products'] );
+		$this->assertEquals( 'prod_123', $body['products'][0]['id'] );
+		$this->assertSame(
+			1,
+			$this->store_api_dispatch_counts[123] ?? 0,
+			'Three identical IDs must produce exactly one Store API dispatch (O(unique), not O(request)).'
+		);
+	}
+
+	public function test_prefixed_and_bare_ids_for_same_product_are_deduplicated(): void {
+		// Both `prod_123` and bare `123` resolve to WC product 123
+		// (see parse_ucp_id_to_wc_int — prefix-stripping is lenient).
+		// The dedup key is the parsed int, so both forms collapse
+		// to a single inputs entry. First-occurrence wins for echo.
+		$this->seed_simple_product( 123, 'Widget' );
+
+		$body = $this->successful_lookup(
+			[ 'ids' => [ 'prod_123', '123', 'var_123_default' ] ]
+		);
+
+		$this->assertEquals( [ 'prod_123' ], $body['inputs'] );
+		$this->assertCount( 1, $body['products'] );
+	}
+
+	public function test_inputs_reflect_deduped_positions_in_message_paths(): void {
+		// Request: [found_A, found_A, missing, found_B]
+		// After dedup: inputs = [found_A, missing, found_B]
+		// The missing one is at deduped position 1 — messages[].path
+		// must point to $.inputs[1], not to the raw request position.
+		$this->seed_simple_product( 100, 'Alpha' );
+		$this->seed_simple_product( 300, 'Gamma' );
+
+		$body = $this->successful_lookup(
+			[ 'ids' => [ 'prod_100', 'prod_100', 'prod_missing', 'prod_300' ] ]
+		);
+
+		$this->assertEquals(
+			[ 'prod_100', 'prod_missing', 'prod_300' ],
+			$body['inputs']
+		);
+		$this->assertCount( 1, $body['messages'] );
+		$this->assertEquals( '$.inputs[1]', $body['messages'][0]['path'] );
+		$this->assertEquals( 'not_found', $body['messages'][0]['code'] );
+	}
+
+	public function test_repeated_malformed_ids_are_deduplicated_as_well(): void {
+		// Malformed inputs dedupe by identical raw echo, so two
+		// instances of the same garbage string collapse. Two
+		// different garbage strings stay distinct.
+		$body = $this->successful_lookup(
+			[ 'ids' => [ 'bogus', 'bogus', 'other_bogus' ] ]
+		);
+
+		$this->assertEquals( [ 'bogus', 'other_bogus' ], $body['inputs'] );
+		$this->assertCount( 2, $body['messages'] );
+		$this->assertEquals( '$.inputs[0]', $body['messages'][0]['path'] );
+		$this->assertEquals( '$.inputs[1]', $body['messages'][1]['path'] );
+	}
+
+	public function test_boolean_ids_echo_as_true_false_not_empty_string(): void {
+		// Regression guard: `(string) false` is `""` in PHP, so
+		// booleans echoed via naive string cast would collide with
+		// an actual empty-string id in the dedup key. Emit
+		// "true"/"false" explicitly so each boolean remains
+		// uniquely addressable in inputs[].
+		$body = $this->successful_lookup(
+			[ 'ids' => [ false, true, false ] ]
+		);
+
+		// Three distinct echo forms from two distinct booleans,
+		// duplicate `false` deduped against the first.
+		$this->assertEquals( [ 'false', 'true' ], $body['inputs'] );
+		$this->assertEmpty( $body['products'] );
+	}
+
+	public function test_non_scalar_ids_echo_with_stable_distinguishable_forms(): void {
+		// Arrays/objects/null in ids[] can't resolve, but they must
+		// echo distinguishably so (1) agents see what kind of
+		// invalid payload they sent, and (2) distinct non-scalars
+		// don't collapse into a single inputs slot (which would
+		// shift message paths). Null → "null"; array → JSON;
+		// objects → JSON. Identical values still dedupe by their
+		// echo form.
+		\Brain\Monkey\Functions\when( 'wp_json_encode' )->alias(
+			static fn( $v ): string|false => json_encode( $v )
+		);
+
+		$body = $this->successful_lookup(
+			[ 'ids' => [ null, [], null, [ 'nested' => 'obj' ] ] ]
+		);
+
+		// Three distinct echo forms — null, empty array, nested
+		// array — with the second null deduped against the first.
+		$this->assertEquals(
+			[ 'null', '[]', '{"nested":"obj"}' ],
+			$body['inputs']
+		);
+		$this->assertCount( 3, $body['messages'] );
+		$this->assertEquals( '$.inputs[0]', $body['messages'][0]['path'] );
+		$this->assertEquals( '$.inputs[1]', $body['messages'][1]['path'] );
+		$this->assertEquals( '$.inputs[2]', $body['messages'][2]['path'] );
+	}
+
+	// ------------------------------------------------------------------
 	// Not-found handling
 	// ------------------------------------------------------------------
 
@@ -337,7 +488,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( [], $body['products'] );
 		$this->assertCount( 1, $body['messages'] );
 		$this->assertEquals( 'not_found', $body['messages'][0]['code'] );
-		$this->assertEquals( '$.ids[0]', $body['messages'][0]['path'] );
+		$this->assertEquals( '$.inputs[0]', $body['messages'][0]['path'] );
 		$this->assertEquals( 'unrecoverable', $body['messages'][0]['severity'] );
 	}
 
@@ -359,7 +510,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 1, $body['messages'] );
 		// The missing ID was at position 1 in the request — that's what
 		// the jsonpath should reflect, not the product-array index.
-		$this->assertEquals( '$.ids[1]', $body['messages'][0]['path'] );
+		$this->assertEquals( '$.inputs[1]', $body['messages'][0]['path'] );
 	}
 
 	public function test_messages_key_omitted_when_all_ids_found(): void {
@@ -383,7 +534,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertEquals( [], $body['products'] );
 		$this->assertCount( 1, $body['messages'] );
-		$this->assertEquals( '$.ids[0]', $body['messages'][0]['path'] );
+		$this->assertEquals( '$.inputs[0]', $body['messages'][0]['path'] );
 	}
 
 	public function test_id_string_with_no_numeric_portion_is_not_found(): void {


### PR DESCRIPTION
## Summary
Two UCP 2026-04-08 MUSTs for `dev.ucp.shopping.catalog.lookup` were missing. This PR addresses both:

- **`inputs[]` echo** in the response so agents can reconcile the normalized/deduped set against what they sent.
- **Request deduplication** — repeated IDs collapse to one fetch and one product. Prefix-form variants (`prod_123` / bare `123`) dedupe by parsed WC id. Malformed IDs dedupe only on identical raw echo.

**Side effect**: message paths now reference `$.inputs[N]` instead of `$.ids[N]` — the deduped array is the canonical post-normalization source of positions.

## Behavior changes
| Request | Before | After |
|---|---|---|
| `["p_1","p_1"]` | 2 fetches, 2 products | 1 fetch, 1 product, `inputs=["p_1"]` |
| `["p_1","1"]` | 2 fetches (same product twice) | 1 fetch, 1 product, `inputs=["p_1"]` |
| `["p_missing"]` | `path: $.ids[0]` | `path: $.inputs[0]` |
| `["bogus","bogus"]` | 2 not_found messages | 1 not_found message, `inputs=["bogus"]` |

## Test plan
- [x] Unit test: `inputs[]` is echoed in response
- [x] Unit test: duplicate IDs collapse to single fetch/product
- [x] Unit test: prefixed + bare form dedupe by parsed int
- [x] Unit test: message paths use deduped positions
- [x] Unit test: repeated malformed IDs dedupe on raw echo
- [x] All 541 unit tests pass; phpcs + phpstan clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)