### PR TITLE
Fix test mock fragility: add_query_arg fragment handling and STRICT-gate sentinels

### DIFF
--- a/tests/php/unit/AttributionTest.php
+++ b/tests/php/unit/AttributionTest.php
@@ -53,18 +53,19 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 	public function test_capture_detects_ai_medium_from_order_meta(): void {
 		$order = new WC_Order();
 		$order->set_test_meta( '_wc_order_attribution_utm_medium', 'ai_agent' );
-		$order->set_test_meta( '_wc_order_attribution_utm_source', 'chatgpt' );
+		// Use a safely-fictional sentinel that can never become a
+		// KNOWN_AGENT_HOSTS key — avoids coupling the test to the
+		// current allowlist roster.
+		$order->set_test_meta( '_wc_order_attribution_utm_source', 'mysteryagent.example' );
 
 		Functions\expect( 'do_action' )->once();
 
 		$this->attribution->capture_ai_attribution( $order );
 
 		$this->assertTrue( $order->was_saved() );
-		// `chatgpt` is NOT a KNOWN_AGENT_HOSTS key (the key is
-		// `chatgpt.com`), so the lenient gate doesn't fire and the
-		// STRICT branch buckets to "Other AI" per 0.5.2 behavior.
-		// (Pre-0.5.2 this test stored the raw `'chatgpt'` value
-		// verbatim, which fragmented Top Agent stats.)
+		// `mysteryagent.example` is NOT in KNOWN_AGENT_HOSTS, so the
+		// lenient gate doesn't fire and the STRICT branch buckets to
+		// "Other AI" per 0.5.2 behavior.
 		$this->assertEquals(
 			WC_AI_Storefront_UCP_Agent_Header::OTHER_AI_BUCKET,
 			$order->get_meta( '_wc_ai_storefront_agent' )
@@ -222,7 +223,7 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 		$order = new WC_Order();
 		// No stored meta — WC core saw a regular landing page.
 		$_GET['utm_medium']    = 'ai_agent';
-		$_GET['utm_source']    = 'gemini'; // not in KNOWN_AGENT_HOSTS (key is gemini.google.com).
+		$_GET['utm_source']    = 'mysteryagent.example'; // not in KNOWN_AGENT_HOSTS.
 		$_GET['ai_session_id'] = 'session-abc';
 
 		Functions\expect( 'sanitize_text_field' )->andReturnFirstArg();
@@ -255,7 +256,8 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 	public function test_capture_does_not_store_empty_session_id(): void {
 		$order = new WC_Order();
 		$order->set_test_meta( '_wc_order_attribution_utm_medium', 'ai_agent' );
-		$order->set_test_meta( '_wc_order_attribution_utm_source', 'claude' );
+		// Safely-fictional sentinel: never a KNOWN_AGENT_HOSTS key.
+		$order->set_test_meta( '_wc_order_attribution_utm_source', 'mysteryagent.example' );
 		// No ai_session_id in $_GET.
 
 		Functions\expect( 'do_action' )->once();
@@ -263,7 +265,7 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 		$this->attribution->capture_ai_attribution( $order );
 
 		$this->assertEquals( '', $order->get_meta( '_wc_ai_storefront_session_id' ) );
-		// `claude` is NOT a KNOWN_AGENT_HOSTS key (key is `claude.ai`)
+		// `mysteryagent.example` is NOT in KNOWN_AGENT_HOSTS
 		// → 0.5.2 buckets to "Other AI".
 		$this->assertEquals(
 			WC_AI_Storefront_UCP_Agent_Header::OTHER_AI_BUCKET,

--- a/tests/php/unit/JsonLdNormalizationTest.php
+++ b/tests/php/unit/JsonLdNormalizationTest.php
@@ -36,9 +36,18 @@ class JsonLdNormalizationTest extends \PHPUnit\Framework\TestCase {
 
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
+				// Strip any fragment before appending query params, then
+				// re-append it — matching WordPress core's behavior and
+				// preventing malformed URLs like `?q=1#frag` where the
+				// query string would be absorbed into the fragment.
+				$fragment = '';
+				if ( str_contains( $url, '#' ) ) {
+					[ $url, $fragment ] = explode( '#', $url, 2 );
+					$fragment = '#' . $fragment;
+				}
 				$query = http_build_query( $args );
 				$sep   = str_contains( $url, '?' ) ? '&' : '?';
-				return $url . $sep . $query;
+				return $url . $sep . $query . $fragment;
 			}
 		);
 		Functions\when( 'wc_get_product_cat_ids' )->justReturn( [] );

--- a/tests/php/unit/JsonLdNormalizationTest.php
+++ b/tests/php/unit/JsonLdNormalizationTest.php
@@ -37,9 +37,11 @@ class JsonLdNormalizationTest extends \PHPUnit\Framework\TestCase {
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
 				// Strip any fragment before appending query params, then
-				// re-append it — matching WordPress core's behavior and
-				// preventing malformed URLs like `?q=1#frag` where the
-				// query string would be absorbed into the fragment.
+				// re-append it — matching WordPress core's behavior.
+				// Without this, a permalink like `.../widget/#reviews`
+				// would produce `.../widget/#reviews?add-to-cart=42`
+				// where the entire query string is part of the fragment
+				// and never reaches the server.
 				$fragment = '';
 				if ( str_contains( $url, '#' ) ) {
 					[ $url, $fragment ] = explode( '#', $url, 2 );

--- a/tests/php/unit/JsonLdReturnPolicyTest.php
+++ b/tests/php/unit/JsonLdReturnPolicyTest.php
@@ -29,9 +29,18 @@ class JsonLdReturnPolicyTest extends \PHPUnit\Framework\TestCase {
 
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
+				// Strip any fragment before appending query params, then
+				// re-append it — matching WordPress core's behavior and
+				// preventing malformed URLs like `?q=1#frag` where the
+				// query string would be absorbed into the fragment.
+				$fragment = '';
+				if ( str_contains( $url, '#' ) ) {
+					[ $url, $fragment ] = explode( '#', $url, 2 );
+					$fragment = '#' . $fragment;
+				}
 				$query = http_build_query( $args );
 				$sep   = str_contains( $url, '?' ) ? '&' : '?';
-				return $url . $sep . $query;
+				return $url . $sep . $query . $fragment;
 			}
 		);
 		Functions\when( 'wc_get_product_cat_ids' )->justReturn( [] );

--- a/tests/php/unit/JsonLdReturnPolicyTest.php
+++ b/tests/php/unit/JsonLdReturnPolicyTest.php
@@ -30,9 +30,11 @@ class JsonLdReturnPolicyTest extends \PHPUnit\Framework\TestCase {
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
 				// Strip any fragment before appending query params, then
-				// re-append it — matching WordPress core's behavior and
-				// preventing malformed URLs like `?q=1#frag` where the
-				// query string would be absorbed into the fragment.
+				// re-append it — matching WordPress core's behavior.
+				// Without this, a permalink like `.../widget/#reviews`
+				// would produce `.../widget/#reviews?add-to-cart=42`
+				// where the entire query string is part of the fragment
+				// and never reaches the server.
 				$fragment = '';
 				if ( str_contains( $url, '#' ) ) {
 					[ $url, $fragment ] = explode( '#', $url, 2 );

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -40,9 +40,18 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		// across tests — simple passthrough that appends params.
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
+				// Strip any fragment before appending query params, then
+				// re-append it — matching WordPress core's behavior and
+				// preventing malformed URLs like `?q=1#frag` where the
+				// query string would be absorbed into the fragment.
+				$fragment = '';
+				if ( str_contains( $url, '#' ) ) {
+					[ $url, $fragment ] = explode( '#', $url, 2 );
+					$fragment = '#' . $fragment;
+				}
 				$query = http_build_query( $args );
 				$sep   = str_contains( $url, '?' ) ? '&' : '?';
-				return $url . $sep . $query;
+				return $url . $sep . $query . $fragment;
 			}
 		);
 		Functions\when( 'wc_get_product_cat_ids' )->justReturn( [] );
@@ -152,6 +161,41 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$platforms = $result['potentialAction']['target']['actionPlatform'];
 		$this->assertContains( 'https://schema.org/DesktopWebPlatform', $platforms );
 		$this->assertContains( 'https://schema.org/MobileWebPlatform', $platforms );
+	}
+
+	public function test_buyaction_uritemplate_preserves_fragment_from_permalink(): void {
+		// Some themes append tab deep-links to product permalinks, e.g.
+		// `https://example.com/product/widget/#tab-description`. The real
+		// `add_query_arg()` strips the fragment, appends query params to
+		// the base URL, then re-appends the fragment — producing a
+		// well-formed URL where the query string is readable by the server.
+		//
+		// Regression guard: the mock must behave identically so CI catches
+		// any future production-code change that re-introduces the bug.
+		$product = $this->make_product(
+			[ 'permalink' => 'https://example.com/product/widget/#tab-description' ]
+		);
+		$result  = $this->jsonld->enhance_product_data( [], $product );
+
+		$url = $result['potentialAction']['target']['urlTemplate'];
+
+		// Query params must appear BEFORE the fragment separator.
+		$fragment_pos    = strpos( $url, '#' );
+		$query_param_pos = strpos( $url, 'add-to-cart=' );
+
+		$this->assertNotFalse( $fragment_pos, 'urlTemplate should still contain the fragment' );
+		$this->assertNotFalse( $query_param_pos, 'urlTemplate should contain add-to-cart param' );
+		$this->assertLessThan(
+			$fragment_pos,
+			$query_param_pos,
+			'Query params must appear before the # fragment separator'
+		);
+
+		// The fragment itself should be intact at the very end.
+		$this->assertStringEndsWith( '#tab-description', $url );
+
+		// Sanity: attribution params must survive too.
+		$this->assertStringContainsString( 'utm_id=woo_ucp', $url );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -41,9 +41,11 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
 				// Strip any fragment before appending query params, then
-				// re-append it — matching WordPress core's behavior and
-				// preventing malformed URLs like `?q=1#frag` where the
-				// query string would be absorbed into the fragment.
+				// re-append it — matching WordPress core's behavior.
+				// Without this, a permalink like `.../widget/#reviews`
+				// would produce `.../widget/#reviews?add-to-cart=42`
+				// where the entire query string is part of the fragment
+				// and never reaches the server.
 				$fragment = '';
 				if ( str_contains( $url, '#' ) ) {
 					[ $url, $fragment ] = explode( '#', $url, 2 );
@@ -196,6 +198,44 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 		// Sanity: attribution params must survive too.
 		$this->assertStringContainsString( 'utm_id=woo_ucp', $url );
+	}
+
+	public function test_buyaction_uritemplate_preserves_fragment_when_permalink_has_existing_query(): void {
+		// Combination case: permalink already carries a query string
+		// (e.g. a language plugin adds `?lang=fr`) AND has a fragment.
+		// The mock's `?`-vs-`&` separator check must look at the
+		// fragment-stripped URL so it finds the existing `?` and uses
+		// `&`. Without the fragment strip, a naive check on the full
+		// URL including `#reviews` would still find `?` and use `&`
+		// — but only by accident; the fragment would still land in the
+		// wrong position. This test pins both invariants explicitly.
+		$product = $this->make_product(
+			[ 'permalink' => 'https://example.com/product/widget/?lang=fr#tab-description' ]
+		);
+		$result  = $this->jsonld->enhance_product_data( [], $product );
+
+		$url = $result['potentialAction']['target']['urlTemplate'];
+
+		// Original query param must survive.
+		$this->assertStringContainsString( 'lang=fr', $url );
+
+		// All added params must appear before the fragment.
+		$fragment_pos    = strpos( $url, '#' );
+		$query_param_pos = strpos( $url, 'add-to-cart=' );
+
+		$this->assertNotFalse( $fragment_pos );
+		$this->assertNotFalse( $query_param_pos );
+		$this->assertLessThan(
+			$fragment_pos,
+			$query_param_pos,
+			'Added query params must appear before the # separator'
+		);
+
+		// Exactly one `#` — no duplication of the fragment marker.
+		$this->assertSame( 1, substr_count( $url, '#' ) );
+
+		// Fragment intact at the end.
+		$this->assertStringEndsWith( '#tab-description', $url );
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
Closes #138
Closes #139

## Summary

Two test quality fixes surfaced during the post-0.6.6 review pass.

**#138 — `add_query_arg` mock doesn't handle URL fragments (JsonLd tests)**

The shared mock in `JsonLdTest`, `JsonLdNormalizationTest`, and `JsonLdReturnPolicyTest` setUp methods concatenated query params directly onto the URL string without stripping any `#fragment` first. On a permalink like `https://example.com/product/widget/#tab-description` the mock produced `.../widget/#tab-description?add-to-cart=42` — the query string absorbed into the fragment, invisible to the server. The real WordPress `add_query_arg()` strips the fragment, appends params, then re-appends the fragment.

Fix: update all three setUp mocks to match core's behavior. Add a regression test in `JsonLdTest` that asserts the query string appears before the `#` separator.

**#139 — STRICT-gate tests use real agent names as sentinels**

Three tests in `AttributionTest.php` used `'chatgpt'`, `'gemini'`, `'claude'` as `utm_source` values in positions where the agent identity is irrelevant to what's being tested (STRICT gate fires / doesn't fire). If any of those names were ever added to `KNOWN_AGENT_HOSTS` as a bare-name alias, the lenient gate would silently also fire, changing the test's semantics undetected.

Fix: replace all three with `'mysteryagent.example'` — an RFC 2606 reserved domain guaranteed never to be a real `KNOWN_AGENT_HOSTS` entry.

## Test plan

- [ ] `./vendor/bin/phpunit tests/php/unit/JsonLdTest.php` — 23 tests, all green including new fragment test
- [ ] `./vendor/bin/phpunit tests/php/unit/JsonLdNormalizationTest.php` — 4 tests, all green
- [ ] `./vendor/bin/phpunit tests/php/unit/JsonLdReturnPolicyTest.php` — 29 tests, all green
- [ ] `./vendor/bin/phpunit tests/php/unit/AttributionTest.php` — 44 tests, all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)