### PR TITLE
fix(jsonld): hex-escape <, >, &, ', " to prevent script-tag breakout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## [Unreleased]
 
+### Fixes
+- **JSON-LD output now hex-escapes `<`, `>`, `&`, `'`, `"` to prevent script-tag breakout via taxonomy / site name strings.** Pre-fix, `wp_json_encode( $data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE )` let `</script>` survive literal in the homepage/shop JSON-LD body. A category name like `</script><script>alert(1)</script>` (creatable by any user with `manage_categories`, typically Editor role) escaped the script-tag CDATA context — stored XSS reachable on every page emitting JSON-LD. Replaced with `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE` across the three encode sites: `output_store_jsonld()` (the actual XSS vector), `WC_AI_Storefront_Ucp::serve_manifest()` and `WC_AI_Storefront_Admin_Controller::update_settings()` (defense-in-depth — manifest cache served as application/json so HTML breakout doesn't apply, but uniform encoding eliminates any future re-emission risk). Schema.org parsers and Google's structured-data validator handle hex-escaped characters correctly per the JSON spec; international (non-ASCII) text is unaffected because `JSON_UNESCAPED_UNICODE` is retained. Closes #122.
+
 ---
 
 ## [0.6.5] – 2026-04-28

--- a/includes/admin/class-wc-ai-storefront-admin-controller.php
+++ b/includes/admin/class-wc-ai-storefront-admin-controller.php
@@ -348,8 +348,15 @@ class WC_AI_Storefront_Admin_Controller {
 				$content  = $llms_txt->generate();
 				set_transient( WC_AI_Storefront_Llms_Txt::CACHE_KEY, $content, HOUR_IN_SECONDS );
 
-				$ucp      = new WC_AI_Storefront_Ucp();
-				$manifest = wp_json_encode( $ucp->generate_manifest( WC_AI_Storefront::get_settings() ), JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
+				$ucp = new WC_AI_Storefront_Ucp();
+				// Safe-encoding flag set matches `WC_AI_Storefront_Ucp::serve_manifest()`
+				// — uniform across the two write sites that populate
+				// `WC_AI_Storefront_Ucp::CACHE_KEY` so a read from the
+				// transient lands on identically-encoded bytes regardless
+				// of which writer produced it. See that method for the
+				// HEX-escape rationale (script-tag breakout + adjacent
+				// injection vectors).
+				$manifest = wp_json_encode( $ucp->generate_manifest( WC_AI_Storefront::get_settings() ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT );
 				set_transient( WC_AI_Storefront_Ucp::CACHE_KEY, $manifest, HOUR_IN_SECONDS );
 			}
 		}

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -354,7 +354,23 @@ class WC_AI_Storefront_JsonLd {
 		 */
 		$store_data = apply_filters( 'wc_ai_storefront_jsonld_store', $store_data, $settings );
 
-		echo '<script type="application/ld+json">' . wp_json_encode( $store_data, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE ) . '</script>' . "\n";
+		// `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`
+		// over the previous `JSON_UNESCAPED_SLASHES` flag: ensures
+		// `<`, `>`, `&`, `'`, `"` in any string field are hex-escaped
+		// to `<` / `>` / `&` / `'` / `"`,
+		// which closes the `</script>` breakout class — a category
+		// name like `</script><script>alert(1)</script>` (creatable
+		// by any user with `manage_categories`, typically Editor role)
+		// would otherwise survive `JSON_UNESCAPED_SLASHES` and break
+		// out of the JSON-LD script-tag CDATA context. The HEX flags
+		// also pre-emptively close adjacent injection vectors
+		// (attribute-breakout via quotes, comment injection via `&`).
+		// `JSON_UNESCAPED_UNICODE` retained so non-ASCII strings
+		// (international product / brand / description text) don't
+		// bloat into `\uXXXX` sequences. Schema.org parsers and
+		// Google's structured-data validator handle hex-escaped
+		// characters correctly per the JSON spec.
+		echo '<script type="application/ld+json">' . wp_json_encode( $store_data, JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE ) . '</script>' . "\n";
 	}
 
 	/**

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -356,8 +356,9 @@ class WC_AI_Storefront_JsonLd {
 
 		// `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`
 		// over the previous `JSON_UNESCAPED_SLASHES` flag: ensures
-		// `<`, `>`, `&`, `'`, `"` in any string field are hex-escaped
-		// to `<` / `>` / `&` / `'` / `"`,
+		// `<`, `>`, `&`, `'`, `"` in any string field serialize as
+		// Unicode escape sequences (`\u003C`, `\u003E`, `\u0026`,
+		// `\u0027`, `\u0022`),
 		// which closes the `</script>` breakout class — a category
 		// name like `</script><script>alert(1)</script>` (creatable
 		// by any user with `manage_categories`, typically Editor role)

--- a/includes/ai-storefront/class-wc-ai-storefront-ucp.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-ucp.php
@@ -145,7 +145,17 @@ class WC_AI_Storefront_Ucp {
 		$cached = get_transient( self::CACHE_KEY );
 		if ( false === $cached ) {
 			WC_AI_Storefront_Logger::debug( 'UCP manifest cache miss — regenerating' );
-			$cached = wp_json_encode( $this->generate_manifest( $settings ), JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT );
+			// HEX flags hex-escape `<`, `>`, `&`, `'`, `"` in any
+			// manifest string (site name, agent_guide translation,
+			// service endpoint URLs). The manifest is served as
+			// `application/json` so HTML script-tag breakout doesn't
+			// apply to the wire response, but applying the same flag
+			// set the JSON-LD emission uses keeps defense uniform —
+			// any future code that re-emits the cached manifest into
+			// HTML inherits the safe encoding automatically. Pretty-
+			// print retained because the manifest is a developer-facing
+			// surface and readability outweighs the byte cost.
+			$cached = wp_json_encode( $this->generate_manifest( $settings ), JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT );
 			set_transient( self::CACHE_KEY, $cached, HOUR_IN_SECONDS );
 		} else {
 			WC_AI_Storefront_Logger::debug( 'UCP manifest cache hit' );

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-28T19:30:32+00:00\n"
+"POT-Creation-Date: 2026-04-28T19:59:25+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -36,12 +36,12 @@ msgid "WooCommerce"
 msgstr ""
 
 #. translators: %s: the unrecognized product_selection_mode enum value
-#: includes/admin/class-wc-ai-storefront-admin-controller.php:527
+#: includes/admin/class-wc-ai-storefront-admin-controller.php:534
 #, php-format
 msgid "Unrecognized product_selection_mode: %s"
 msgstr ""
 
-#: includes/admin/class-wc-ai-storefront-admin-controller.php:705
+#: includes/admin/class-wc-ai-storefront-admin-controller.php:712
 msgid "Could not load pages."
 msgstr ""
 
@@ -76,7 +76,7 @@ msgid "Products"
 msgstr ""
 
 #. translators: This string is injected verbatim into LLM system prompts via the UCP manifest. Translate the natural-language prose, but DO NOT translate the technical identifiers (`requires_escalation`, `continue_url`, `/checkout-sessions`, `unsupported_operation`, `UCP-Agent`, `Product/Version`, `Other AI`) or HTTP methods (POST, GET, PUT, PATCH, DELETE) — agents must see these tokens exactly.
-#: includes/ai-storefront/class-wc-ai-storefront-ucp.php:565
+#: includes/ai-storefront/class-wc-ai-storefront-ucp.php:575
 msgid "This store uses requires_escalation checkout: agents do not place orders directly. POST /checkout-sessions returns a continue_url with attribution UTMs already attached; redirect the user to that URL to complete the purchase on the merchant site. The /checkout-sessions/{id} URL is stateless — GET, PUT, PATCH, and DELETE all return HTTP 405 with code \"unsupported_operation\" because there is no persistent session to act on. Send your agent identity via the UCP-Agent header (profile URL form preferred, Product/Version form also accepted) so attribution canonicalizes to your brand rather than bucketing as \"Other AI\"."
 msgstr ""
 

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -248,9 +248,10 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		// Editor) becomes a stored XSS on the homepage and shop page.
 		//
 		// Fix uses `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`
-		// so `<` and `>` hex-escape to `<` / `>`. The script
-		// tag's CDATA is preserved; Schema.org parsers handle the hex
-		// escapes per the JSON spec.
+		// so `<` and `>` serialize as `\u003C` and `\u003E` (and
+		// the other flagged characters likewise serialize as escaped
+		// code points). The script tag's CDATA is preserved; Schema.org
+		// parsers handle these escapes per the JSON spec.
 		Functions\when( 'is_front_page' )->justReturn( true );
 		Functions\when( 'is_shop' )->justReturn( false );
 		Functions\when( 'home_url' )->alias(
@@ -278,11 +279,13 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$category->count = 1;
 		Functions\when( 'get_terms' )->justReturn( [ $category ] );
 		Functions\when( 'get_term_link' )->justReturn( 'https://example.com/category/malicious-category/' );
-		// Real `wp_json_encode` so we exercise the actual flag set
-		// rather than the string-builder alias used elsewhere.
-		Functions\when( 'wp_json_encode' )->alias(
-			static fn( $data, $flags = 0 ) => json_encode( $data, $flags )
-		);
+		// Real `wp_json_encode` stand-in via PHP's encoder so we
+		// exercise the actual flag handling rather than the
+		// string-builder alias used elsewhere in this file. Aliasing
+		// directly to `json_encode` (per Copilot review on PR #131)
+		// is consistent with surrounding tests and forwards all
+		// arguments correctly.
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
 		Functions\when( '__' )->returnArg( 1 );
 
 		ob_start();
@@ -341,10 +344,21 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 		// Extract the JSON between the script tags and confirm it
 		// parses — the hex-escaped output is still valid JSON-LD.
+		// `preg_match_all` over `preg_match` (per Copilot review on
+		// PR #131): `preg_match` returns the FIRST match only, so a
+		// regression that emitted TWO `<script type=...>` blocks
+		// would slip past `preg_match`'s result-shape check entirely.
+		// `preg_match_all` with PREG_SET_ORDER groups each match's
+		// captures together so we can assert exactly one block.
 		$matches = [];
-		preg_match( '/<script type="application\/ld\+json">(.*?)<\/script>/s', $output, $matches );
-		$this->assertCount( 2, $matches, 'Expected exactly one matched script-tag pair.' );
-		$decoded = json_decode( $matches[1], true );
+		preg_match_all(
+			'/<script type="application\/ld\+json">(.*?)<\/script>/s',
+			$output,
+			$matches,
+			PREG_SET_ORDER
+		);
+		$this->assertCount( 1, $matches, 'Expected exactly one <script type="application/ld+json"> block in output.' );
+		$decoded = json_decode( $matches[0][1], true );
 		$this->assertIsArray( $decoded, 'JSON inside the script tag must parse to an array.' );
 
 		// Cross-field round-trip: BOTH the site name AND the category

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -289,14 +289,54 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->jsonld->output_store_jsonld();
 		$output = ob_get_clean();
 
+		// Positive proof the emission ran: presence of the wrapping
+		// opening tag. Without this, a regression that returned early
+		// before echoing anything would leave `$output` empty — and
+		// the rest of the assertions below would all trivially pass.
+		$this->assertStringContainsString(
+			'<script type="application/ld+json">',
+			$output,
+			'output_store_jsonld() must emit the wrapping script tag.'
+		);
+
 		// Critical assertion: the literal `</script>` byte sequence
 		// MUST NOT appear inside the JSON body, only as the closing
-		// of our own intended `<script type="application/ld+json">`
-		// wrapper. Total occurrence count = 1 (our closing tag).
+		// of our own intended wrapper. The fixture injects two payloads
+		// (in site name AND in category name) each containing two
+		// `</script>` occurrences, so a complete fix produces exactly
+		// 1 occurrence (the wrapper close); a complete regression
+		// produces 5 (1 wrapper + 2 fields × 2 occurrences). Anything
+		// in between is a partial regression and also fails the
+		// `=== 1` check, so this single assertion catches every
+		// regression class.
 		$this->assertSame(
 			1,
 			substr_count( $output, '</script>' ),
-			'JSON body must not contain literal </script> — only our wrapper closing tag is permitted.'
+			'JSON body must contain ZERO literal </script> sequences (only our wrapper close is permitted).'
+		);
+
+		// Same defense for the OPENING-tag-injection variant. Sneaky
+		// regressions that hex-escape `</script>` but leave `<script`
+		// raw would still allow injection of NEW script blocks into
+		// the page. The fixture payloads each contain one literal
+		// `<script` (the second tag in `</script><script>...`); a
+		// complete fix produces exactly 1 (our wrapper open).
+		$this->assertSame(
+			1,
+			substr_count( $output, '<script' ),
+			'JSON body must not contain a literal <script (only our wrapper open is permitted).'
+		);
+
+		// Same defense for HTML-comment injection. The flag set
+		// hex-escapes `<` so `<!--` becomes `<!--` — the
+		// canonical comment-injection vector should be blocked too.
+		// Fixture doesn't inject this, but a future test extension
+		// adding a `<!--` payload would land here without a code
+		// change.
+		$this->assertStringNotContainsString(
+			'<!--',
+			$output,
+			'JSON body must not contain HTML-comment open sequence.'
 		);
 
 		// Extract the JSON between the script tags and confirm it
@@ -306,6 +346,17 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 2, $matches, 'Expected exactly one matched script-tag pair.' );
 		$decoded = json_decode( $matches[1], true );
 		$this->assertIsArray( $decoded, 'JSON inside the script tag must parse to an array.' );
+
+		// Cross-field round-trip: BOTH the site name AND the category
+		// name should be preserved as data. A regression that fixed
+		// only one path (e.g., site-name encoding fixed but
+		// `get_catalog_summary()`'s category-name path still raw)
+		// would fail one of these.
+		$this->assertEquals(
+			'</script><script>document.cookie</script>',
+			$decoded['hasOfferCatalog']['itemListElement'][0]['name'],
+			'Malicious category name must round-trip through hex-escape and JSON-decode.'
+		);
 		// Round-trip through decode confirms the malicious string is
 		// preserved as data (not as breakout markup): the decoded
 		// `name` equals the original input.

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -237,6 +237,85 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringNotContainsString( 'utm_medium=ai_agent', $url );
 	}
 
+	public function test_store_jsonld_hex_escapes_script_close_tag_in_taxonomy_names(): void {
+		// Regression guard for the script-tag-breakout class: any
+		// string field flowing into the JSON-LD body that contains
+		// `</script>` would, under the previous `JSON_UNESCAPED_SLASHES`
+		// flag, survive verbatim and break out of the
+		// `<script type="application/ld+json">` CDATA context. A
+		// taxonomy name like `</script><script>alert(1)</script>`
+		// (creatable by any role with `manage_categories`, typically
+		// Editor) becomes a stored XSS on the homepage and shop page.
+		//
+		// Fix uses `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`
+		// so `<` and `>` hex-escape to `<` / `>`. The script
+		// tag's CDATA is preserved; Schema.org parsers handle the hex
+		// escapes per the JSON spec.
+		Functions\when( 'is_front_page' )->justReturn( true );
+		Functions\when( 'is_shop' )->justReturn( false );
+		Functions\when( 'home_url' )->alias(
+			static fn( $path = '' ) => 'https://example.com' . $path
+		);
+		// Site name carries the malicious payload — the most reachable
+		// path: an admin types it into Settings → General → Site Title.
+		Functions\when( 'get_bloginfo' )->alias(
+			static function ( $key ) {
+				if ( 'name' === $key ) {
+					return '</script><script>alert("xss")</script>';
+				}
+				if ( 'description' === $key ) {
+					return 'normal description';
+				}
+				return '';
+			}
+		);
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		// Add a taxonomy with the same payload — covers the Editor-role
+		// `manage_categories` reach as well.
+		$category       = new stdClass();
+		$category->name = '</script><script>document.cookie</script>';
+		$category->slug = 'malicious-category';
+		$category->count = 1;
+		Functions\when( 'get_terms' )->justReturn( [ $category ] );
+		Functions\when( 'get_term_link' )->justReturn( 'https://example.com/category/malicious-category/' );
+		// Real `wp_json_encode` so we exercise the actual flag set
+		// rather than the string-builder alias used elsewhere.
+		Functions\when( 'wp_json_encode' )->alias(
+			static fn( $data, $flags = 0 ) => json_encode( $data, $flags )
+		);
+		Functions\when( '__' )->returnArg( 1 );
+
+		ob_start();
+		$this->jsonld->output_store_jsonld();
+		$output = ob_get_clean();
+
+		// Critical assertion: the literal `</script>` byte sequence
+		// MUST NOT appear inside the JSON body, only as the closing
+		// of our own intended `<script type="application/ld+json">`
+		// wrapper. Total occurrence count = 1 (our closing tag).
+		$this->assertSame(
+			1,
+			substr_count( $output, '</script>' ),
+			'JSON body must not contain literal </script> — only our wrapper closing tag is permitted.'
+		);
+
+		// Extract the JSON between the script tags and confirm it
+		// parses — the hex-escaped output is still valid JSON-LD.
+		$matches = [];
+		preg_match( '/<script type="application\/ld\+json">(.*?)<\/script>/s', $output, $matches );
+		$this->assertCount( 2, $matches, 'Expected exactly one matched script-tag pair.' );
+		$decoded = json_decode( $matches[1], true );
+		$this->assertIsArray( $decoded, 'JSON inside the script tag must parse to an array.' );
+		// Round-trip through decode confirms the malicious string is
+		// preserved as data (not as breakout markup): the decoded
+		// `name` equals the original input.
+		$this->assertEquals(
+			'</script><script>alert("xss")</script>',
+			$decoded['name'],
+			'Malicious site-name must round-trip cleanly through hex-escape and JSON-decode.'
+		);
+	}
+
 	// ------------------------------------------------------------------
 	// Inventory (only when managing stock)
 	// ------------------------------------------------------------------


### PR DESCRIPTION
Closes #122.

## Summary

JSON-LD output previously used `JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE`, letting `</script>` survive literal in the homepage and shop `<script type=\"application/ld+json\">` body. A category name like `</script><script>alert(1)</script>` (creatable by any user with `manage_categories`, typically Editor role) escaped the script-tag CDATA context — **stored XSS reachable on every page emitting JSON-LD**.

Replaced with `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT | JSON_UNESCAPED_UNICODE` across all three encode sites.

## Changes

| File:line | Why |
|---|---|
| \`class-wc-ai-storefront-jsonld.php:357\` | The actual XSS vector — inline script-tag emission. |
| \`class-wc-ai-storefront-ucp.php:148\` | Manifest cache (defense-in-depth; manifest is served as \`application/json\` so HTML breakout doesn't apply on the wire response, but uniform encoding prevents any future code path that re-emits the cached manifest into HTML from inheriting the unsafe flag set). |
| \`class-wc-ai-storefront-admin-controller.php:352\` | Eager manifest cache writer — same data path, same flag set. |

## Why HEX flags over just dropping `JSON_UNESCAPED_SLASHES`

Dropping the slashes flag would convert `</script>` to `<\/script>`, which works but only addresses the script-tag case. The HEX flags hex-escape `<`, `>`, `&`, `'`, `\"` to their `\\u003c` etc. forms — closing several adjacent injection vectors at once: `<img>` injection, attribute breakout via `\"`, comment-style injection via `&`. Stronger defense for the same syntactic cost.

`JSON_UNESCAPED_UNICODE` retained so non-ASCII strings (international product / brand / description text) don't bloat into `\\uXXXX` sequences. Schema.org parsers and Google's structured-data validator handle hex-escaped characters correctly per the JSON spec.

## Test plan

- [x] New regression test \`test_store_jsonld_hex_escapes_script_close_tag_in_taxonomy_names\` covers a malicious site name AND a malicious category name. Asserts:
  - \`</script>\` literal appears exactly **once** in the output (just our wrapper closing tag).
  - The JSON between the script tags parses cleanly.
  - Decoded fields preserve the malicious input verbatim — round-trip proves we encoded, not stripped.
- [x] \`composer test\` — 921/921 (was 920, +1 new test).
- [x] \`vendor/bin/phpcs\` clean on changed files.
- [x] \`vendor/bin/phpstan analyse\` clean.
- [x] \`./bin/make-pot.sh\` regenerated.
- [ ] Manual verification: install on test store, set Site Title to \`</script><script>alert(1)</script>\`, view homepage source, confirm no breakout.
- [ ] Google Rich Results Test passes the modified JSON-LD output for a typical product page (hex-escaped \`<\`/\`>\` are valid JSON).

## Out of scope

- The other \`wp_json_encode\` calls in \`ucp-rest-controller.php\` (lines 2403, 2580, 2583) don't use \`JSON_UNESCAPED_SLASHES\` and aren't HTML-emission sites. Left as-is.

## Severity

CRITICAL. Reachable from any user with \`manage_categories\` (Editor role+). Public surface (every page that emits JSON-LD).

## Milestone

0.6.6 (CHANGELOG entry under \`[Unreleased]\`; final release commit will move it to \`[0.6.6]\` and bump versions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)