### PR TITLE
0.1.7: scope Store API filter to UCP + add llms.txt tag/brand sections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [0.1.7] – 2026-04-25
+
+### Fixes
+- **Store API filter is now scoped to UCP-controller dispatches.** Pre-0.1.7 the `woocommerce_store_api_product_collection_query_args` filter was registered globally — every Store API consumer (front-end Cart, block-theme Checkout, themes, third-party plugins) silently saw the merchant's AI scoping applied to their own queries. The Products tab is labeled "Products available to AI crawlers"; applying the scope to non-AI Store API traffic violated that promise. New `enter_ucp_dispatch()` / `exit_ucp_dispatch()` markers wrap the UCP REST controller's `rest_do_request` calls; the filter self-gates and returns args unchanged outside that scope.
+- **llms.txt now lists selected tags and brands, not just categories.** Pre-0.1.7 only the `## Product Categories` section emitted under `by_taxonomy` mode, so a merchant scoping by 3 categories + 1 tag + 1 brand saw only the categories. Now emits three independent sections (`## Product Categories`, `## Product Tags`, `## Product Brands`), each populated from its corresponding `selected_*` array.
+
+### Tests
+- Two new tests for the Store API filter UCP-dispatch gate (`test_filter_is_noop_outside_ucp_dispatch`, `test_dispatch_depth_counter_balances`).
+- LlmsTxtTest's `categories_section_suppressed_when_only_tags_brands_selected` extended to verify the new tag and brand sections render with their own fixtures.
+
+---
+
 ## [0.1.6] – 2026-04-25
 
 ### Fixes

--- a/includes/ai-storefront/class-wc-ai-storefront-llms-txt.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-llms-txt.php
@@ -308,17 +308,47 @@ class WC_AI_Storefront_Llms_Txt {
 			$lines[] = '';
 		}
 
-		// Product categories summary.
-		$categories = $this->get_syndicated_categories( $settings );
-		if ( ! empty( $categories ) ) {
-			$lines[] = '## Product Categories';
+		// Per-taxonomy navigation summary. Three independent
+		// sections (categories / tags / brands) so an agent reading
+		// llms.txt sees ALL the dimensions in scope, not just the
+		// category dimension. Pre-0.1.6 only categories rendered,
+		// which under-reported what merchants had configured —
+		// e.g., a merchant scoping by 3 categories + 1 tag + 1
+		// brand saw only the 3 categories, with no signal that
+		// tags or brands were also part of the scope.
+		//
+		// Each section follows the same shape: a heading + a
+		// bulleted list of `[term name](term link) (N products)`
+		// entries. The same per-taxonomy gate applies (see
+		// `get_syndicated_terms()`) so a section is suppressed
+		// when its corresponding `selected_*` array is empty in
+		// `by_taxonomy` mode.
+		$taxonomy_sections = [
+			[
+				'heading' => '## Product Categories',
+				'terms'   => $this->get_syndicated_categories( $settings ),
+			],
+			[
+				'heading' => '## Product Tags',
+				'terms'   => $this->get_syndicated_tags( $settings ),
+			],
+			[
+				'heading' => '## Product Brands',
+				'terms'   => $this->get_syndicated_brands( $settings ),
+			],
+		];
+		foreach ( $taxonomy_sections as $section ) {
+			if ( empty( $section['terms'] ) ) {
+				continue;
+			}
+			$lines[] = $section['heading'];
 			$lines[] = '';
-			foreach ( $categories as $category ) {
-				$link = get_term_link( $category );
+			foreach ( $section['terms'] as $term ) {
+				$link = get_term_link( $term );
 				if ( ! is_wp_error( $link ) ) {
-					$cat_name    = html_entity_decode( wp_strip_all_tags( $category->name ), ENT_QUOTES, 'UTF-8' );
-					$count_label = 1 === (int) $category->count ? 'product' : 'products';
-					$lines[]     = "- [{$cat_name}]({$link}) ({$category->count} {$count_label})";
+					$term_name   = html_entity_decode( wp_strip_all_tags( $term->name ), ENT_QUOTES, 'UTF-8' );
+					$count_label = 1 === (int) $term->count ? 'product' : 'products';
+					$lines[]     = "- [{$term_name}]({$link}) ({$term->count} {$count_label})";
 				}
 			}
 			$lines[] = '';
@@ -529,71 +559,90 @@ class WC_AI_Storefront_Llms_Txt {
 	}
 
 	private function get_syndicated_categories( $settings ) {
+		return $this->get_syndicated_terms( $settings, 'product_cat', 'selected_categories' );
+	}
+
+	private function get_syndicated_tags( $settings ) {
+		return $this->get_syndicated_terms( $settings, 'product_tag', 'selected_tags' );
+	}
+
+	private function get_syndicated_brands( $settings ) {
+		// `product_brand` is WC 9.5+. Without the taxonomy
+		// registered, return empty rather than emit a `get_terms()`
+		// call against an unknown taxonomy.
+		if ( ! taxonomy_exists( 'product_brand' ) ) {
+			return [];
+		}
+		return $this->get_syndicated_terms( $settings, 'product_brand', 'selected_brands' );
+	}
+
+	/**
+	 * Resolve syndicated terms for a given taxonomy + selection key.
+	 *
+	 * The three `## Product {Categories,Tags,Brands}` sections in
+	 * llms.txt are navigation hints: "here's the shape of what
+	 * this store sells." We only emit them when truthful relative
+	 * to the merchant's actual scoping:
+	 *
+	 *   - `all` → top-N-by-count list (every term reachable).
+	 *   - `by_taxonomy` with the matching `selected_*` non-empty
+	 *     → list those selected terms. Other taxonomies in the
+	 *     UNION may widen the product set, but THIS taxonomy's
+	 *     selections are a real (sub)set of the scope and listing
+	 *     them gives agents accurate navigation. Under-reports
+	 *     rather than over-reports — agents that want precision
+	 *     enumerate via the Store API, which applies the full
+	 *     UNION filter.
+	 *   - `by_taxonomy` with the matching `selected_*` empty →
+	 *     suppressed for that taxonomy.
+	 *   - `selected` → suppressed (individual product picking;
+	 *     taxonomy aggregation doesn't describe scope shape).
+	 *
+	 * Defensive legacy-mode fallback: pre-0.1.5 stored values of
+	 * `categories` / `tags` / `brands` route through `by_taxonomy`.
+	 *
+	 * On term counts: when listing selected terms, `get_terms()`
+	 * returns the TOTAL products in each term — not the subset
+	 * matching the full UNION. The displayed count can differ
+	 * from what Store API returns. Acceptable for a navigation
+	 * hint.
+	 *
+	 * @param array  $settings      Plugin settings.
+	 * @param string $taxonomy      Taxonomy slug
+	 *                              (`product_cat` / `product_tag`
+	 *                              / `product_brand`).
+	 * @param string $selection_key Settings key holding the
+	 *                              merchant's selected term IDs
+	 *                              for this taxonomy.
+	 * @return array<int, WP_Term>
+	 */
+	private function get_syndicated_terms( $settings, $taxonomy, $selection_key ) {
 		$product_mode = $settings['product_selection_mode'] ?? 'all';
 
-		// Defensive legacy-mode fallback. Pre-0.1.5 enum values
-		// (`categories` / `tags` / `brands`) map to `by_taxonomy`
-		// under UNION enforcement. The silent migration in
-		// `WC_AI_Storefront::get_settings()` rewrites stored values,
-		// but handle direct callers defensively.
 		if ( in_array( $product_mode, [ 'categories', 'tags', 'brands' ], true ) ) {
 			$product_mode = 'by_taxonomy';
-		}
-
-		// The `## Product Categories` section is a navigation hint:
-		// "here's the shape of what this store sells." We only emit
-		// it when it's truthful relative to the merchant's actual
-		// scoping:
-		//
-		//   - `all` → top-N-by-count list (every category reachable).
-		//   - `by_taxonomy` with `selected_categories` non-empty →
-		//     list those selected categories. Tags/brands may add
-		//     more products via the UNION, but the selected
-		//     categories ARE a real (sub)set of the scope and
-		//     listing them gives agents accurate navigation into
-		//     the catalog portion defined by category scoping.
-		//     Under-reports rather than over-reports: agents that
-		//     want the full product set enumerate via Store API,
-		//     which applies the full UNION filter.
-		//
-		// Suppressed otherwise:
-		//
-		//   - `by_taxonomy` with no `selected_categories` (only tags
-		//     and/or brands) → no category is actually in scope;
-		//     listing top store categories would advertise products
-		//     the scope excludes.
-		//   - `selected` → individual product picking; category
-		//     aggregation doesn't describe the scope shape.
-		//
-		// Silent on-trailing category counts: when we list selected
-		// categories, the counts returned by `get_terms()` reflect
-		// the TOTAL products in each category, not just the subset
-		// matching the UNION. That's a minor inaccuracy when the
-		// merchant has also set `selected_tags`/`selected_brands`
-		// that narrow within those categories — the displayed
-		// count can be higher than what Store API will actually
-		// return. Acceptable for a navigation hint; agents that
-		// need precision hit Store API.
-		$has_selected_categories = ! empty( $settings['selected_categories'] );
-
-		if ( 'by_taxonomy' === $product_mode && ! $has_selected_categories ) {
-			return [];
 		}
 
 		if ( ! in_array( $product_mode, [ 'all', 'by_taxonomy' ], true ) ) {
 			return [];
 		}
 
+		$has_selection = ! empty( $settings[ $selection_key ] );
+
+		if ( 'by_taxonomy' === $product_mode && ! $has_selection ) {
+			return [];
+		}
+
 		$args = [
-			'taxonomy'   => 'product_cat',
+			'taxonomy'   => $taxonomy,
 			'hide_empty' => true,
 			'orderby'    => 'count',
 			'order'      => 'DESC',
 			'number'     => 20,
 		];
 
-		if ( 'by_taxonomy' === $product_mode && $has_selected_categories ) {
-			$args['include'] = array_map( 'absint', $settings['selected_categories'] );
+		if ( 'by_taxonomy' === $product_mode && $has_selection ) {
+			$args['include'] = array_map( 'absint', $settings[ $selection_key ] );
 			$args['number']  = 0;
 		}
 

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -324,7 +324,18 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			$store_request->set_param( $k, $v );
 		}
 
-		$store_response = rest_do_request( $store_request );
+		// Mark this dispatch as UCP-initiated so the Store API
+		// query-args filter fires (the filter is otherwise
+		// self-gated to no-op outside UCP scope — see
+		// `WC_AI_Storefront_UCP_Store_API_Filter` class docblock).
+		// `try/finally` ensures the depth is decremented even if
+		// `rest_do_request()` throws.
+		WC_AI_Storefront_UCP_Store_API_Filter::enter_ucp_dispatch();
+		try {
+			$store_response = rest_do_request( $store_request );
+		} finally {
+			WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+		}
 
 		if ( $store_response instanceof WP_Error ) {
 			WC_AI_Storefront_Logger::debug(

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-store-api-filter.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-store-api-filter.php
@@ -1,26 +1,33 @@
 <?php
 /**
- * AI Syndication: Store API Product Collection Filter
+ * AI Storefront: Store API Product Collection Filter
  *
  * Hooks `woocommerce_store_api_product_collection_query_args` to
  * restrict Store API product queries according to the plugin's
- * `product_selection_mode` setting. Without this filter, the
- * merchant's "only these categories" or "only these products"
- * choice silently applies to llms.txt / JSON-LD but NOT to the
- * Store API — meaning AI agents hitting our UCP catalog routes
- * would see every product, including ones the merchant explicitly
- * chose to hide.
+ * `product_selection_mode` setting — but ONLY when the request is
+ * a UCP-controller-initiated dispatch (i.e., an AI agent hit
+ * `/wc/ucp/v1/catalog/...` and the controller is delegating to
+ * `/wc/store/v1/products` via `rest_do_request`).
  *
- * The filter fires for ALL Store API product queries (not just
- * UCP routes), which is intentional — if a merchant configures
- * "only these products," they mean it everywhere (including
- * block-theme Cart/Checkout blocks that hit Store API). Merchants
- * who need the filter scoped only to UCP routes can toggle the
- * selection mode back to "all" and rely on their own storefront
- * controls.
+ * Why scoped: the Products tab is labeled "Products available to
+ * AI crawlers" — the merchant's mental model is "filter what AI
+ * sees." Applying the filter to every Store API call (front-end
+ * cart, block-theme Checkout, third-party plugins consuming
+ * Store API) would silently scope the merchant's own storefront
+ * to whatever they configured for AI, which violates the UI
+ * promise.
+ *
+ * How scoping works: the UCP REST controller calls
+ * `enter_ucp_dispatch()` immediately before each
+ * `rest_do_request()` and `exit_ucp_dispatch()` immediately after
+ * (in a `try/finally` so an exception still cleans up). The
+ * filter checks `is_in_ucp_dispatch()` and short-circuits to
+ * "no-op return $args" outside that scope. A counter (not a
+ * boolean) handles nested dispatches, though current code never
+ * nests.
  *
  * @package WooCommerce_AI_Storefront
- * @since 1.3.0
+ * @since 1.3.0 (initial); 0.1.7 (UCP-scoped enforcement)
  */
 
 defined( 'ABSPATH' ) || exit;
@@ -29,6 +36,27 @@ defined( 'ABSPATH' ) || exit;
  * Restricts Store API product queries to the plugin's selected products/categories.
  */
 class WC_AI_Storefront_UCP_Store_API_Filter {
+
+	/**
+	 * Depth counter for UCP-initiated dispatches.
+	 *
+	 * Incremented by `enter_ucp_dispatch()` before every UCP
+	 * controller call to `rest_do_request()`, decremented by
+	 * `exit_ucp_dispatch()` immediately after (in a `finally`
+	 * block so exceptions don't leak the depth). The query-args
+	 * filter checks this counter and short-circuits when zero,
+	 * meaning Store API requests OUTSIDE UCP-controller dispatch
+	 * (front-end cart, block-theme Checkout, third-party Store
+	 * API consumers) are unaffected by the merchant's AI-scoping
+	 * settings.
+	 *
+	 * Counter (not boolean) so nested dispatches still terminate
+	 * correctly — current code doesn't nest, but future
+	 * controllers might compose UCP requests internally.
+	 *
+	 * @var int
+	 */
+	private static int $ucp_dispatch_depth = 0;
 
 	/**
 	 * Register the query-args filter.
@@ -43,6 +71,35 @@ class WC_AI_Storefront_UCP_Store_API_Filter {
 			'woocommerce_store_api_product_collection_query_args',
 			[ $this, 'restrict_to_syndicated_products' ]
 		);
+	}
+
+	/**
+	 * Mark the start of a UCP-controller-initiated Store API
+	 * dispatch. Pair with `exit_ucp_dispatch()` in a `try/finally`
+	 * around every `rest_do_request()` call inside the UCP REST
+	 * controller. Enables the query-args filter for the duration
+	 * of the inner dispatch.
+	 */
+	public static function enter_ucp_dispatch(): void {
+		self::$ucp_dispatch_depth++;
+	}
+
+	/**
+	 * Mark the end of a UCP-controller-initiated Store API
+	 * dispatch. Idempotent: never decrements below zero, so an
+	 * accidental double-call from a `finally` block can't leak
+	 * negative depth.
+	 */
+	public static function exit_ucp_dispatch(): void {
+		self::$ucp_dispatch_depth = max( 0, self::$ucp_dispatch_depth - 1 );
+	}
+
+	/**
+	 * Whether the current Store API request is inside a
+	 * UCP-controller dispatch. Public so tests can introspect.
+	 */
+	public static function is_in_ucp_dispatch(): bool {
+		return self::$ucp_dispatch_depth > 0;
 	}
 
 	/**
@@ -112,6 +169,18 @@ class WC_AI_Storefront_UCP_Store_API_Filter {
 	 * @return array<string, mixed>      Modified args.
 	 */
 	public function restrict_to_syndicated_products( array $args ): array {
+		// UCP-dispatch gate. The filter is registered globally
+		// (WordPress doesn't expose a "fire only for these
+		// callers" registration), so we self-gate based on the
+		// UCP controller's enter/exit_ucp_dispatch markers. Any
+		// Store API request OUTSIDE that scope (front-end cart,
+		// block-theme Checkout, theme product carousels, third-
+		// party plugins consuming Store API) returns args
+		// unchanged.
+		if ( ! self::is_in_ucp_dispatch() ) {
+			return $args;
+		}
+
 		$settings = WC_AI_Storefront::get_settings();
 		$mode     = $settings['product_selection_mode'] ?? 'all';
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-24T22:45:58+00:00\n"
+"POT-Creation-Date: 2026-04-24T23:03:18+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -79,167 +79,167 @@ msgid "RFC 3339 / ISO 8601 timestamp (UTC, `Z`-suffixed) of the product's last m
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:271
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:760
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:956
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:771
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:967
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:336
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:363
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:347
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:374
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:787
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:798
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:797
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:808
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:815
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:826
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:967
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:978
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:977
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:988
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1121
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1132
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1140
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1151
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1178
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1189
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1999
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2010
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2070
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2081
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2101
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2112
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2121
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2132
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2146
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2157
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2179
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2190
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2215
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2226
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2246
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2257
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2318
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2329
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2369
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2380
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2399
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2410
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2489
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2500
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2728
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2739
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2763
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2774
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3177
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3188
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3328
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3339
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3332
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3343
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3336
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3347
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3338
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3349
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3340
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3351
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3344
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3355
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3346
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3357
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-ai-storefront",
-	"version": "0.1.6",
+	"version": "0.1.7",
 	"description": "Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude).",
 	"author": "WooCommerce",
 	"license": "GPL-3.0-or-later",

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -69,6 +69,12 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		Functions\when( 'wc_get_products' )->justReturn( [] );
 		Functions\when( 'apply_filters' )->returnArg( 2 );
 
+		// `get_syndicated_brands()` consults `taxonomy_exists` to
+		// decide whether to query the `product_brand` taxonomy.
+		// Default to true so brand-aware tests work; brand-absent
+		// tests can override.
+		Functions\when( 'taxonomy_exists' )->justReturn( true );
+
 		// Sitemap-discovery stubs. Default: nothing found (no sitemap
 		// section in output). Individual tests override via
 		// `Functions\when()->alias()` to simulate found sitemaps.
@@ -730,13 +736,45 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 	 * nothing is more truthful than a wrong list.
 	 */
 	public function test_llms_txt_categories_section_suppressed_when_only_tags_brands_selected(): void {
+		// Taxonomy-aware stub: only the `product_cat` query needs
+		// to be specifically tested. Tag and brand queries return
+		// their own fixture data so the `## Product Tags` and
+		// `## Product Brands` sections (added in 0.1.7) get
+		// reasonable mocks rather than the category fixture
+		// leaking across taxonomy boundaries.
 		$category          = new stdClass();
 		$category->name    = 'Clothing';
 		$category->slug    = 'clothing';
 		$category->count   = 42;
 		$category->term_id = 1;
 
-		Functions\when( 'get_terms' )->justReturn( [ $category ] );
+		$tag          = new stdClass();
+		$tag->name    = 'Summer';
+		$tag->slug    = 'summer';
+		$tag->count   = 5;
+		$tag->term_id = 7;
+
+		$brand          = new stdClass();
+		$brand->name    = 'Acme';
+		$brand->slug    = 'acme';
+		$brand->count   = 3;
+		$brand->term_id = 3;
+
+		Functions\when( 'get_terms' )->alias(
+			static function ( $args ) use ( $category, $tag, $brand ) {
+				$taxonomy = $args['taxonomy'] ?? '';
+				if ( 'product_cat' === $taxonomy ) {
+					return [ $category ];
+				}
+				if ( 'product_tag' === $taxonomy ) {
+					return [ $tag ];
+				}
+				if ( 'product_brand' === $taxonomy ) {
+					return [ $brand ];
+				}
+				return [];
+			}
+		);
 
 		WC_AI_Storefront::$test_settings = [
 			'enabled'                => 'yes',
@@ -748,8 +786,18 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 
 		$output = $this->llms->generate();
 
+		// Categories section suppressed: empty `selected_categories`
+		// + `by_taxonomy` mode means no category is in scope.
 		$this->assertStringNotContainsString( '## Product Categories', $output );
 		$this->assertStringNotContainsString( 'Clothing', $output );
+
+		// Tag and brand sections render with their own fixtures —
+		// the merchant's tag and brand selections ARE in scope
+		// (UNION semantics).
+		$this->assertStringContainsString( '## Product Tags', $output );
+		$this->assertStringContainsString( 'Summer', $output );
+		$this->assertStringContainsString( '## Product Brands', $output );
+		$this->assertStringContainsString( 'Acme', $output );
 	}
 
 	/**

--- a/tests/php/unit/UcpStoreApiFilterTest.php
+++ b/tests/php/unit/UcpStoreApiFilterTest.php
@@ -39,11 +39,79 @@ class UcpStoreApiFilterTest extends \PHPUnit\Framework\TestCase {
 		\Brain\Monkey\setUp();
 		\Brain\Monkey\Functions\when( 'taxonomy_exists' )->justReturn( true );
 		WC_AI_Storefront::$test_settings = [];
+
+		// As of 0.1.7 the filter is gated to UCP-controller-
+		// initiated dispatches via an `is_in_ucp_dispatch()`
+		// counter check. Tests that exercise the enforcement
+		// behavior need to enter that scope; tearDown exits it
+		// so a leak from one test can't contaminate another.
+		// The dedicated test
+		// `test_filter_is_noop_outside_ucp_dispatch` exits before
+		// asserting, then re-enters in its own finally so this
+		// shared lifecycle stays consistent.
+		\WC_AI_Storefront_UCP_Store_API_Filter::enter_ucp_dispatch();
 	}
 
 	protected function tearDown(): void {
+		\WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
 		\Brain\Monkey\tearDown();
 		parent::tearDown();
+	}
+
+	// ------------------------------------------------------------------
+	// UCP-dispatch gate (0.1.7+)
+	// ------------------------------------------------------------------
+
+	public function test_filter_is_noop_outside_ucp_dispatch(): void {
+		// 0.1.7 scoped the filter to UCP-controller-initiated
+		// dispatches so unrelated Store API consumers (front-end
+		// cart, block-theme Checkout, themes, third-party plugins)
+		// aren't silently scoped to the merchant's AI settings.
+		// The shared setUp() enters UCP scope; this test exits to
+		// exercise the no-op path, then re-enters so tearDown's
+		// pair stays balanced.
+		\WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+		try {
+			WC_AI_Storefront::$test_settings = [
+				'product_selection_mode' => 'by_taxonomy',
+				'selected_categories'    => [ 5, 12 ],
+			];
+
+			$filter = new WC_AI_Storefront_UCP_Store_API_Filter();
+			$input  = [ 'orderby' => 'date', 'posts_per_page' => 10 ];
+			$result = $filter->restrict_to_syndicated_products( $input );
+
+			// No tax_query, no post__in injection — the filter
+			// short-circuited because we're outside UCP scope.
+			$this->assertSame( $input, $result );
+		} finally {
+			\WC_AI_Storefront_UCP_Store_API_Filter::enter_ucp_dispatch();
+		}
+	}
+
+	public function test_dispatch_depth_counter_balances(): void {
+		// Counter starts at 1 (set by shared setUp). Verify the
+		// enter/exit pair is balanced so a nested dispatch
+		// doesn't leak depth into subsequent tests.
+		$this->assertTrue( \WC_AI_Storefront_UCP_Store_API_Filter::is_in_ucp_dispatch() );
+
+		\WC_AI_Storefront_UCP_Store_API_Filter::enter_ucp_dispatch();
+		$this->assertTrue( \WC_AI_Storefront_UCP_Store_API_Filter::is_in_ucp_dispatch() );
+
+		\WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+		$this->assertTrue( \WC_AI_Storefront_UCP_Store_API_Filter::is_in_ucp_dispatch() );
+
+		// Excessive exit_ucp_dispatch() is idempotent (clamps
+		// to zero) so a buggy controller can't drive the counter
+		// negative.
+		\WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+		\WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+		\WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+		$this->assertFalse( \WC_AI_Storefront_UCP_Store_API_Filter::is_in_ucp_dispatch() );
+
+		// Restore so tearDown's exit_ucp_dispatch can decrement
+		// to a clean state (zero) before the next test's setUp.
+		\WC_AI_Storefront_UCP_Store_API_Filter::enter_ucp_dispatch();
 	}
 
 	// ------------------------------------------------------------------

--- a/woocommerce-ai-storefront.php
+++ b/woocommerce-ai-storefront.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Storefront
  * Plugin URI: https://woocommerce.com/
  * Description: Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control — store-only checkout, standard WooCommerce attribution.
- * Version: 0.1.6
+ * Version: 0.1.7
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-storefront
@@ -22,7 +22,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_STOREFRONT_VERSION', '0.1.6' );
+define( 'WC_AI_STOREFRONT_VERSION', '0.1.7' );
 define( 'WC_AI_STOREFRONT_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_STOREFRONT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_STOREFRONT_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
## Summary

Two architectural fixes addressing user-reported gaps in 0.1.6:

### 1. Store API filter scoped to UCP dispatches

**Before**: \`woocommerce_store_api_product_collection_query_args\` filter applied to **every** Store API consumer — front-end Cart, block-theme Checkout, themes, third-party plugins consuming Store API for product carousels. The Products tab is labeled "Products available to AI crawlers"; silently scoping the merchant's own storefront violated the UI's promise.

**After**: counter-based UCP-dispatch scope. The UCP REST controller calls \`enter_ucp_dispatch()\` immediately before each \`rest_do_request()\` and \`exit_ucp_dispatch()\` immediately after (try/finally protected). The filter self-gates and returns \`\$args\` unchanged outside that scope.

The 0.1.5 file-level docblock claimed the global scope was \"intentional\" — that claim was wrong; this commit updates the docblock to reflect the actual desired behavior.

### 2. llms.txt now lists selected tags and brands

**Before**: only \`## Product Categories\` rendered under \`by_taxonomy\` mode. A merchant scoping by 3 categories + 1 tag + 1 brand saw only the categories.

**After**: three independent sections (\`## Product Categories\`, \`## Product Tags\`, \`## Product Brands\`), each populated from its \`selected_*\` array. \`get_syndicated_categories()\` consolidated into a parameterized \`get_syndicated_terms()\` helper shared across all three taxonomies.

## Test plan

- [ ] Set mode=by_taxonomy with 1 category + 1 tag + 1 brand → llms.txt shows all three \`## Product *\` sections.
- [ ] Open the front-end Cart block on a store with mode=by_taxonomy → cart shows ALL the merchant's products (not just the AI-scoped subset).
- [ ] Hit \`POST /wc/ucp/v1/catalog/search\` from outside the admin → response is properly scoped (UCP dispatch enters scope).
- [ ] CI green on all 11 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)