### PR TITLE
fix: checkout-session buyer-handoff message no longer reads as an error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@
 
 ---
 
+## [0.6.5] – 2026-04-28
+
+### Fixes
+- **Checkout-session buyer-handoff message no longer reads as an error.** Pre-fix, the happy-path message accompanying every `requires_escalation` redirect carried `type: error` + `severity: requires_buyer_input`, which UCPPlayground (and any agent reading `messages[].type` as a UI rendering hint) styled in red/error framing. The result: AI assistants paraphrased the response as "there was an issue, here's a link" instead of "you're set, click here to buy" — and rendered the `continue_url` as a plain hyperlink rather than a primary Buy Now CTA. Now `type: info` + `severity: advisory`, matching the partner `total_is_provisional` info message that's already in the same response. Same `code` (`buyer_handoff_required`) and same `content` — only the rendering hints changed. The `status: requires_escalation` field continues to signal the redirect posture; the message type/severity now matches the emotional valence (informational, not failure).
+
+---
+
 ## [0.6.4] – 2026-04-28
 
 ### Fixes

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -1603,10 +1603,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				'code'     => 'minimum_not_met',
 				// `requires_buyer_input`, not `unrecoverable`: the
 				// message instructs the buyer to "add more items to
-				// proceed" — it's a fixable condition, parallel to
-				// `buyer_handoff_required`. Using unrecoverable would
-				// mislead agents into treating this as a terminal
-				// failure and abandoning the cart.
+				// proceed" — a fixable condition that requires buyer
+				// action (modify the cart) before retry. Using
+				// unrecoverable would mislead agents into treating
+				// this as a terminal failure and abandoning the cart.
+				// Distinct from `buyer_handoff_required` (the
+				// happy-path redirect message), which is `type: info`
+				// + `severity: advisory` because it's not an error —
+				// just informational copy accompanying the redirect.
 				'severity' => 'requires_buyer_input',
 				'path'     => '$.line_items',
 				'content'  => sprintf(
@@ -1650,10 +1654,26 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			if ( ! is_string( $handoff_content ) ) {
 				$handoff_content = $default_handoff;
 			}
+			// Type `info` + severity `advisory` rather than `error` /
+			// `requires_buyer_input`: this message accompanies the
+			// happy-path redirect, not a failure. Agents (UCPPlayground
+			// observed; production agents likely follow) read
+			// `messages[].type` as a UI rendering hint — `error`
+			// triggers red/warning styling and the AI mirrors the
+			// problem-flavored framing back to the user, producing
+			// "there was an issue, here's the link" copy instead of
+			// "you're set, click here to buy." The `status` field
+			// already says `requires_escalation` to signal the redirect
+			// posture; the message type/severity should match the
+			// emotional valence (informational, not an error condition)
+			// rather than restate the protocol-level state. The
+			// partner `total_is_provisional` message below uses the
+			// same `info` / `advisory` shape and renders correctly —
+			// staying consistent with that.
 			$messages[] = [
-				'type'     => 'error',
+				'type'     => 'info',
 				'code'     => 'buyer_handoff_required',
-				'severity' => 'requires_buyer_input',
+				'severity' => 'advisory',
 				'content'  => $handoff_content,
 			];
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -2,14 +2,14 @@
 # This file is distributed under the GPL-3.0-or-later.
 msgid ""
 msgstr ""
-"Project-Id-Version: WooCommerce AI Storefront 0.6.4\n"
+"Project-Id-Version: WooCommerce AI Storefront 0.6.5\n"
 "Report-Msgid-Bugs-To: https://wordpress.org/support/plugin/woocommerce-ai-storefront\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-28T17:27:53+00:00\n"
+"POT-Creation-Date: 2026-04-28T17:48:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -148,136 +148,136 @@ msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1614
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1618
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1633
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1637
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1671
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1691
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2107
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2127
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2643
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2663
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2714
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2734
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2745
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2765
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2765
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2785
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2790
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2810
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2823
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2843
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2859
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2879
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2890
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2910
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2962
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2982
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3013
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3033
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3043
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3063
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3133
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3153
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3372
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3392
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3407
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3427
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3947
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3967
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4174
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4194
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4178
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4198
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4182
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4202
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4184
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4204
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4186
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4206
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4190
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4210
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4192
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4212
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "woocommerce-ai-storefront",
-	"version": "0.3.1",
+	"version": "0.6.5",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "woocommerce-ai-storefront",
-			"version": "0.3.1",
+			"version": "0.6.5",
 			"license": "GPL-3.0-or-later",
 			"dependencies": {
 				"@wordpress/api-fetch": "^7.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "woocommerce-ai-storefront",
-	"version": "0.6.4",
+	"version": "0.6.5",
 	"description": "Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude).",
 	"author": "WooCommerce",
 	"license": "GPL-3.0-or-later",

--- a/readme.txt
+++ b/readme.txt
@@ -6,7 +6,7 @@ Tested up to: 6.8
 Requires PHP: 8.1
 WC requires at least: 9.9
 WC tested up to: 9.9
-Stable tag: 0.6.4
+Stable tag: 0.6.5
 License: GPL-3.0-or-later
 License URI: https://www.gnu.org/licenses/gpl-3.0.html
 

--- a/tests/php/unit/UcpCheckoutSessionsTest.php
+++ b/tests/php/unit/UcpCheckoutSessionsTest.php
@@ -1175,7 +1175,19 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 		);
 		$this->assertCount( 1, $handoff );
 		$msg = array_values( $handoff )[0];
-		$this->assertEquals( 'requires_buyer_input', $msg['severity'] );
+		// Type `info` + severity `advisory` — the buyer-handoff
+		// message accompanies the happy-path redirect, not a failure.
+		// Pre-fix this carried `type: error` / `severity:
+		// requires_buyer_input`, which agents (UCPPlayground confirmed,
+		// production agents likely) read as a UI hint to render the
+		// response in error styling, producing "there was an issue,
+		// here's the link" copy instead of a Buy Now CTA. The
+		// `status: requires_escalation` field already signals the
+		// redirect posture; the message type/severity should match
+		// the emotional valence (informational), not restate the
+		// protocol-level state.
+		$this->assertEquals( 'info', $msg['type'] );
+		$this->assertEquals( 'advisory', $msg['severity'] );
 	}
 
 	public function test_buyer_handoff_message_omitted_when_no_continue_url(): void {

--- a/woocommerce-ai-storefront.php
+++ b/woocommerce-ai-storefront.php
@@ -3,7 +3,7 @@
  * Plugin Name: WooCommerce AI Storefront
  * Plugin URI: https://woocommerce.com/
  * Description: Make your WooCommerce store ready for AI shopping assistants (ChatGPT, Gemini, Perplexity, Claude). Full merchant control with store-only checkout and standard WooCommerce attribution.
- * Version: 0.6.4
+ * Version: 0.6.5
  * Author: WooCommerce
  * Author URI: https://woocommerce.com/
  * Text Domain: woocommerce-ai-storefront
@@ -23,7 +23,7 @@
 
 defined( 'ABSPATH' ) || exit;
 
-define( 'WC_AI_STOREFRONT_VERSION', '0.6.4' );
+define( 'WC_AI_STOREFRONT_VERSION', '0.6.5' );
 define( 'WC_AI_STOREFRONT_PLUGIN_FILE', __FILE__ );
 define( 'WC_AI_STOREFRONT_PLUGIN_PATH', untrailingslashit( plugin_dir_path( __FILE__ ) ) );
 define( 'WC_AI_STOREFRONT_PLUGIN_URL', untrailingslashit( plugin_dir_url( __FILE__ ) ) );


### PR DESCRIPTION
Closes #118.

## Summary

Fixes a UX bug where the AI's rendered response to `/checkout-sessions` reads as an error and the `continue_url` is presented as a plain hyperlink rather than a styled Buy Now CTA.

The buyer-handoff message accompanying every successful redirect previously carried `type: error` + `severity: requires_buyer_input`, which UCPPlayground (and any agent reading `messages[].type` as a UI rendering hint) styled in red/error framing. AI assistants then mirrored the problem-flavored tone in their output.

The `status: requires_escalation` field already signals the redirect posture at the protocol level. The message type/severity should match the emotional valence (informational, not failure), not restate the protocol-level state.

## What changed

```diff
 \$messages[] = [
-    'type'     => 'error',
+    'type'     => 'info',
     'code'     => 'buyer_handoff_required',
-    'severity' => 'requires_buyer_input',
+    'severity' => 'advisory',
     'content'  => \$handoff_content,
 ];
```

Same \`code\`. Same filterable \`content\`. Only the rendering hints changed. Now matches the partner \`total_is_provisional\` message in the same response (which was already correctly typed \`info\`/\`advisory\`).

## Out of scope

The \`minimum_not_met\` message legitimately uses \`type: error\` + \`severity: requires_buyer_input\` — that IS an error condition where the buyer must take action (add more items). Left untouched. The comment explaining why has been touched up to remove the now-stale "parallel to \`buyer_handoff_required\`" reference.

## Test plan

- [x] \`composer test\` — 920/920 passing
- [x] \`test_buyer_handoff_message_present_when_continue_url_issued\` updated to assert \`type: info\` + \`severity: advisory\`
- [x] \`vendor/bin/phpcs\` clean on changed files
- [x] \`vendor/bin/phpstan analyse\` clean
- [x] \`./bin/make-pot.sh\` regenerated
- [ ] Manual verification with UCPPlayground after merge: confirm AI no longer renders error styling, ideally renders Buy Now CTA. (If UCPPlayground still doesn't render a styled CTA, that's a separate UCPPlayground-side fix worth contributing upstream.)

## Version bump

0.6.4 → 0.6.5 (patch — bugfix, no schema change, no API contract change beyond the rendering-hint fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)