### PR TITLE
CI: expand PHP matrix to 8.1–8.4 + align manifest floor to tested reality

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        php: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1', '8.2', '8.3']
+        php: ['8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php: ['8.1', '8.2', '8.3', '8.4']
+        php: ['8.0', '8.1', '8.2', '8.3', '8.4']
     steps:
       - uses: actions/checkout@v4
 

--- a/readme.txt
+++ b/readme.txt
@@ -3,7 +3,7 @@ Contributors: woocommerce
 Tags: woocommerce, ai, chatgpt, seo, llms-txt
 Requires at least: 6.7
 Tested up to: 6.8
-Requires PHP: 8.0
+Requires PHP: 8.1
 WC requires at least: 9.9
 WC tested up to: 9.9
 Stable tag: 0.1.0

--- a/woocommerce-ai-storefront.php
+++ b/woocommerce-ai-storefront.php
@@ -12,7 +12,7 @@
  * Tested up to: 6.8
  * WC requires at least: 9.9
  * WC tested up to: 9.9
- * Requires PHP: 8.0
+ * Requires PHP: 8.1
  * License: GPL-3.0-or-later
  * License URI: https://www.gnu.org/licenses/gpl-3.0.html
  * Update URI: https://github.com/Automattic/woocommerce-ai-storefront


### PR DESCRIPTION
## Summary

Expands the `php-tests` matrix in `.github/workflows/ci.yml` from 3 shards (8.1 / 8.2 / 8.3) to 4 (8.1 / 8.2 / 8.3 / 8.4), and raises the plugin's `Requires PHP` manifest floor from 8.0 → 8.1 to match what CI can actually verify.

Three tiny changes; single diff hunk per file.

## What happened along the way

I initially tried adding 8.0 too (to match the `Requires PHP: 8.0` manifest declaration) — CI promptly surfaced that PHPUnit 10 requires PHP 8.1+, so `composer install` under PHP 8.0 fails with "lock file does not contain a compatible set of packages" and the fail-fast matrix behavior cancelled the other shards.

Three ways to reconcile the mismatch:

a. Keep 8.0 in the matrix, downgrade PHPUnit to 9.x so 8.0 can actually be tested. Significant dev-dep churn and PHPUnit 9 loses features (e.g. attribute syntax) the current tests use.
b. Keep 8.0 as an untested "aspiration" in the manifest. Dishonest — we'd be claiming support we don't verify.
c. Raise the manifest floor to 8.1 so "what we claim" matches "what CI verifies."

Went with (c). The realistic support floor for this plugin given the modern tooling it depends on (PHPUnit 10, PHPStan 2.x, WP-CLI for `.pot` regen) is 8.1. Still comfortably above WooCommerce 9.9's own stated minimum (7.4) and compatible with every currently-maintained WP version.

## What 8.4 will catch that 8.3 didn't

- **Implicit nullable parameter deprecation.** `function foo( string $x = null )` now emits a deprecation — must be `?string $x = null` explicitly. A grep of `includes/` shows the plugin code doesn't currently have any, but the matrix entry catches any that creep in.
- **`mhash()` removed**, **`DateTime::createFromFormat` stricter**, minor tightenings around `stream_get_contents` / `libxml_set_external_entity_loader`.

## Merchant impact of the manifest bump

If a merchant on PHP 8.0 activates the plugin after this lands, WordPress core's own `Plugin_Upgrader` checks the `Requires PHP:` header and refuses activation with a clear "your PHP version is too old" message. Graceful degradation — no fatal, no WSOD.

## Test plan

- [ ] `php-tests` job runs 4 shards (8.1 / 8.2 / 8.3 / 8.4), all passing
- [ ] Non-PHP jobs continue to pass (js-tests, js-lint, phpcs, phpstan, i18n-check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)