### PR TITLE
CI: add build-freshness + supply-chain audit jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -308,34 +308,80 @@ jobs:
 
       - name: Rebuild and compare
         shell: bash
-        # The webpack output + asset.php + the dataviews CSS copy
-        # are all under `build/`; a single `git diff --exit-code`
-        # on that directory catches any drift. `--` guards against
-        # a future branch where `build` might shadow a rev-spec.
+        # Catches two distinct classes of drift under `build/`:
         #
-        # If drift is detected, emit the diff in the failure log
-        # so the PR author can see exactly which file(s) changed.
-        # For binary / large diffs we cap at a sane line count.
+        #   1. Tracked files whose contents changed. `git diff` is
+        #      the right tool for that.
+        #   2. NEW files webpack emitted this run that aren't yet
+        #      committed — e.g. a future code-splitting bump that
+        #      starts shipping an additional chunk. `git diff`
+        #      alone won't see those (it only inspects tracked
+        #      paths); `git ls-files --others --exclude-standard`
+        #      lists untracked files the build produced. Both
+        #      checks are required: the first catches a content
+        #      regression, the second catches an emit-surface
+        #      expansion.
+        #
+        # `--` guards against a future branch where `build` might
+        # shadow a rev-spec.
+        #
+        # Diff output is capped at 200 lines. Webpack-emitted JS
+        # often has a single minified line that spans tens of
+        # thousands of characters; `git diff` at full length
+        # would bloat the log past GitHub's per-line limit and
+        # truncate in a way that hides which file drifted. 200
+        # lines is enough for a human to see which paths changed
+        # and roughly how; the total line count is reported so
+        # the real magnitude isn't hidden.
         run: |
           npm run build
-          if ! git diff --exit-code -- build/; then
-            echo ""
-            echo "::error::The build/ artifacts are out of date."
-            echo ""
-            echo "The committed webpack output doesn't match what"
-            echo "'npm run build' produces for the current source."
-            echo "That usually means a client/ source change was"
-            echo "committed without rebuilding the admin bundle."
-            echo ""
-            echo "To fix, regenerate locally:"
-            echo ""
-            echo "  npm ci"
-            echo "  npm run build"
-            echo ""
-            echo "Then commit the updated files under build/ and"
-            echo "push again."
-            exit 1
+
+          changed="$(git diff --name-only -- build/)"
+          untracked="$(git ls-files --others --exclude-standard -- build/)"
+
+          if [ -z "$changed" ] && [ -z "$untracked" ]; then
+            exit 0
           fi
+
+          echo ""
+          echo "::error::The build/ artifacts are out of date."
+          echo ""
+          echo "The committed webpack output doesn't match what"
+          echo "'npm run build' produces for the current source."
+          echo "That usually means a client/ source change was"
+          echo "committed without rebuilding the admin bundle."
+          echo ""
+
+          if [ -n "$changed" ]; then
+            echo "Modified files under build/:"
+            echo "$changed" | sed 's/^/  /'
+            echo ""
+
+            diff_lines="$(git diff -- build/ | wc -l | tr -d ' ')"
+            echo "First 200 lines of diff:"
+            echo "--------"
+            git diff -- build/ | sed -n '1,200p'
+            echo "--------"
+            if [ "$diff_lines" -gt 200 ]; then
+              echo "... diff truncated (${diff_lines} total lines)."
+            fi
+            echo ""
+          fi
+
+          if [ -n "$untracked" ]; then
+            echo "New untracked files under build/:"
+            echo "$untracked" | sed 's/^/  /'
+            echo ""
+          fi
+
+          echo "To fix, regenerate locally:"
+          echo ""
+          echo "  npm ci"
+          echo "  npm run build"
+          echo ""
+          echo "Then commit the updated files under build/ and"
+          echo "push again."
+          exit 1
 
   audit:
     # Supply-chain scanning for composer + npm dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,14 +325,17 @@ jobs:
         # `--` guards against a future branch where `build` might
         # shadow a rev-spec.
         #
-        # Diff output is capped at 200 lines. Webpack-emitted JS
-        # often has a single minified line that spans tens of
-        # thousands of characters; `git diff` at full length
-        # would bloat the log past GitHub's per-line limit and
-        # truncate in a way that hides which file drifted. 200
-        # lines is enough for a human to see which paths changed
-        # and roughly how; the total line count is reported so
-        # the real magnitude isn't hidden.
+        # Failure output uses `git diff --stat` rather than the
+        # full content diff. Webpack emits minified JS as a single
+        # enormous line (250+ KiB on one line), which means
+        # content diffs both bloat the CI log AND get truncated
+        # unpredictably by GitHub Actions' per-line length limit
+        # — sometimes hiding exactly the path that drifted. The
+        # `--stat` format gives just `<path> | N ++--` per file,
+        # which is the useful signal for the PR author (which
+        # files + rough magnitude) without printing any code.
+        # The full diff remains available locally after
+        # `npm run build`.
         run: |
           npm run build
 
@@ -357,14 +360,23 @@ jobs:
             echo "$changed" | sed 's/^/  /'
             echo ""
 
-            diff_lines="$(git diff -- build/ | wc -l | tr -d ' ')"
-            echo "First 200 lines of diff:"
+            # Use `--stat` rather than the full content diff. Webpack
+            # emits minified JS as a SINGLE enormous line (250+ KiB of
+            # code on one line), so a content diff would print that
+            # entire line even if only one token changed — and GitHub
+            # Actions truncates long individual lines unpredictably,
+            # hiding the exact path that drifted. `--stat` gives the
+            # shape we actually want here (path + added/removed count
+            # per file) without printing any code, which means the
+            # output stays human-readable and the log stays small.
+            # The full diff is still accessible locally after
+            # `npm run build`; CI's job is just to surface WHICH
+            # files drifted and ROUGHLY how much, not reproduce the
+            # entire regeneration for review.
+            echo "Change summary (git diff --stat):"
             echo "--------"
-            git diff -- build/ | sed -n '1,200p'
+            git diff --stat -- build/
             echo "--------"
-            if [ "$diff_lines" -gt 200 ]; then
-              echo "... diff truncated (${diff_lines} total lines)."
-            fi
             echo ""
           fi
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -281,3 +281,113 @@ jobs:
               exit "$diff_status"
               ;;
           esac
+
+  build-check:
+    # Fails the build when the committed `build/` artifacts drift
+    # from what `npm run build` produces for the current source.
+    # Mirrors the i18n-check pattern: the repo commits webpack
+    # output (so merchants installing the plugin from a zip don't
+    # need Node locally), which means every PR author is
+    # responsible for re-running `npm run build` after touching
+    # `client/`. Easy to forget — and when forgotten, ships a
+    # stale admin bundle with a working `package.json` + asset.php
+    # that look fine on review. This job catches it.
+    name: Build (bundle freshness)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Rebuild and compare
+        shell: bash
+        # The webpack output + asset.php + the dataviews CSS copy
+        # are all under `build/`; a single `git diff --exit-code`
+        # on that directory catches any drift. `--` guards against
+        # a future branch where `build` might shadow a rev-spec.
+        #
+        # If drift is detected, emit the diff in the failure log
+        # so the PR author can see exactly which file(s) changed.
+        # For binary / large diffs we cap at a sane line count.
+        run: |
+          npm run build
+          if ! git diff --exit-code -- build/; then
+            echo ""
+            echo "::error::The build/ artifacts are out of date."
+            echo ""
+            echo "The committed webpack output doesn't match what"
+            echo "'npm run build' produces for the current source."
+            echo "That usually means a client/ source change was"
+            echo "committed without rebuilding the admin bundle."
+            echo ""
+            echo "To fix, regenerate locally:"
+            echo ""
+            echo "  npm ci"
+            echo "  npm run build"
+            echo ""
+            echo "Then commit the updated files under build/ and"
+            echo "push again."
+            exit 1
+          fi
+
+  audit:
+    # Supply-chain scanning for composer + npm dependencies.
+    #
+    # npm audit is scoped to `--omit=dev` because
+    # `@wordpress/scripts` and the rest of the build toolchain
+    # transitively pull in old puppeteer / ws / glob versions that
+    # routinely carry advisories — those affect the build
+    # toolchain on developer machines, not the code that ships to
+    # merchants. Making every PR red when a transitive dev-dep
+    # gets a CVE would buy false urgency. Production deps only
+    # (`@wordpress/api-fetch`, components, data, element, i18n,
+    # icons, dataviews) get the high-severity gate. If the plugin
+    # ever adds a hard production runtime dep (SDK, 3rd-party
+    # client), the scan surface expands automatically via
+    # package.json's `dependencies` block.
+    #
+    # `--audit-level=high` exits nonzero on high/critical
+    # advisories only; moderate + low pass. Severe CVEs surface
+    # fast; noise stays quiet.
+    #
+    # Composer audit has no severity filter (composer 2.9). The
+    # plugin's composer deps are all dev-only (PHPUnit, PHPStan,
+    # wpcs), so any advisory there reaches developers not
+    # merchants — but we still want to know about it promptly, so
+    # composer-audit stays unfiltered.
+    name: Security audit (composer + npm)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          tools: composer:v2
+          coverage: none
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: composer audit
+        run: composer audit --format=plain
+
+      - name: npm audit (production deps, high severity)
+        run: npm audit --omit=dev --audit-level=high

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -441,8 +441,18 @@ jobs:
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist
 
-      - name: Install npm dependencies
-        run: npm ci
+      - name: Install npm dependencies (production only)
+        # `--omit=dev` aligns with `npm audit --omit=dev` below:
+        # since the audit step scopes to production deps only,
+        # installing the devDependencies tree (several hundred MB
+        # of @wordpress/scripts + puppeteer + webpack, including
+        # lifecycle scripts like puppeteer's Chromium download)
+        # buys nothing for this job. Skipping them shaves minutes
+        # off install time and also cuts the attack surface —
+        # fewer lifecycle scripts run means fewer opportunities
+        # for a transitive dev-dep to execute arbitrary code in
+        # the CI environment.
+        run: npm ci --omit=dev
 
       - name: composer audit
         run: composer audit --format=plain


### PR DESCRIPTION
## Summary

Adds two CI jobs to `.github/workflows/ci.yml`:

- **build-check** — fails the build when the committed `build/` artifacts drift from what `npm run build` produces for the current source. Catches both modified tracked files and newly-emitted untracked ones.
- **audit** — runs `composer audit` (unfiltered, dev-only deps) and `npm audit --omit=dev --audit-level=high` (production deps, high severity).

## Why

### `build-check`

The repo commits webpack output (so merchants installing from a zip don't need Node locally). Every PR that touches `client/` is responsible for re-running the build. Easy to forget — and when forgotten, a merchant installs a zip whose JS lags behind the PHP they just got. Same class of "regen-required, humans forget" bug that PR #66 put under CI enforcement for `.pot`.

On failure, the job prints (1) the list of modified files, (2) a `git diff --stat` summary (path + insertion/deletion counts, no code content — minified webpack output would otherwise bloat the log and truncate unpredictably), (3) any newly-untracked files under `build/`, and (4) the copy-paste regen command:

```
npm ci
npm run build
```

### `audit`

Supply-chain scanning. Composer audit is unfiltered since all composer deps are dev-only (PHPUnit, PHPStan, wpcs) — any advisory is worth looking at even if it doesn't ship to merchants.

**npm audit scope decisions:**

- **`--omit=dev`**: `@wordpress/scripts` transitively pulls in old `puppeteer` / `ws` / `glob` / etc. that ship CVEs on a rolling basis. Those affect the build toolchain on developer machines, not merchant installs. Auditing dev-tooling would fail every PR every time upstream ships a minor advisory, burning trust in the signal. Production deps (`@wordpress/api-fetch`, components, data, element, i18n, icons, dataviews) stay in scope.
- **`--audit-level=high`**: high/critical advisories = real merchant exposure; moderate/low in a dev-bundle ecosystem carry too much noise. Can tighten later if the production graph stabilizes.

Locally validated: `composer audit` returns clean, `npm audit --omit=dev --audit-level=high` exits 0 (4 moderate advisories are listed for visibility but pass the high filter).

## Deliberately out of scope

- **CSS lint job.** The `lint:css` npm script exists but there are currently no `.css` or `.scss` files under `client/` (plugin uses inline style props per AGENTS.md). The job would pass trivially on zero files. Add it the moment the first CSS/SCSS file lands; adding it preemptively would just be dead workflow weight.

## Job count after this PR merges

`.github/workflows/ci.yml` will define **8 jobs**: php-tests, js-tests, js-lint, phpcs, phpstan, i18n-check, **build-check**, **audit**. Because `php-tests` runs as a 4-entry matrix (PHP 8.1/8.2/8.3/8.4), GitHub will report **11 job runs per PR** total.

## Test plan

- [ ] Main after this merges shows all 8 jobs green for a normal PR (11 runs including the matrix shards)
- [ ] A PR that modifies `client/` but doesn't re-run `npm run build` fails `build-check` with a `--stat` summary and the regeneration command in the error log
- [ ] A PR that adds a new untracked file under `build/` is caught by the `git ls-files --others` check
- [ ] A future production-dep advisory with severity ≥ high would fail the `audit` job; moderate/low would surface in output but pass
- [ ] Neither new job adds runtime to the blocking path (both are parallel with php-tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)