### PR TITLE
Refactor: drop em-dash from plugin description

### DIFF
--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-26T07:23:52+00:00\n"
+"POT-Creation-Date: 2026-04-26T07:30:32+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -27,7 +27,7 @@ msgstr ""
 
 #. Description of the plugin
 #: woocommerce-ai-storefront.php
-msgid "Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control — store-only checkout, standard WooCommerce attribution."
+msgid "Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control with store-only checkout and standard WooCommerce attribution."
 msgstr ""
 
 #. Author of the plugin

--- a/woocommerce-ai-storefront.php
+++ b/woocommerce-ai-storefront.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: WooCommerce AI Storefront
  * Plugin URI: https://woocommerce.com/
- * Description: Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control — store-only checkout, standard WooCommerce attribution.
+ * Description: Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control with store-only checkout and standard WooCommerce attribution.
  * Version: 0.2.0
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/


### PR DESCRIPTION
## Summary

Em-dash (\`—\`) in the plugin Description header rendered inconsistently across WP plugin-listing surfaces. Replaced with an ASCII-clean equivalent.

## Before
> Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control — store-only checkout, standard WooCommerce attribution.

## After
> Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control with store-only checkout and standard WooCommerce attribution.

Same meaning, ASCII-only.

## Changes
- \`woocommerce-ai-storefront.php\` — Description: header
- \`languages/woocommerce-ai-storefront.pot\` — regenerated for the updated msgid

## Test plan
- [x] \`composer test\` → 698 tests, 2040 assertions, all green
- [x] \`bash bin/make-pot.sh\` → regenerated, msgid updated cleanly
- [ ] CI matrix green