### PR TITLE
Fix: emit inventoryLevel at Offer level (offers[0]) instead of mixing list + assoc shapes

### DIFF
--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -62,11 +62,30 @@ class WC_AI_Storefront_JsonLd {
 			],
 		];
 
-		// Enhanced availability with inventory detail.
+		// Enhanced availability with inventory detail. Emit at the
+		// Offer level (Schema.org/Google preferred placement) — the
+		// outer `$markup['offers']` is a LIST array (numeric indices)
+		// per WC core's structured_data_product output, so the
+		// assignment must target `offers[0]`, not `offers` directly.
+		// Pre-this-fix the assignment was
+		// `$markup['offers']['inventoryLevel'] = ...`, which only
+		// worked if `offers` were associative; on production stores
+		// it produced a list with a string key mixed in — JSON-LD
+		// parsers see that as `[{...}, "inventoryLevel" => {...}]`
+		// which serializes to invalid output.
+		//
+		// Same `isset() && is_array()` guard the other Offer-level
+		// emissions (priceCurrency, hasMerchantReturnPolicy,
+		// shippingDetails) use so a third-party filter that strips
+		// or rewrites `offers` doesn't fatal the path.
 		if ( $product->managing_stock() ) {
 			$stock_qty = $product->get_stock_quantity();
-			if ( null !== $stock_qty ) {
-				$markup['offers']['inventoryLevel'] = [
+			if (
+				null !== $stock_qty
+				&& isset( $markup['offers'][0] )
+				&& is_array( $markup['offers'][0] )
+			) {
+				$markup['offers'][0]['inventoryLevel'] = [
 					'@type' => 'QuantitativeValue',
 					'value' => $stock_qty,
 				];

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -62,14 +62,14 @@ class WC_AI_Storefront_JsonLd {
 			],
 		];
 
-		// Inventory detail at Offer level. WC core's
-		// `structured_data_product` emits `offers` as a list, so the
-		// assignment targets `offers[0]`, not `offers` directly.
-		// Mirrors the `isset() && is_array()` guard the priceCurrency
-		// + hasMerchantReturnPolicy + shippingDetails emissions later
-		// in this method use; consider consolidating into one
-		// Offer-level block in a future cleanup. Regression locked
-		// by JsonLdTest.
+		// Inventory detail at Offer level. In the markup filtered by
+		// `woocommerce_structured_data_product`, `offers` is emitted
+		// as a list, so the assignment targets `offers[0]`, not
+		// `offers` directly. Mirrors the `isset() && is_array()`
+		// guard the priceCurrency + hasMerchantReturnPolicy +
+		// shippingDetails emissions later in this method use;
+		// consider consolidating into one Offer-level block in a
+		// future cleanup. Regression locked by JsonLdTest.
 		if ( $product->managing_stock() ) {
 			$stock_qty = $product->get_stock_quantity();
 			if (

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -62,22 +62,14 @@ class WC_AI_Storefront_JsonLd {
 			],
 		];
 
-		// Enhanced availability with inventory detail. Emit at the
-		// Offer level (Schema.org/Google preferred placement) — the
-		// outer `$markup['offers']` is a LIST array (numeric indices)
-		// per WC core's structured_data_product output, so the
-		// assignment must target `offers[0]`, not `offers` directly.
-		// Pre-this-fix the assignment was
-		// `$markup['offers']['inventoryLevel'] = ...`, which only
-		// worked if `offers` were associative; on production stores
-		// it produced a list with a string key mixed in — JSON-LD
-		// parsers see that as `[{...}, "inventoryLevel" => {...}]`
-		// which serializes to invalid output.
-		//
-		// Same `isset() && is_array()` guard the other Offer-level
-		// emissions (priceCurrency, hasMerchantReturnPolicy,
-		// shippingDetails) use so a third-party filter that strips
-		// or rewrites `offers` doesn't fatal the path.
+		// Inventory detail at Offer level. WC core's
+		// `structured_data_product` emits `offers` as a list, so the
+		// assignment targets `offers[0]`, not `offers` directly.
+		// Mirrors the `isset() && is_array()` guard the priceCurrency
+		// + hasMerchantReturnPolicy + shippingDetails emissions later
+		// in this method use; consider consolidating into one
+		// Offer-level block in a future cleanup. Regression locked
+		// by JsonLdTest.
 		if ( $product->managing_stock() ) {
 			$stock_qty = $product->get_stock_quantity();
 			if (

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-26T08:51:49+00:00\n"
+"POT-Creation-Date: 2026-04-26T09:03:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:312
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:331
 #: client/settings/ai-storefront/product-selection.js:916
 #: client/settings/ai-storefront/product-selection.js:1129
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-26T09:03:24+00:00\n"
+"POT-Creation-Date: 2026-04-26T09:03:37+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -65,7 +65,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:331
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:323
 #: client/settings/ai-storefront/product-selection.js:916
 #: client/settings/ai-storefront/product-selection.js:1129
 msgid "Products"

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -157,7 +157,10 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 	public function test_inventory_level_added_at_offer_level_when_stock_is_tracked(): void {
 		// Production input shape: WC core emits `offers` as a list of
-		// Offer dicts. Emission must land at `offers[0]`. See PR #95.
+		// Offer dicts. Emission must land at `offers[0]`, never as a
+		// string key on the outer `offers` list (would mix list +
+		// assoc shapes — PHP serializes that as a JSON object, not
+		// an Offer array).
 		$product = $this->make_product( [
 			'managing_stock' => true,
 			'stock_quantity' => 17,
@@ -175,8 +178,10 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 			],
 			$result['offers'][0]['inventoryLevel']
 		);
-		// Regression guard for the pre-fix bug
-		// `$markup['offers']['inventoryLevel'] = ...`. See PR #95.
+		// Regression guard: `inventoryLevel` must never be a string
+		// key on the outer `offers` list. The earlier-shipped form
+		// `$markup['offers']['inventoryLevel'] = ...` would smuggle
+		// it in there and break Offer-array shape on serialization.
 		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'] );
 	}
 

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -155,14 +155,19 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 	// Inventory (only when managing stock)
 	// ------------------------------------------------------------------
 
-	public function test_inventory_level_added_when_stock_is_tracked(): void {
+	public function test_inventory_level_added_at_offer_level_when_stock_is_tracked(): void {
+		// Production input shape: `offers` is a list of Offer dicts
+		// (numeric indices), per WC core's structured_data_product
+		// filter contract. The inventoryLevel emission must land at
+		// `offers[0]`, NOT at `offers['inventoryLevel']` (which would
+		// mix list + assoc shapes and produce invalid JSON-LD).
 		$product = $this->make_product( [
 			'managing_stock' => true,
 			'stock_quantity' => 17,
 		] );
 
 		$result = $this->jsonld->enhance_product_data(
-			[ 'offers' => [ '@type' => 'Offer' ] ],
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
 			$product
 		);
 
@@ -171,18 +176,25 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 				'@type' => 'QuantitativeValue',
 				'value' => 17,
 			],
-			$result['offers']['inventoryLevel']
+			$result['offers'][0]['inventoryLevel']
 		);
+		// Regression guard: inventoryLevel MUST NOT appear as a string
+		// key on the outer `offers` list. Pre-fix the assignment
+		// `$markup['offers']['inventoryLevel'] = ...` would silently
+		// poison the list shape and serialize as
+		// `"offers": [{...}, "inventoryLevel": {...}]` — broken JSON-LD.
+		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'] );
 	}
 
 	public function test_inventory_level_omitted_when_stock_is_not_tracked(): void {
 		$product = $this->make_product( [ 'managing_stock' => false ] );
 
 		$result = $this->jsonld->enhance_product_data(
-			[ 'offers' => [ '@type' => 'Offer' ] ],
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
 			$product
 		);
 
+		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'][0] );
 		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'] );
 	}
 
@@ -196,11 +208,35 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		] );
 
 		$result = $this->jsonld->enhance_product_data(
-			[ 'offers' => [ '@type' => 'Offer' ] ],
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
 			$product
 		);
 
+		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'][0] );
 		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'] );
+	}
+
+	public function test_inventory_level_omitted_when_offers_is_missing(): void {
+		// Defensive: if a third-party filter strips `offers` entirely
+		// before our hook fires, the inventoryLevel emission must
+		// gracefully skip rather than write to a non-existent path.
+		// The `isset($markup['offers'][0])` guard mirrors the same
+		// defense used by the priceCurrency / hasMerchantReturnPolicy
+		// emissions.
+		$product = $this->make_product( [
+			'managing_stock' => true,
+			'stock_quantity' => 17,
+		] );
+
+		$result = $this->jsonld->enhance_product_data(
+			// No 'offers' key at all.
+			[ '@type' => 'Product' ],
+			$product
+		);
+
+		// No fatal, no spurious offers key, no inventoryLevel
+		// orphaned at the top level.
+		$this->assertArrayNotHasKey( 'inventoryLevel', $result );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -156,11 +156,8 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 	// ------------------------------------------------------------------
 
 	public function test_inventory_level_added_at_offer_level_when_stock_is_tracked(): void {
-		// Production input shape: `offers` is a list of Offer dicts
-		// (numeric indices), per WC core's structured_data_product
-		// filter contract. The inventoryLevel emission must land at
-		// `offers[0]`, NOT at `offers['inventoryLevel']` (which would
-		// mix list + assoc shapes and produce invalid JSON-LD).
+		// Production input shape: WC core emits `offers` as a list of
+		// Offer dicts. Emission must land at `offers[0]`. See PR #95.
 		$product = $this->make_product( [
 			'managing_stock' => true,
 			'stock_quantity' => 17,
@@ -178,12 +175,35 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 			],
 			$result['offers'][0]['inventoryLevel']
 		);
-		// Regression guard: inventoryLevel MUST NOT appear as a string
-		// key on the outer `offers` list. Pre-fix the assignment
-		// `$markup['offers']['inventoryLevel'] = ...` would silently
-		// poison the list shape and serialize as
-		// `"offers": [{...}, "inventoryLevel": {...}]` — broken JSON-LD.
+		// Regression guard for the pre-fix bug
+		// `$markup['offers']['inventoryLevel'] = ...`. See PR #95.
 		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'] );
+	}
+
+	public function test_inventory_level_omitted_when_offers_is_assoc_shape(): void {
+		// Defensive: a third-party filter could pass associative
+		// `offers` (e.g., `['@type' => 'Offer']` instead of
+		// `[['@type' => 'Offer']]`). The `isset($markup['offers'][0])`
+		// guard returns false on assoc input, so emission correctly
+		// skips. Without this test, a future refactor that loosens
+		// the guard to `is_array($markup['offers'])` could
+		// accidentally re-introduce the original assoc-key write
+		// against this shape.
+		$product = $this->make_product( [
+			'managing_stock' => true,
+			'stock_quantity' => 17,
+		] );
+
+		$result = $this->jsonld->enhance_product_data(
+			[ 'offers' => [ '@type' => 'Offer' ] ],
+			$product
+		);
+
+		// inventoryLevel must be absent at every level — neither
+		// stamped as a string key on `offers` (the original bug)
+		// nor injected at the top level.
+		$this->assertArrayNotHasKey( 'inventoryLevel', $result['offers'] );
+		$this->assertArrayNotHasKey( 'inventoryLevel', $result );
 	}
 
 	public function test_inventory_level_omitted_when_stock_is_not_tracked(): void {


### PR DESCRIPTION
## Summary

The JSON-LD enhancer wrote \`\$markup['offers']['inventoryLevel'] = [...]\`, which silently produced invalid JSON-LD on production stores. WC core's \`woocommerce_structured_data_product\` filter passes \`offers\` as a LIST of Offer dicts (numeric indices), and an assoc-key write into a list-shape array yields a mixed-keys array. PHP serializes mixed-keys arrays as JSON **objects**, not arrays — so \`offers\` round-tripped as \`{"0": {...}, "inventoryLevel": {...}}\` instead of an Offer array. Schema.org / Google validators reject this; AI agents JSON-parsing the markup get a malformed Offer.

## Fix

Move the emission to \`\$markup['offers'][0]['inventoryLevel']\` — Offer level, the same target the other Offer-level emissions use (priceCurrency, hasMerchantReturnPolicy, shippingDetails). Same defensive guard (\`isset(\$markup['offers'][0]) && is_array(...)\`).

\`\`\`php
if ( \$product->managing_stock() ) {
    \$stock_qty = \$product->get_stock_quantity();
    if (
        null !== \$stock_qty
        && isset( \$markup['offers'][0] )
        && is_array( \$markup['offers'][0] )
    ) {
        \$markup['offers'][0]['inventoryLevel'] = [...];
    }
}
\`\`\`

## Why this wasn't caught earlier

Existing tests passed associative-shape input (\`offers => ['@type' => 'Offer']\`), which masked the bug — under that input the assoc-key write worked. Production stores receive list-shape input, so the bug was real but invisible to tests. Tests updated to use the production list shape.

## Tests

- 3 existing inventoryLevel tests updated to use list-shape input (\`offers => [[...]]\`).
- 3 existing tests gained regression guards: \`assertArrayNotHasKey('inventoryLevel', \$result['offers'])\` catches a future regression that brings back the assoc-key write.
- 2 new tests:
  - \`test_inventory_level_omitted_when_offers_is_missing\` exercises the defensive guard for the no-offers-key case.
  - \`test_inventory_level_omitted_when_offers_is_assoc_shape\` covers the third-party-filter case where \`offers\` is associative — the \`isset(offers[0])\` guard correctly skips. Without this test, a future refactor that loosened the guard to \`is_array(offers)\` could accidentally re-introduce the original assoc-key write.

## Test plan

- [x] \`composer test\` → 720 tests, 2094 assertions, all green
- [x] \`vendor/bin/phpstan\` → clean
- [x] \`bash bin/make-pot.sh\` → regenerated
- [ ] CI matrix green
- [ ] Manual: inspect a stock-tracked product page on a test store; confirm JSON-LD has \`inventoryLevel\` inside the first Offer object, not as a sibling key on the offers array

## Origin

Independent of any other open PR; no rebase contention. Latent bug — tests were passing because they used a different input shape than WC core actually emits in production.