### PR TITLE
Release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+## [0.1.2] – 2026-04-24
+
+### Features
+- **Products tab: decouple browse-state from scoping commit** — Clicking a taxonomy tab (Categories / Tags / Brands) inside the By-taxonomy row is now browse-only. The persisted scoping mode is no longer flipped on tab click, which removed a spurious "No tags selected, products hidden" warning that fired for merchants with a valid brand-scoped catalog who clicked the Tags tab to look around. The warning now tracks the *enforcing* mode, not the viewed tab. ([#71](https://github.com/Automattic/woocommerce-ai-storefront/pull/71))
+
+### Fixes
+- **llms.txt: hide category list when scoping by brand / tag / selected products** — Previously, the Product Categories section emitted the top-20 store categories in every mode, so a merchant scoping to a single brand saw their llms.txt advertise categories unrelated to the scoped catalog. Now only emitted for `all` and `categories` modes. ([#70](https://github.com/Automattic/woocommerce-ai-storefront/pull/70))
+- **llms.txt: use prefixed UCP IDs in the Attribution request-body example** — Changed `"id": "123"` to `"id": "prod_123"` to match the wire format UCP catalog/search/lookup responses actually emit; agents copy-pasting the example would otherwise POST a raw numeric ID and be rejected by `parse_ucp_id()`. ([#70](https://github.com/Automattic/woocommerce-ai-storefront/pull/70))
+
+### UI polish
+- **Remove sample-product grid from the "All products" row** — The 6-tile preview rendered as half-empty placeholder boxes on fresh-install / staging stores, reading as "looks half-broken" rather than "here's your catalog." Count pill + deep link carry the information value. ([#70](https://github.com/Automattic/woocommerce-ai-storefront/pull/70))
+- **By-taxonomy row: multi-count badge + conditional copy** — Badge now surfaces every non-zero taxonomy count (e.g. "3 categories · 1 brand") so a merchant flipping tabs doesn't lose sight of their full scope. Separator exposed as a translatable string for RTL locales. Badge is suppressed when the By-taxonomy row isn't selected and no counts apply. ([#71](https://github.com/Automattic/woocommerce-ai-storefront/pull/71))
+- **llms.txt declutter** — Dropped stale post-v2.0.0 archaeology comments, URL-template patterns that contradicted the POST-first checkout posture, and the merchant-facing agent-mapping table. Collapsed programmatic-verification bullets into a single pointer. ([#70](https://github.com/Automattic/woocommerce-ai-storefront/pull/70))
+
+---
+
 ## [0.1.1] – 2026-04-24
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-ai-storefront",
-	"version": "0.1.1",
+	"version": "0.1.2",
 	"description": "Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude).",
 	"author": "WooCommerce",
 	"license": "GPL-3.0-or-later",

--- a/woocommerce-ai-storefront.php
+++ b/woocommerce-ai-storefront.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Storefront
  * Plugin URI: https://woocommerce.com/
  * Description: Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control — store-only checkout, standard WooCommerce attribution.
- * Version: 0.1.1
+ * Version: 0.1.2
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-storefront
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_STOREFRONT_VERSION', '0.1.1' );
+define( 'WC_AI_STOREFRONT_VERSION', '0.1.2' );
 define( 'WC_AI_STOREFRONT_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_STOREFRONT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_STOREFRONT_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Summary

Bump to **0.1.2**, rolling up PRs #70 + #71.

## What's in this release

### Features
- **Products tab: decouple browse-state from scoping commit** (#71) — Tab clicks inside the By-taxonomy row are now browse-only. The persisted mode no longer flips on tab click, removing a spurious "products hidden" warning that fired when a merchant with a valid brand-scoped catalog clicked the Tags tab to browse.

### Fixes
- **llms.txt: hide category list when scoping by brand / tag / selected products** (#70) — Top-20 categories no longer advertised for modes where they would be misleading (e.g. a single-brand scope surfacing cross-brand categories).
- **llms.txt: use prefixed UCP IDs in attribution example** (#70) — `"id": "123"` → `"id": "prod_123"` to match the wire format agents actually receive.

### UI polish
- **Remove sample-product grid from the "All products" row** (#70) — 6-tile placeholder preview read as "looks half-broken" on fresh-install stores; count pill + deep link carry the information value.
- **By-taxonomy row: multi-count badge + conditional copy** (#71) — "3 categories · 1 brand" style badge, RTL-safe separator, suppressed when the row isn't selected and no counts apply.
- **llms.txt declutter** (#70) — Post-v2.0.0 archaeology + URL-template patterns + merchant-facing agent-mapping table dropped.

## Test plan

- [ ] Install on a fresh store → Products tab renders without the sample grid; By-taxonomy row shows badge-less on mode=all.
- [ ] Scope to a single brand → llms.txt shows no `## Product Categories` section.
- [ ] `POST /wc/ucp/v1/checkout-sessions` with `"item": { "id": "prod_123" }` works; the llms.txt example copy-pastes into a working request.
- [ ] By-taxonomy row: set mode=brands, click Tags tab, confirm NO "No tags selected, products hidden" warning.
- [ ] Click "Select all" in Categories tab from mode=all → mode flips to `categories` and the server enforces the selection on next Save.
- [ ] CI green on all 11 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)