### PR TITLE
fix: stamp UTM attribution on /catalog/search and /catalog/lookup product URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@
 
 ---
 
+## [0.6.4] – 2026-04-28
+
+### Fixes
+- **`/catalog/search` and `/catalog/lookup` now stamp UTM attribution on every product `url`.** Pre-fix, the bare permalink was returned. That's correct for buyers who follow the agent's `/checkout-sessions` integration end-to-end (the continue_url carries UTMs), but it loses attribution for the common path where the agent surfaces the product card with the bare URL as the click-through link, the buyer follows that link directly, and checks out on the merchant's site. Without UTMs on the product URL, those orders bucket as "direct" in WC Order Attribution (or get attributed to the agent's HTTP referrer header), invisible to the AI-orders dashboard. The fix stamps the same `utm_source` / `utm_medium=referral` / `utm_id=woo_ucp` / `ai_agent_host_raw` payload that continue_urls carry — same wire shape, captured by the same `WC_AI_Storefront_Attribution::capture_ai_attribution()` machinery, so attribution lands consistently regardless of which URL the buyer follows.
+- **Shared UTM-builder helper unifies the wire shape across both attribution surfaces.** Refactor extracts the UTM-stamping logic out of the REST controller's private `build_continue_url()` into a public `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` static method. The continue_url builder and the product translator now call the same helper, so the stamped param order, the FALLBACK_SOURCE substitution for missing source_host, and the conditional `ai_agent_host_raw` inclusion can't drift between surfaces. Existing wire shape preserved bit-for-bit (string-concat helper, not `add_query_arg()` — `add_query_arg()` re-encodes existing query params via `urlencode_deep`, which would have flipped continue_url's `products=100:2` to `products=100%3A2`, a real byte-level change).
+
+---
+
 ## [0.6.3] – 2026-04-28
 
 ### Fixes

--- a/includes/ai-storefront/class-wc-ai-storefront-attribution.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-attribution.php
@@ -146,6 +146,115 @@ class WC_AI_Storefront_Attribution {
 	const WOO_UCP_ID = 'woo_ucp';
 
 	/**
+	 * Stamp our canonical attribution UTM shape onto a URL.
+	 *
+	 * Two emission surfaces share this helper so the wire shape stays
+	 * identical across both:
+	 *
+	 *   - `/checkout-sessions` continue_url (built by the REST
+	 *     controller's `build_continue_url()`). The continue_url is the
+	 *     primary attribution path: agents redirect the buyer to it,
+	 *     WC Order Attribution captures the params on the resulting
+	 *     order.
+	 *
+	 *   - `/catalog/search` and `/catalog/lookup` product `url` field
+	 *     (applied by `WC_AI_Storefront_UCP_Product_Translator`). The
+	 *     bare product permalink is what agents render as the "view
+	 *     product" link in chat. Buyers who follow that link directly,
+	 *     add to cart, and check out (rather than going through the
+	 *     agent's checkout-session integration) need the same UTM
+	 *     payload to attribute correctly. Without this, those orders
+	 *     bucket as "direct" or get attributed to the agent's referrer
+	 *     header — invisible to the AI-orders dashboard.
+	 *
+	 * UTM shape (canonical 0.5.0+):
+	 *
+	 *   - `utm_source` — `$source_host` when non-empty, else
+	 *     `WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE`
+	 *     (`ucp_unknown`). Keeping the sentinel preserves the "agent
+	 *     didn't identify itself" cohort as a distinct row in WC
+	 *     Origin breakdowns rather than collapsing it into "direct".
+	 *
+	 *   - `utm_medium` — `referral` (Google-canonical). AI agent
+	 *     traffic IS referral traffic by Google's analytics taxonomy;
+	 *     `referral` lets GA4 auto-bucket under the Referral default
+	 *     channel grouping rather than "Unassigned".
+	 *
+	 *   - `utm_id` — `WOO_UCP_ID` (`woo_ucp`). The "we routed this"
+	 *     flag the STRICT attribution gate matches on, regardless of
+	 *     `utm_source`/`utm_medium` values. Decouples WHO sent the
+	 *     user (utm_source) from HOW it was routed (utm_id).
+	 *
+	 * Plus, when `$raw_host` is non-empty, an `ai_agent_host_raw`
+	 * param carries the producer-side raw identifier for "Other AI"
+	 * drill-in. Captured by `capture_ai_attribution()` into
+	 * `AGENT_HOST_RAW_META_KEY`. Empty raw_host (no UCP-Agent header
+	 * AND no body fallback) means the param is omitted entirely — no
+	 * spurious `&ai_agent_host_raw=` in the URL.
+	 *
+	 * Implementation uses string concatenation rather than
+	 * `add_query_arg()` for two reasons:
+	 *
+	 *   - `add_query_arg()` runs existing query parameters through
+	 *     `urlencode_deep()` and rebuilds via `build_query()`, which
+	 *     re-encodes characters that the original URL left raw.
+	 *     Pre-0.6.4 `build_continue_url()` used string concat and
+	 *     produced `?products=100:2&...` with a literal `:`. Routing
+	 *     through `add_query_arg()` would silently change the wire
+	 *     shape to `?products=100%3A2&...` — semantically equivalent
+	 *     but a real byte-level diff for any agent with a fragile URL
+	 *     parser. Wire-shape stability across this refactor matters
+	 *     more than `add_query_arg()`'s "merge into existing query"
+	 *     elegance.
+	 *
+	 *   - Permalinks with existing query strings (Polylang/WPML
+	 *     `?lang=fr`, custom rewrite-rule params, paginated archives)
+	 *     are handled by the `?` vs `&` separator check below — naive
+	 *     "always append `?utm_source=`" would produce
+	 *     `permalink?lang=fr?utm_source=...` (broken — the second `?`
+	 *     becomes part of `lang`'s value). Detecting existing `?` and
+	 *     using `&` keeps both clean-permalink and existing-query
+	 *     cases correct without `add_query_arg()`'s re-encoding side
+	 *     effect.
+	 *
+	 * @param string $url         Base URL to tag. May or may not
+	 *                            already have a query string.
+	 * @param string $source_host Lowercase identifier for `utm_source`:
+	 *                            usually a normalized hostname (e.g.
+	 *                            `chatgpt.com`); may be a lowercase
+	 *                            product / agent token fallback when
+	 *                            no hostname mapping exists. Empty
+	 *                            falls back to `FALLBACK_SOURCE`.
+	 * @param string $raw_host    Untransformed identifier from the
+	 *                            UCP-Agent header or body field.
+	 *                            Empty string skips the
+	 *                            `ai_agent_host_raw` param entirely.
+	 *                            Defaults to empty.
+	 * @return string             URL with attribution params stamped.
+	 */
+	public static function with_woo_ucp_utm( string $url, string $source_host, string $raw_host = '' ): string {
+		$utm_source = '' !== $source_host
+			? $source_host
+			: WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE;
+
+		// `?` if URL has no query yet; `&` to append onto existing
+		// query. `str_contains()` over the simpler `false === strpos()`
+		// for readability — same semantics, PHP 8.0+.
+		$separator = str_contains( $url, '?' ) ? '&' : '?';
+
+		$url .= $separator
+			. 'utm_source=' . rawurlencode( $utm_source )
+			. '&utm_medium=referral'
+			. '&utm_id=' . self::WOO_UCP_ID;
+
+		if ( '' !== $raw_host ) {
+			$url .= '&ai_agent_host_raw=' . rawurlencode( $raw_host );
+		}
+
+		return $url;
+	}
+
+	/**
 	 * Initialize hooks.
 	 *
 	 * Deliberately minimal: we capture agent metadata onto the order

--- a/includes/ai-storefront/class-wc-ai-storefront-attribution.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-attribution.php
@@ -237,6 +237,22 @@ class WC_AI_Storefront_Attribution {
 			? $source_host
 			: WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE;
 
+		// Strip `#fragment` first so the appended query lands BEFORE
+		// it on rejoin. WC permalinks shouldn't carry fragments today,
+		// but defensive: a third-party plugin that adds `#reviews` /
+		// `#description` deep-links to product permalinks would
+		// otherwise produce a broken URL like
+		// `/product/widget/#reviews?utm_source=...`, where the `?` is
+		// part of the fragment per RFC 3986 (fragment runs to
+		// end-of-URI). Splitting before append puts the query in the
+		// right structural position: `/product/widget/?utm_source=...#reviews`.
+		$fragment   = '';
+		$hash_index = strpos( $url, '#' );
+		if ( false !== $hash_index ) {
+			$fragment = substr( $url, $hash_index );
+			$url      = substr( $url, 0, $hash_index );
+		}
+
 		// `?` if URL has no query yet; `&` to append onto existing
 		// query. `str_contains()` over the simpler `false === strpos()`
 		// for readability — same semantics, PHP 8.0+.
@@ -251,7 +267,7 @@ class WC_AI_Storefront_Attribution {
 			$url .= '&ai_agent_host_raw=' . rawurlencode( $raw_host );
 		}
 
-		return $url;
+		return $url . $fragment;
 	}
 
 	/**

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
@@ -60,9 +60,42 @@ class WC_AI_Storefront_UCP_Product_Translator {
 	 *                                                        in a request, so the controller
 	 *                                                        computes it once and passes it in —
 	 *                                                        keeps the translator WP-unaware.
+	 * @param string|null                      $source_host   Optional UTM source host for
+	 *                                                        stamping attribution params on the
+	 *                                                        product `url`. When non-null, the
+	 *                                                        permalink is rewritten through
+	 *                                                        `WC_AI_Storefront_Attribution::with_woo_ucp_utm()`
+	 *                                                        so a buyer who follows the link
+	 *                                                        directly (instead of going through
+	 *                                                        the agent's checkout-session
+	 *                                                        integration) still produces an
+	 *                                                        AI-attributed order. Empty string
+	 *                                                        is treated as "agent didn't
+	 *                                                        identify" — the helper substitutes
+	 *                                                        the FALLBACK_SOURCE sentinel.
+	 *                                                        `null` skips UTM stamping entirely
+	 *                                                        (preserves bare permalink); useful
+	 *                                                        for direct-call test contexts and
+	 *                                                        future internal callers that don't
+	 *                                                        have an agent context.
+	 * @param string                           $raw_host      Producer-side raw identifier from
+	 *                                                        the UCP-Agent header or body
+	 *                                                        fallback. Threaded through to the
+	 *                                                        UTM helper so the same
+	 *                                                        `ai_agent_host_raw` param continue_url
+	 *                                                        carries also lands on the
+	 *                                                        product-link path. Empty skips the
+	 *                                                        param entirely. Ignored when
+	 *                                                        `$source_host` is null.
 	 * @return array<string, mixed>                           UCP product shape.
 	 */
-	public static function translate( array $wc_product, array $wc_variations = [], ?array $seller = null ): array {
+	public static function translate(
+		array $wc_product,
+		array $wc_variations = [],
+		?array $seller = null,
+		?string $source_host = null,
+		string $raw_host = ''
+	): array {
 		$id = (int) ( $wc_product['id'] ?? 0 );
 
 		$product = [
@@ -120,7 +153,34 @@ class WC_AI_Storefront_UCP_Product_Translator {
 		}
 
 		if ( ! empty( $wc_product['permalink'] ) ) {
-			$product['url'] = $wc_product['permalink'];
+			// Stamp our canonical UTM payload onto the permalink when
+			// the controller threaded an agent context through. Buyers
+			// who click the product link in chat — instead of going
+			// through the agent's `/checkout-sessions` integration —
+			// otherwise land on the product page with no attribution
+			// markers, and WC Order Attribution buckets the resulting
+			// order as "direct" (or attributes it to the agent's HTTP
+			// referrer header, fragmenting AI-orders stats by referrer
+			// rather than rolling them up under the agent). See
+			// `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` for
+			// the canonical UTM contract; the same helper feeds
+			// `build_continue_url()` so the search-link and
+			// continue-url surfaces stay byte-identical on the
+			// attribution portion.
+			//
+			// `null` source_host is the "translator called outside an
+			// agent context" path — leave the permalink bare. Empty
+			// string source_host is "agent context exists, but agent
+			// didn't identify itself" — the helper substitutes the
+			// FALLBACK_SOURCE sentinel so the cohort stays observable
+			// in WC Origin breakdowns.
+			$product['url'] = null !== $source_host
+				? WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+					$wc_product['permalink'],
+					$source_host,
+					$raw_host
+				)
+				: $wc_product['permalink'];
 		}
 
 		// Taxonomies split (2.0.0+):

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -596,16 +596,33 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			);
 		}
 
-		// Attribution: note the calling agent (unblocking; logging only).
-		$agent_header = $request->get_header( 'ucp-agent' );
-		if ( is_string( $agent_header ) && '' !== $agent_header ) {
-			$host = WC_AI_Storefront_UCP_Agent_Header::extract_profile_hostname(
-				$agent_header
-			);
-			WC_AI_Storefront_Logger::debug(
-				'UCP catalog/search from agent: ' . ( '' !== $host ? $host : 'unknown' )
-			);
-		}
+		// Attribution: resolve calling agent. Used for two purposes
+		// inside this handler:
+		//
+		//   - Debug logging (observability of who's hitting the
+		//     endpoint — preserved verbatim from pre-resolve_agent_host
+		//     behavior, just sourcing from the unified resolver
+		//     output now).
+		//
+		//   - `utm_source` + `ai_agent_host_raw` stamped on every
+		//     product `url` in the response (via the product
+		//     translator). Buyers who follow a bare product link
+		//     from chat — rather than going through the agent's
+		//     checkout-session integration — need attribution to
+		//     land. Without these params on the search-response URL,
+		//     those orders bucket as "direct" in WC Order
+		//     Attribution or get attributed to the agent's HTTP
+		//     referrer header, invisible to the AI-orders dashboard.
+		//     See `WC_AI_Storefront_Attribution::with_woo_ucp_utm()`
+		//     for the wire-shape contract.
+		$agent_data        = self::resolve_agent_host( $request );
+		$agent_source_host = $agent_data['source_host'];
+		$agent_raw_host    = $agent_data['raw_host'];
+
+		WC_AI_Storefront_Logger::debug(
+			'UCP catalog/search from agent: '
+			. ( '' !== $agent_source_host ? $agent_source_host : 'unknown' )
+		);
 
 		// Signals (spec-level field, platform-observed environment data).
 		// Accept and log for observability; do not gate on any signal
@@ -836,7 +853,9 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			$products[] = WC_AI_Storefront_UCP_Product_Translator::translate(
 				$wc_product,
 				$variation_fetch['variations'],
-				$seller
+				$seller,
+				$agent_source_host,
+				$agent_raw_host
 			);
 		}
 
@@ -1206,6 +1225,22 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			);
 		}
 
+		// Attribution: resolve calling agent. Same role as in
+		// `handle_catalog_search` — log for observability AND thread
+		// `source_host` / `raw_host` through to the product translator
+		// so every product `url` in the response carries our canonical
+		// UTM payload. See the corresponding block in
+		// `handle_catalog_search` for full rationale; the contract is
+		// identical.
+		$agent_data        = self::resolve_agent_host( $request );
+		$agent_source_host = $agent_data['source_host'];
+		$agent_raw_host    = $agent_data['raw_host'];
+
+		WC_AI_Storefront_Logger::debug(
+			'UCP catalog/lookup from agent: '
+			. ( '' !== $agent_source_host ? $agent_source_host : 'unknown' )
+		);
+
 		// Signals parity with catalog.search — log for observability, no
 		// trust decisions yet. See handle_catalog_search for the
 		// rationale on deferring trust-model work until there's a
@@ -1308,7 +1343,9 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			$products[] = WC_AI_Storefront_UCP_Product_Translator::translate(
 				$wc_product,
 				$variation_fetch['variations'],
-				$seller
+				$seller,
+				$agent_source_host,
+				$agent_raw_host
 			);
 		}
 
@@ -4016,30 +4053,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			? home_url( '/checkout-link/' )
 			: '/checkout-link/';
 
-		// utm_source: hostname when available, sentinel when not.
-		// Keeping the sentinel preserves the "agent didn't identify"
-		// cohort as a distinct row in WC Origin breakdowns.
-		$utm_source = '' !== $source_host
-			? $source_host
-			: WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE;
+		// `?products=` is the checkout-link-specific payload —
+		// stamped here, not in the attribution helper. The shared
+		// helper handles the `utm_source` / `utm_medium` / `utm_id` /
+		// `ai_agent_host_raw` shape so search-result product URLs
+		// and continue_urls stay byte-identical on the attribution
+		// portion. See `WC_AI_Storefront_Attribution::with_woo_ucp_utm()`
+		// for the canonical UTM contract.
+		$url_with_products = $base . '?products=' . implode( ',', $segments );
 
-		// Use the `WOO_UCP_ID` constant from the attribution class
-		// rather than a literal string here. The STRICT gate's matcher
-		// in `WC_AI_Storefront_Attribution::capture_ai_attribution()`
-		// reads the same constant — keeping both sides on the constant
-		// means a future rename can't silently break round-trip
-		// recognition of orders we routed.
-		$url = $base
-			. '?products=' . implode( ',', $segments )
-			. '&utm_source=' . rawurlencode( $utm_source )
-			. '&utm_medium=referral'
-			. '&utm_id=' . WC_AI_Storefront_Attribution::WOO_UCP_ID;
-
-		if ( '' !== $raw_host ) {
-			$url .= '&ai_agent_host_raw=' . rawurlencode( $raw_host );
-		}
-
-		return $url;
+		return WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			$url_with_products,
+			$source_host,
+			$raw_host
+		);
 	}
 
 	/**

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -600,9 +600,12 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// inside this handler:
 		//
 		//   - Debug logging (observability of who's hitting the
-		//     endpoint — preserved verbatim from pre-resolve_agent_host
-		//     behavior, just sourcing from the unified resolver
-		//     output now).
+		//     endpoint). Guarded on `UCP-Agent` header presence to
+		//     match pre-resolve_agent_host behavior — non-agent
+		//     traffic (curl probes, browsers, monitoring tools) hits
+		//     the endpoint too and would otherwise log
+		//     "from agent: unknown" once per request, drowning real
+		//     agent activity in the debug log when logging is on.
 		//
 		//   - `utm_source` + `ai_agent_host_raw` stamped on every
 		//     product `url` in the response (via the product
@@ -619,10 +622,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		$agent_source_host = $agent_data['source_host'];
 		$agent_raw_host    = $agent_data['raw_host'];
 
-		WC_AI_Storefront_Logger::debug(
-			'UCP catalog/search from agent: '
-			. ( '' !== $agent_source_host ? $agent_source_host : 'unknown' )
-		);
+		$agent_header = $request->get_header( 'ucp-agent' );
+		if ( is_string( $agent_header ) && '' !== $agent_header ) {
+			WC_AI_Storefront_Logger::debug(
+				'UCP catalog/search from agent: '
+				. ( '' !== $agent_source_host ? $agent_source_host : 'unknown' )
+			);
+		}
 
 		// Signals (spec-level field, platform-observed environment data).
 		// Accept and log for observability; do not gate on any signal
@@ -1229,17 +1235,22 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// `handle_catalog_search` — log for observability AND thread
 		// `source_host` / `raw_host` through to the product translator
 		// so every product `url` in the response carries our canonical
-		// UTM payload. See the corresponding block in
-		// `handle_catalog_search` for full rationale; the contract is
-		// identical.
+		// UTM payload. Debug-log line is gated on UCP-Agent header
+		// presence for the same reason: non-agent traffic shouldn't
+		// produce "from agent: unknown" log noise. See the
+		// corresponding block in `handle_catalog_search` for full
+		// rationale; the contract is identical.
 		$agent_data        = self::resolve_agent_host( $request );
 		$agent_source_host = $agent_data['source_host'];
 		$agent_raw_host    = $agent_data['raw_host'];
 
-		WC_AI_Storefront_Logger::debug(
-			'UCP catalog/lookup from agent: '
-			. ( '' !== $agent_source_host ? $agent_source_host : 'unknown' )
-		);
+		$agent_header = $request->get_header( 'ucp-agent' );
+		if ( is_string( $agent_header ) && '' !== $agent_header ) {
+			WC_AI_Storefront_Logger::debug(
+				'UCP catalog/lookup from agent: '
+				. ( '' !== $agent_source_host ? $agent_source_host : 'unknown' )
+			);
+		}
 
 		// Signals parity with catalog.search — log for observability, no
 		// trust decisions yet. See handle_catalog_search for the

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-28T16:50:30+00:00\n"
+"POT-Creation-Date: 2026-04-28T17:27:53+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -53,19 +53,19 @@ msgstr ""
 msgid "Override the store-wide return policy for this product. AI agents will see \"no returns\" regardless of your store policy. Use for clearance items, custom orders, or any product whose return terms diverge from the store default."
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:608
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:624
 msgid "AI Agent Attribution"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:609
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:625
 msgid "Agent:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:617
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:633
 msgid "Agent host:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:621
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:637
 msgid "Session ID:"
 msgstr ""
 
@@ -113,171 +113,171 @@ msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:592
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1221
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1435
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1227
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1446
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:773
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:800
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:779
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:806
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1264
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1275
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1274
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1285
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1292
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1303
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1446
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1457
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1456
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1467
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1603
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1614
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1622
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1633
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1660
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1671
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2096
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2107
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2632
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2643
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2703
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2714
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2734
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2745
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2754
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2765
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2779
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2790
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2812
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2823
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2848
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2859
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2879
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2890
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2951
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2962
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3002
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3013
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3032
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3043
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3122
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3133
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3361
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3372
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3396
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3407
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3936
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3947
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4163
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4174
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4167
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4178
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4171
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4182
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4173
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4184
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4175
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4186
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4179
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4190
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4181
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4192
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce AI Storefront 0.6.3\n"
+"Project-Id-Version: WooCommerce AI Storefront 0.6.4\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-ai-storefront\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-28T13:34:44+00:00\n"
+"POT-Creation-Date: 2026-04-28T16:50:30+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -53,19 +53,19 @@ msgstr ""
 msgid "Override the store-wide return policy for this product. AI agents will see \"no returns\" regardless of your store policy. Use for clearance items, custom orders, or any product whose return terms diverge from the store default."
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:499
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:608
 msgid "AI Agent Attribution"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:500
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:609
 msgid "Agent:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:508
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:617
 msgid "Agent host:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:512
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:621
 msgid "Session ID:"
 msgstr ""
 
@@ -113,171 +113,171 @@ msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:592
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1202
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1398
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1221
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1435
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:756
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:783
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:773
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:800
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1229
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1264
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1239
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1274
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1257
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1292
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1409
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1446
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1419
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1456
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1566
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1603
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1585
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1622
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1623
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1660
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2059
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2096
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2595
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2632
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2666
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2703
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2697
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2734
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2717
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2754
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2742
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2779
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2775
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2812
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2811
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2848
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2842
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2879
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2914
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2951
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2965
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3002
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2995
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3032
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3085
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3122
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3324
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3361
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3359
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3396
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3899
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3936
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4136
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4163
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4140
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4167
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4144
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4171
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4146
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4173
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4148
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4175
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4152
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4179
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4154
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4181
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-ai-storefront",
-	"version": "0.6.3",
+	"version": "0.6.4",
 	"description": "Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude).",
 	"author": "WooCommerce",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.1
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 0.6.3
+Stable tag: 0.6.4
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/tests/php/unit/AttributionTest.php
+++ b/tests/php/unit/AttributionTest.php
@@ -986,11 +986,12 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_with_woo_ucp_utm_preserves_existing_query_string(): void {
-		// The helper uses `add_query_arg()` which merges into existing
-		// query parameters rather than naively appending `?`. This
-		// matters for permalinks carrying language plugin params
-		// (`?lang=fr`), pagination, or custom rewrite rules — naive
-		// concat would produce `permalink?lang=fr?utm_source=...`
+		// The helper detects an existing `?` in the URL and appends
+		// with `&` rather than blindly appending `?` (string concat,
+		// not `add_query_arg()` — the helper's docblock explains why).
+		// This matters for permalinks carrying language plugin params
+		// (`?lang=fr`), pagination, or custom rewrite rules: naive
+		// `?` append would produce `permalink?lang=fr?utm_source=...`
 		// (broken — second `?` is interpreted as part of `lang`'s
 		// value).
 		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
@@ -1005,6 +1006,48 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 			substr_count( $result, '?' ),
 			'Result must contain exactly one `?` — two means the URL is broken.'
 		);
+	}
+
+	public function test_with_woo_ucp_utm_preserves_fragment_after_query(): void {
+		// Per RFC 3986 the `#fragment` runs to end-of-URI, so a query
+		// string MUST come before the fragment. WC permalinks don't
+		// carry fragments today, but third-party plugins can deep-link
+		// product pages to anchors like `#reviews` or `#description`.
+		// Naive append would produce `/product/widget/#reviews?utm_source=...`
+		// where the `?` becomes part of the fragment, defeating
+		// attribution capture entirely (the params never reach the
+		// server). The helper splits the fragment off before appending
+		// query params and rejoins it at the end.
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/#reviews',
+			'chatgpt.com'
+		);
+
+		$this->assertEquals(
+			'https://example.com/product/widget/'
+				. '?utm_source=chatgpt.com'
+				. '&utm_medium=referral'
+				. '&utm_id=woo_ucp'
+				. '#reviews',
+			$result
+		);
+	}
+
+	public function test_with_woo_ucp_utm_handles_url_with_query_and_fragment(): void {
+		// Combination case: existing query + fragment. The query
+		// detector must look at the URL's query portion (not the
+		// fragment), and the fragment must land at the end after
+		// query rebuild.
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/?lang=fr#reviews',
+			'chatgpt.com'
+		);
+
+		$this->assertStringContainsString( 'lang=fr&utm_source=chatgpt.com', $result );
+		$this->assertStringEndsWith( '#reviews', $result );
+		// Hash count: exactly one `#`. Two would mean we duplicated
+		// the fragment marker.
+		$this->assertEquals( 1, substr_count( $result, '#' ) );
 	}
 
 	public function test_with_woo_ucp_utm_uses_woo_ucp_id_constant(): void {

--- a/tests/php/unit/AttributionTest.php
+++ b/tests/php/unit/AttributionTest.php
@@ -921,4 +921,105 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 			$order->get_meta( WC_AI_Storefront_Attribution::AGENT_META_KEY )
 		);
 	}
+
+	// ------------------------------------------------------------------
+	// with_woo_ucp_utm — emission-side helper that stamps our canonical
+	// UTM payload onto a URL. Shared between `build_continue_url` (the
+	// /checkout-sessions redirect URL) and the product translator (the
+	// /catalog/search and /catalog/lookup product `url` field). The
+	// identical wire shape is the contract that lets WC Order
+	// Attribution + `capture_ai_attribution()` recognize orders from
+	// either entry path.
+	// ------------------------------------------------------------------
+
+	public function test_with_woo_ucp_utm_stamps_canonical_shape(): void {
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/',
+			'chatgpt.com'
+		);
+
+		$this->assertEquals(
+			'https://example.com/product/widget/'
+				. '?utm_source=chatgpt.com'
+				. '&utm_medium=referral'
+				. '&utm_id=woo_ucp',
+			$result
+		);
+	}
+
+	public function test_with_woo_ucp_utm_substitutes_fallback_source_when_empty(): void {
+		// Empty source_host = "agent context exists, agent didn't
+		// identify itself". The helper substitutes FALLBACK_SOURCE
+		// (`ucp_unknown`) so the cohort stays observable in WC Origin
+		// breakdowns rather than collapsing into "direct".
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/',
+			''
+		);
+
+		$this->assertStringContainsString( 'utm_source=ucp_unknown', $result );
+		$this->assertStringContainsString( 'utm_medium=referral', $result );
+		$this->assertStringContainsString( 'utm_id=woo_ucp', $result );
+	}
+
+	public function test_with_woo_ucp_utm_appends_ai_agent_host_raw_when_provided(): void {
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/',
+			'chatgpt.com',
+			'chatgpt.com'
+		);
+
+		$this->assertStringContainsString( 'ai_agent_host_raw=chatgpt.com', $result );
+	}
+
+	public function test_with_woo_ucp_utm_omits_ai_agent_host_raw_when_empty(): void {
+		// Default `$raw_host = ''` — no `ai_agent_host_raw` param at
+		// all (not just an empty value). A spurious
+		// `&ai_agent_host_raw=` would mislead the capture path into
+		// stamping empty meta.
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/',
+			'chatgpt.com'
+		);
+
+		$this->assertStringNotContainsString( 'ai_agent_host_raw', $result );
+	}
+
+	public function test_with_woo_ucp_utm_preserves_existing_query_string(): void {
+		// The helper uses `add_query_arg()` which merges into existing
+		// query parameters rather than naively appending `?`. This
+		// matters for permalinks carrying language plugin params
+		// (`?lang=fr`), pagination, or custom rewrite rules — naive
+		// concat would produce `permalink?lang=fr?utm_source=...`
+		// (broken — second `?` is interpreted as part of `lang`'s
+		// value).
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/product/widget/?lang=fr',
+			'chatgpt.com'
+		);
+
+		$this->assertStringContainsString( 'lang=fr', $result );
+		$this->assertStringContainsString( 'utm_source=chatgpt.com', $result );
+		$this->assertEquals(
+			1,
+			substr_count( $result, '?' ),
+			'Result must contain exactly one `?` — two means the URL is broken.'
+		);
+	}
+
+	public function test_with_woo_ucp_utm_uses_woo_ucp_id_constant(): void {
+		// Defense against a future rename drifting the constant on
+		// either side of the round-trip. The STRICT capture gate
+		// reads the same constant; both surfaces tied to the constant
+		// means a rename touches both atomically.
+		$result = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+			'https://example.com/',
+			'chatgpt.com'
+		);
+
+		$this->assertStringContainsString(
+			'utm_id=' . WC_AI_Storefront_Attribution::WOO_UCP_ID,
+			$result
+		);
+	}
 }

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -601,8 +601,13 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 			'chatgpt.com'
 		);
 
-		// Order is enforced by add_query_arg's stable iteration: the
-		// helper passes utm_source first, then utm_medium, then utm_id.
+		// Order is enforced by the helper's string-concat append:
+		// utm_source first, then utm_medium, then utm_id (then the
+		// optional ai_agent_host_raw, when raw_host is non-empty).
+		// See `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` for
+		// why this is string concat rather than `add_query_arg()` —
+		// `add_query_arg()`'s `urlencode_deep` would re-encode
+		// existing query params, changing the wire shape.
 		$this->assertEquals(
 			'https://example.com/product/widget/'
 				. '?utm_source=chatgpt.com'
@@ -657,9 +662,10 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 	public function test_url_preserves_existing_query_params_on_permalink(): void {
 		// Polylang/WPML language plugins, custom rewrite rules, and
 		// paginated archives can put query strings on permalinks.
-		// The UTM helper uses `add_query_arg()` which merges into the
-		// existing query rather than naively appending `?`, so a
-		// permalink like `/product/widget/?lang=fr` should land as
+		// The UTM helper detects an existing `?` in the URL and uses
+		// `&` as its separator (string concat, not `add_query_arg()` —
+		// see the helper's docblock for why), so a permalink like
+		// `/product/widget/?lang=fr` should land as
 		// `/product/widget/?lang=fr&utm_source=...&utm_medium=...&utm_id=...`
 		// rather than the broken `/product/widget/?lang=fr?utm_source=...`.
 		$fixture              = $this->simple_product_fixture();

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -581,6 +581,122 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
+	// URL UTM stamping (attribution)
+	//
+	// When the controller threads an agent context through
+	// (`$source_host` non-null), the translator stamps our canonical
+	// UTM payload onto the product `url`. This is the buyer-clicks-the-
+	// link-in-chat path: without it, those orders bucket as "direct"
+	// in WC Order Attribution rather than rolling up under the agent.
+	//
+	// `null` source_host (default, the existing call shape) preserves
+	// the bare permalink — covered by `test_url_from_permalink` above.
+	// ------------------------------------------------------------------
+
+	public function test_url_stamped_with_utm_when_source_host_provided(): void {
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			null,
+			'chatgpt.com'
+		);
+
+		// Order is enforced by add_query_arg's stable iteration: the
+		// helper passes utm_source first, then utm_medium, then utm_id.
+		$this->assertEquals(
+			'https://example.com/product/widget/'
+				. '?utm_source=chatgpt.com'
+				. '&utm_medium=referral'
+				. '&utm_id=woo_ucp',
+			$result['url']
+		);
+	}
+
+	public function test_url_includes_ai_agent_host_raw_when_provided(): void {
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			null,
+			'chatgpt.com',
+			'chatgpt.com'
+		);
+
+		$this->assertStringContainsString( 'utm_source=chatgpt.com', $result['url'] );
+		$this->assertStringContainsString( 'ai_agent_host_raw=chatgpt.com', $result['url'] );
+	}
+
+	public function test_url_omits_ai_agent_host_raw_when_empty(): void {
+		// Default `$raw_host = ''` — no `ai_agent_host_raw` param
+		// should appear in the URL.
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			null,
+			'chatgpt.com'
+		);
+
+		$this->assertStringNotContainsString( 'ai_agent_host_raw', $result['url'] );
+	}
+
+	public function test_url_substitutes_fallback_source_when_source_host_empty(): void {
+		// Empty string source_host = "agent context exists but no
+		// hostname could be resolved". The helper substitutes the
+		// FALLBACK_SOURCE sentinel so the cohort stays observable
+		// in WC Origin breakdowns rather than collapsing into "direct".
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			null,
+			''
+		);
+
+		$this->assertStringContainsString( 'utm_source=ucp_unknown', $result['url'] );
+		$this->assertStringContainsString( 'utm_id=woo_ucp', $result['url'] );
+	}
+
+	public function test_url_preserves_existing_query_params_on_permalink(): void {
+		// Polylang/WPML language plugins, custom rewrite rules, and
+		// paginated archives can put query strings on permalinks.
+		// The UTM helper uses `add_query_arg()` which merges into the
+		// existing query rather than naively appending `?`, so a
+		// permalink like `/product/widget/?lang=fr` should land as
+		// `/product/widget/?lang=fr&utm_source=...&utm_medium=...&utm_id=...`
+		// rather than the broken `/product/widget/?lang=fr?utm_source=...`.
+		$fixture              = $this->simple_product_fixture();
+		$fixture['permalink'] = 'https://example.com/product/widget/?lang=fr';
+
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$fixture,
+			[],
+			null,
+			'chatgpt.com'
+		);
+
+		$this->assertStringContainsString( 'lang=fr', $result['url'] );
+		$this->assertStringContainsString( 'utm_source=chatgpt.com', $result['url'] );
+		// One `?`, the rest must be `&`. Two `?` would mean we broke
+		// the URL.
+		$this->assertEquals( 1, substr_count( $result['url'], '?' ) );
+	}
+
+	public function test_url_left_bare_when_source_host_null(): void {
+		// The default-null case is the "no agent context" path —
+		// future internal callers and direct-call test contexts.
+		// Permalink should pass through verbatim, no UTMs.
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$this->simple_product_fixture(),
+			[],
+			null,
+			null
+		);
+
+		$this->assertEquals(
+			'https://example.com/product/widget/',
+			$result['url']
+		);
+	}
+
+	// ------------------------------------------------------------------
 	// Categories
 	// ------------------------------------------------------------------
 

--- a/woocommerce-ai-storefront.php
+++ b/woocommerce-ai-storefront.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Storefront
  * Plugin URI: https://woocommerce.com/
  * Description: Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control with store-only checkout and standard WooCommerce attribution.
- * Version: 0.6.3
+ * Version: 0.6.4
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-storefront
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_STOREFRONT_VERSION', '0.6.3' );
+define( 'WC_AI_STOREFRONT_VERSION', '0.6.4' );
 define( 'WC_AI_STOREFRONT_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_STOREFRONT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_STOREFRONT_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
Closes #117.

## Summary

Closes an attribution gap on `/catalog/search` and `/catalog/lookup`: the bare product permalink was returned, no UTMs. That's correct for buyers who go through the agent's `/checkout-sessions` integration end-to-end (the continue_url carries UTMs), but it loses attribution for the common path:

> Shopper finds the item in chat → clicks the product link → lands on the merchant site → adds to cart → checks out.

Without UTMs on the product URL, those orders bucket as "direct" in WC Order Attribution (or attribute to the agent's HTTP referrer header), invisible to the plugin's AI-orders dashboard.

## What changed

- **New shared helper: `WC_AI_Storefront_Attribution::with_woo_ucp_utm()`.** Single source of truth for the UTM wire shape (`utm_source` / `utm_medium=referral` / `utm_id=woo_ucp` / optional `ai_agent_host_raw`). Both `build_continue_url()` and the product translator call it now, so the two emission surfaces can't drift.
- **`build_continue_url()` refactored to use the helper.** Wire shape preserved bit-for-bit (string-concat helper, not `add_query_arg()` — `add_query_arg()`'s `urlencode_deep` would have flipped continue_url's `products=100:2` to `products=100%3A2`, a real byte-level change).
- **Search and lookup handlers now invoke `resolve_agent_host()` once each.** Threads `source_host` and `raw_host` to the product translator, AND consolidates the existing per-handler debug logging through the same resolver output (no double-resolution per request).
- **Product translator's `translate()` accepts optional `\$source_host` and `\$raw_host`.** Default `null` source_host preserves the bare-permalink behavior for tests / future internal callers without agent context. When provided, the permalink is rewritten through the helper.

## Wire shape

Today, every `/catalog/search` and `/catalog/lookup` product URL in the response looks like:

\`\`\`
https://merchant.com/product/widget/?utm_source=chatgpt.com&utm_medium=referral&utm_id=woo_ucp&ai_agent_host_raw=chatgpt.com
\`\`\`

Identical UTM payload to what continue_urls carry. WC Order Attribution captures the same way. STRICT gate (\`utm_id === 'woo_ucp'\`) recognizes the buyer-followed-link path the same as the buyer-followed-continue-url path.

## Test plan

- [x] \`composer test\` — 918/918 passing (including 11 new tests across \`AttributionTest\` + \`UcpProductTranslatorTest\`)
- [x] \`vendor/bin/phpcs\` clean on changed files
- [x] \`vendor/bin/phpstan analyse\` clean
- [x] \`./bin/make-pot.sh\` regenerated
- [ ] Manual verification on a test store: hit \`/wp-json/wc/storefront/ucp/v1/catalog/search\` with \`UCP-Agent\` header set, confirm product \`url\` carries UTMs

## Out of scope

- Variant translator UTM stamping — UCP variants don't carry their own URL (they reference the parent product's URL implicitly), so no changes needed there.
- Existing wire shape on continue_url — preserved bit-for-bit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)