### PR TITLE
Rename UI copy: AI Syndication → AI Storefront

### DIFF
--- a/client/settings/ai-syndication/endpoint-info.js
+++ b/client/settings/ai-syndication/endpoint-info.js
@@ -358,7 +358,7 @@ const EndpointInfo = ( { settings, onChange, onSave, isSaving } ) => {
 						} }
 					>
 						{ __(
-							'These endpoints are automatically available when AI Syndication is enabled.',
+							'These endpoints are automatically available when AI Storefront is enabled.',
 							'woocommerce-ai-syndication'
 						) }
 					</p>
@@ -372,7 +372,7 @@ const EndpointInfo = ( { settings, onChange, onSave, isSaving } ) => {
 							} }
 						>
 							{ __(
-								'AI Syndication is currently disabled. Enable it in the Overview tab to activate these endpoints.',
+								'AI Storefront is currently disabled. Enable it in the Overview tab to activate these endpoints.',
 								'woocommerce-ai-syndication'
 							) }
 						</p>

--- a/client/settings/ai-syndication/settings-page.js
+++ b/client/settings/ai-syndication/settings-page.js
@@ -321,7 +321,7 @@ const PreEnableView = ( { onChange, onSave, isSaving } ) => (
 							} }
 						>
 							{ __(
-								'Make your products discoverable by AI shopping assistants',
+								'Make your store ready for AI shopping assistants',
 								'woocommerce-ai-syndication'
 							) }
 						</h2>
@@ -334,7 +334,7 @@ const PreEnableView = ( { onChange, onSave, isSaving } ) => (
 							} }
 						>
 							{ __(
-								'Turn on discovery in one click. Checkout stays on your store — no fees, no middleman, fully reversible.',
+								'Go live in one click. Checkout stays on your store — no fees, no middleman, fully reversible.',
 								'woocommerce-ai-syndication'
 							) }
 						</p>
@@ -353,7 +353,7 @@ const PreEnableView = ( { onChange, onSave, isSaving } ) => (
 										'woocommerce-ai-syndication'
 								  )
 								: __(
-										'Enable AI Syndication',
+										'Enable AI Storefront',
 										'woocommerce-ai-syndication'
 								  ) }
 						</Button>
@@ -521,7 +521,7 @@ const PostEnableView = ( { settings, onChange, onSave, isSaving } ) => {
 				<div>
 					<strong style={ { color: colors.success } }>
 						{ __(
-							'AI Syndication is active',
+							'AI Storefront is active',
 							'woocommerce-ai-syndication'
 						) }
 					</strong>
@@ -533,7 +533,7 @@ const PostEnableView = ( { settings, onChange, onSave, isSaving } ) => {
 						} }
 					>
 						{ __(
-							'Your products are discoverable by AI assistants. Checkout and customer data stay on your store.',
+							'Your store is ready for AI shopping assistants. Checkout and customer data stay on your store.',
 							'woocommerce-ai-syndication'
 						) }
 					</p>

--- a/includes/ai-syndication/class-wc-ai-syndication-robots.php
+++ b/includes/ai-syndication/class-wc-ai-syndication-robots.php
@@ -401,7 +401,7 @@ class WC_AI_Syndication_Robots {
 		// (which would create a feedback loop if we re-emitted them).
 		$sitemap_urls = self::extract_sitemap_urls( $output );
 
-		$output .= "\n# WooCommerce AI Syndication\n";
+		$output .= "\n# WooCommerce AI Storefront\n";
 		$output .= "# Machine-readable store data for AI-assisted product discovery\n\n";
 
 		// Derive paths from actual WooCommerce permalink settings.

--- a/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
+++ b/includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php
@@ -268,7 +268,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			WC_AI_Syndication_Logger::debug( 'UCP catalog/search rejected: syndication disabled' );
 			return self::ucp_catalog_error_response(
 				$capability,
-				__( 'AI Syndication is not currently enabled on this store.', 'woocommerce-ai-syndication' ),
+				__( 'AI Storefront is not currently enabled on this store.', 'woocommerce-ai-syndication' ),
 				'ucp_disabled',
 				null,
 				503
@@ -757,7 +757,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 			WC_AI_Syndication_Logger::debug( 'UCP catalog/lookup rejected: syndication disabled' );
 			return self::ucp_catalog_error_response(
 				$capability,
-				__( 'AI Syndication is not currently enabled on this store.', 'woocommerce-ai-syndication' ),
+				__( 'AI Storefront is not currently enabled on this store.', 'woocommerce-ai-syndication' ),
 				'ucp_disabled',
 				null,
 				503
@@ -953,7 +953,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		if ( self::is_syndication_disabled() ) {
 			WC_AI_Syndication_Logger::debug( 'UCP checkout-sessions rejected: syndication disabled' );
 			return self::ucp_checkout_error_response(
-				__( 'AI Syndication is not currently enabled on this store.', 'woocommerce-ai-syndication' ),
+				__( 'AI Storefront is not currently enabled on this store.', 'woocommerce-ai-syndication' ),
 				'ucp_disabled',
 				null,
 				503
@@ -1267,7 +1267,7 @@ class WC_AI_Syndication_UCP_REST_Controller {
 		$schema = [
 			'$schema'     => 'https://json-schema.org/draft/2020-12/schema',
 			'$id'         => $self_id,
-			'title'       => 'WooCommerce AI Syndication UCP Extension Contract',
+			'title'       => 'WooCommerce AI Storefront UCP Extension Contract',
 			'description' => 'Schema for the `com.woocommerce.ai_syndication` extension contract. The top-level `config` property describes the merchant-extension configuration advertised in the UCP manifest at `capabilities[com.woocommerce.ai_syndication][0].config`. Starting 2.0.0, no response-level payloads are emitted under this extension — rating data moved to core `product.rating` per the UCP 2026-04-08 product shape.',
 			'type'        => 'object',
 			'properties'  => [

--- a/includes/class-wc-ai-syndication.php
+++ b/includes/class-wc-ai-syndication.php
@@ -254,8 +254,8 @@ class WC_AI_Syndication {
 	public function add_admin_menu() {
 		add_submenu_page(
 			'woocommerce',
-			__( 'AI Syndication', 'woocommerce-ai-syndication' ),
-			__( 'AI Syndication', 'woocommerce-ai-syndication' ),
+			__( 'AI Storefront', 'woocommerce-ai-syndication' ),
+			__( 'AI Storefront', 'woocommerce-ai-syndication' ),
 			'manage_woocommerce',
 			'wc-ai-syndication',
 			[ $this, 'render_admin_page' ]
@@ -267,7 +267,7 @@ class WC_AI_Syndication {
 	 */
 	public function render_admin_page() {
 		echo '<div class="wrap">';
-		echo '<h1>' . esc_html__( 'AI Syndication', 'woocommerce-ai-syndication' ) . '</h1>';
+		echo '<h1>' . esc_html__( 'AI Storefront', 'woocommerce-ai-syndication' ) . '</h1>';
 		echo '<div id="wc-ai-syndication-settings"></div>';
 		echo '</div>';
 	}


### PR DESCRIPTION
## Summary

- Renames all user-visible strings from "AI Syndication" to "AI Storefront" across admin UI, REST error messages, and robots.txt comment
- Refreshes enablement card language: replaces discovery/discoverable framing with "ready for AI shopping assistants"
- Updates UCP contract title in the REST controller

### Files changed
- `includes/class-wc-ai-syndication.php` — admin menu labels + page title
- `includes/ai-syndication/ucp-rest/class-wc-ai-syndication-ucp-rest-controller.php` — error messages + UCP contract title
- `includes/ai-syndication/class-wc-ai-syndication-robots.php` — robots.txt comment
- `client/settings/ai-syndication/settings-page.js` — enablement card copy
- `client/settings/ai-syndication/endpoint-info.js` — endpoint tab copy

## Test plan
- [ ] Enable AI Storefront — confirm toggle label and active state text updated
- [ ] Check Overview tab copy matches new strings
- [ ] Check Endpoints tab copy matches new strings
- [ ] Verify robots.txt comment on a test store
- [ ] Confirm REST error response still readable when plugin is disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)