### PR TITLE
docs: note we don't support MCP + add FAQ block to readme

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,8 @@ woo-ucp-syndicate-ai/
 
 8. **Cache invalidation.** llms.txt and UCP manifest use transient caching with event-driven invalidation on product/category/settings changes. Version-based cache bust on plugin updates. UCP REST responses are not cached — every dispatch computes fresh, because agent-specific attribution (UTM from UCP-Agent) and session IDs must be per-request.
 
+9. **No MCP (Model Context Protocol) support, intentionally.** MCP's model — exposing tools/resources to external LLM clients via a dedicated server — requires infrastructure that neither WordPress core nor WooCommerce provide today. There is no first-class MCP-server primitive to hook into, no external-client auth surface, no transport abstraction, no capability-routing layer. Adding one inside this plugin would mean shipping a parallel REST framework alongside WP's existing REST API, with its own auth model. That's an explicitly out-of-scope choice: the plugin targets UCP, which is spec-compliant with the public HTTP surfaces WP/WC already expose (Store API, core REST, rewrite rules). If WP or WC grow native MCP-server primitives in future, we'll evaluate support then. Until that infrastructure exists, "MCP support" would be a bespoke server alongside the main application — a different product, not this one.
+
 ## Settings
 
 All runtime settings are stored in a single serialized option to keep reads cheap (`autoload=true` + static memoization in `WC_AI_Syndication::get_settings()`).

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Plus integrations with WordPress and WooCommerce:
 - No authentication. No API keys to manage.
 - No custom rate limiter. Uses WC's built-in with user-agent fingerprinting.
 - No Stripe or other payment provider dependency.
+- **No MCP (Model Context Protocol) support.** MCP requires a server surface reachable by external, non-admin clients — neither WordPress core nor WooCommerce scaffold one today, and there's no first-class plugin hook to add one without standing up auth, transport, and capability-routing infrastructure outside this plugin's reasonable scope. AI Storefront targets the Universal Commerce Protocol (UCP) instead, which works with the public HTTP/REST surfaces WP/WC already expose. MCP will be evaluated once WP or WC grow native MCP-server primitives.
 
 ## Requirements
 

--- a/readme.txt
+++ b/readme.txt
@@ -108,6 +108,22 @@ In the standard WooCommerce orders list. Every AI-referred order is a normal WC 
 * `_wc_ai_storefront_agent` (denormalized for faster queries)
 * `_wc_ai_storefront_session_id` (conversation identifier)
 
+== Frequently Asked Questions ==
+
+= Does this support MCP (Model Context Protocol)? =
+
+Not currently. MCP's tool and resource exposure pattern requires running a server surface reachable by external, non-admin clients — something neither WordPress core nor WooCommerce scaffold today. There is no first-class MCP entry point for a plugin to hook into, and running one alongside the WP stack would require auth, transport, and capability-routing infrastructure outside this plugin's scope.
+
+AI Storefront targets the Universal Commerce Protocol (UCP) instead, which works with the HTTP/REST surfaces WordPress and WooCommerce already expose to public clients. UCP gives AI shopping agents a stable, spec-conforming way to discover and transact against your catalog. MCP support will be evaluated if and when WP/WC grow native MCP-server primitives.
+
+= Will my customer data be shared with AI companies? =
+
+No. Customer data stays on your store. AI agents see the public catalog (the same products a shopper browsing your storefront sees) via the discovery endpoints; checkout happens on your own site via a continue URL, using WooCommerce's native checkout flow. No PII is transmitted to AI providers by this plugin.
+
+= What happens if I disable the plugin? =
+
+Discovery endpoints (`/llms.txt`, `/.well-known/ucp`, JSON-LD markup) stop being served. The `robots.txt` additions are removed. Order attribution already captured on completed orders remains in the database; new orders stop getting AI attribution stamps. No product data is deleted.
+
 == Changelog ==
 
 = 0.1.0 =


### PR DESCRIPTION
Adds a scope note about MCP support across readme.txt (FAQ), README.md ('What it doesn't do'), and AGENTS.md (Key Design Decisions). Also adds two adjacent FAQ entries to readme.txt (customer data, plugin-disable behavior).

Rationale: MCP is a predictable FAQ for any AI-adjacent plugin. The honest answer is structural (WP/WC don't scaffold an MCP-server surface). Documenting it up front saves support tickets.

No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)