### PR TITLE
Security hardening: H-2, H-1, M-3, M-4, L-2

### DIFF
--- a/includes/admin/class-wc-ai-storefront-admin-controller.php
+++ b/includes/admin/class-wc-ai-storefront-admin-controller.php
@@ -327,7 +327,7 @@ class WC_AI_Storefront_Admin_Controller {
 	public function update_settings( $request ) {
 		$data = [];
 
-		$fields = [ 'enabled', 'product_selection_mode', 'selected_categories', 'selected_tags', 'selected_brands', 'selected_products', 'rate_limit_rpm', 'allowed_crawlers', 'return_policy' ];
+		$fields = [ 'enabled', 'product_selection_mode', 'selected_categories', 'selected_tags', 'selected_brands', 'selected_products', 'rate_limit_rpm', 'allowed_crawlers', 'allow_unknown_ucp_agents', 'return_policy' ];
 		foreach ( $fields as $field ) {
 			$value = $request->get_param( $field );
 			if ( null !== $value ) {

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -309,11 +309,21 @@ class WC_AI_Storefront_JsonLd {
 		 * Filter the enhanced JSON-LD product data.
 		 *
 		 * @since 1.0.0
-		 * @param array      $markup   The enhanced product structured data.
-		 * @param WC_Product $product  The product.
-		 * @param array      $settings The AI syndication settings.
+		 * @param array      $markup          The enhanced product structured data.
+		 * @param WC_Product $product         The product.
+		 * @param array      $settings_subset Minimal safe subset of settings:
+		 *                                    `enabled`, `product_selection_mode`,
+		 *                                    `return_policy`. Security-sensitive
+		 *                                    fields (rate limits, access-control
+		 *                                    flags, crawler allow-lists) are
+		 *                                    intentionally excluded.
 		 */
-		return apply_filters( 'wc_ai_storefront_jsonld_product', $markup, $product, $settings );
+		$settings_subset = [
+			'enabled'                => $settings['enabled'] ?? 'no',
+			'product_selection_mode' => $settings['product_selection_mode'] ?? 'all',
+			'return_policy'          => $settings['return_policy'] ?? [],
+		];
+		return apply_filters( 'wc_ai_storefront_jsonld_product', $markup, $product, $settings_subset );
 	}
 
 	/**
@@ -362,10 +372,20 @@ class WC_AI_Storefront_JsonLd {
 		 * Filter the store-level JSON-LD data.
 		 *
 		 * @since 1.0.0
-		 * @param array $store_data The store structured data.
-		 * @param array $settings   The AI syndication settings.
+		 * @param array $store_data      The store structured data.
+		 * @param array $settings_subset Minimal safe subset of settings:
+		 *                               `enabled`, `product_selection_mode`,
+		 *                               `return_policy`. Security-sensitive
+		 *                               fields (rate limits, access-control
+		 *                               flags, crawler allow-lists) are
+		 *                               intentionally excluded.
 		 */
-		$store_data = apply_filters( 'wc_ai_storefront_jsonld_store', $store_data, $settings );
+		$settings_subset = [
+			'enabled'                => $settings['enabled'] ?? 'no',
+			'product_selection_mode' => $settings['product_selection_mode'] ?? 'all',
+			'return_policy'          => $settings['return_policy'] ?? [],
+		];
+		$store_data = apply_filters( 'wc_ai_storefront_jsonld_store', $store_data, $settings_subset );
 
 		// `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`
 		// over the previous `JSON_UNESCAPED_SLASHES` flag: ensures
@@ -592,13 +612,22 @@ class WC_AI_Storefront_JsonLd {
 		}
 
 		// Always emit returnFees (sanitization defaults to FreeReturn
-		// when unset).
-		$fees                = isset( $policy['fees'] ) && is_string( $policy['fees'] ) ? $policy['fees'] : 'FreeReturn';
+		// when unset). Allow-list validated here at emission time as a
+		// second gate — save-time sanitization is the primary defence,
+		// but a future DB import or direct option write could bypass it.
+		$allowed_fees = [ 'FreeReturn', 'ReturnFeesCustomerResponsibility', 'OriginalShippingFees', 'RestockingFees' ];
+		$fees         = isset( $policy['fees'] ) && is_string( $policy['fees'] ) && in_array( $policy['fees'], $allowed_fees, true )
+			? $policy['fees']
+			: 'FreeReturn';
 		$block['returnFees'] = 'https://schema.org/' . $fees;
 
 		// returnMethod: scalar string when 1 method selected, array
-		// when 2+, omitted when none.
-		$methods = isset( $policy['methods'] ) && is_array( $policy['methods'] ) ? $policy['methods'] : [];
+		// when 2+, omitted when none. Methods are also allow-list
+		// validated at emission time for the same reason as fees above.
+		$allowed_methods = [ 'ReturnByMail', 'ReturnInStore', 'ReturnAtKiosk' ];
+		$methods         = isset( $policy['methods'] ) && is_array( $policy['methods'] )
+			? array_values( array_filter( $policy['methods'], static fn( $m ) => in_array( $m, $allowed_methods, true ) ) )
+			: [];
 		if ( count( $methods ) === 1 ) {
 			$block['returnMethod'] = 'https://schema.org/' . $methods[0];
 		} elseif ( count( $methods ) >= 2 ) {

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -626,7 +626,11 @@ class WC_AI_Storefront_JsonLd {
 		// validated at emission time for the same reason as fees above.
 		$allowed_methods = [ 'ReturnByMail', 'ReturnInStore', 'ReturnAtKiosk' ];
 		$methods         = isset( $policy['methods'] ) && is_array( $policy['methods'] )
-			? array_values( array_filter( $policy['methods'], static fn( $m ) => in_array( $m, $allowed_methods, true ) ) )
+			? array_values(
+				array_unique(
+					array_filter( $policy['methods'], static fn( $m ) => in_array( $m, $allowed_methods, true ) )
+				)
+			)
 			: [];
 		if ( count( $methods ) === 1 ) {
 			$block['returnMethod'] = 'https://schema.org/' . $methods[0];

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -385,7 +385,7 @@ class WC_AI_Storefront_JsonLd {
 			'product_selection_mode' => $settings['product_selection_mode'] ?? 'all',
 			'return_policy'          => $settings['return_policy'] ?? [],
 		];
-		$store_data = apply_filters( 'wc_ai_storefront_jsonld_store', $store_data, $settings_subset );
+		$store_data      = apply_filters( 'wc_ai_storefront_jsonld_store', $store_data, $settings_subset );
 
 		// `JSON_HEX_TAG | JSON_HEX_AMP | JSON_HEX_APOS | JSON_HEX_QUOT`
 		// over the previous `JSON_UNESCAPED_SLASHES` flag: ensures
@@ -615,8 +615,8 @@ class WC_AI_Storefront_JsonLd {
 		// when unset). Allow-list validated here at emission time as a
 		// second gate — save-time sanitization is the primary defence,
 		// but a future DB import or direct option write could bypass it.
-		$allowed_fees = [ 'FreeReturn', 'ReturnFeesCustomerResponsibility', 'OriginalShippingFees', 'RestockingFees' ];
-		$fees         = isset( $policy['fees'] ) && is_string( $policy['fees'] ) && in_array( $policy['fees'], $allowed_fees, true )
+		$allowed_fees        = [ 'FreeReturn', 'ReturnFeesCustomerResponsibility', 'OriginalShippingFees', 'RestockingFees' ];
+		$fees                = isset( $policy['fees'] ) && is_string( $policy['fees'] ) && in_array( $policy['fees'], $allowed_fees, true )
 			? $policy['fees']
 			: 'FreeReturn';
 		$block['returnFees'] = 'https://schema.org/' . $fees;

--- a/includes/ai-storefront/class-wc-ai-storefront-llms-txt.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-llms-txt.php
@@ -574,10 +574,12 @@ class WC_AI_Storefront_Llms_Txt {
 					'timeout'     => 1,
 					'redirection' => 1,
 					'blocking'    => true,
-					// Skip SSL verify on self-origin probes — some
-					// local/dev environments have self-signed certs
-					// that would otherwise reject the probe.
-					'sslverify'   => false,
+					// SSL verification: disabled only in dev/debug
+					// environments (WP_DEBUG on) where self-signed certs
+					// are common. In production, verify the cert so these
+					// self-origin probes don't silently accept MITM
+					// responses.
+					'sslverify'   => ! ( defined( 'WP_DEBUG' ) && WP_DEBUG ),
 				]
 			);
 			if ( is_wp_error( $response ) ) {

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3825,7 +3825,16 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		$meta_source = isset( $meta['source'] ) && is_string( $meta['source'] )
 			? trim( $meta['source'] )
 			: '';
-		if ( '' !== $meta_source ) {
+		// Enforce the same constraints that the UCP-Agent header path
+		// enforces via `canonicalize_host()`: length <= 253 chars
+		// (RFC 1035 max FQDN) and only hostname-safe characters
+		// (letters, digits, hyphens, dots). This prevents an attacker
+		// who can craft arbitrary JSON bodies from injecting arbitrary
+		// strings into order meta or the `raw_host` attribution field.
+		if ( '' !== $meta_source
+			&& strlen( $meta_source ) <= 253
+			&& (bool) preg_match( '/^[A-Za-z0-9.\-]+$/', $meta_source )
+		) {
 			$normalized = strtolower( $meta_source );
 			return [
 				'name'        => WC_AI_Storefront_UCP_Agent_Header::canonicalize_product( $normalized ),

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3825,15 +3825,17 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		$meta_source = isset( $meta['source'] ) && is_string( $meta['source'] )
 			? trim( $meta['source'] )
 			: '';
-		// Enforce the same constraints that the UCP-Agent header path
-		// enforces via `canonicalize_host()`: length <= 253 chars
-		// (RFC 1035 max FQDN) and only hostname-safe characters
-		// (letters, digits, hyphens, dots). This prevents an attacker
-		// who can craft arbitrary JSON bodies from injecting arbitrary
-		// strings into order meta or the `raw_host` attribution field.
+		// Validate meta_source as a plausible product-name token —
+		// the same token style that Path 2 (Product/Version header)
+		// accepts — before storing it in order meta or the raw_host
+		// attribution field. Product tokens may contain underscores
+		// (e.g. `my_agent`), so the charset is wider than pure
+		// hostname characters. Length cap: RFC 1035 FQDN max (253)
+		// keeps the stored value bounded without rejecting any
+		// realistic agent identifier.
 		if ( '' !== $meta_source
 			&& strlen( $meta_source ) <= 253
-			&& (bool) preg_match( '/^[A-Za-z0-9.\-]+$/', $meta_source )
+			&& (bool) preg_match( '/^[A-Za-z0-9._\-]+$/', $meta_source )
 		) {
 			$normalized = strtolower( $meta_source );
 			return [

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-28T21:55:34+00:00\n"
+"POT-Creation-Date: 2026-04-28T23:23:48+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -69,7 +69,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:356
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:366
 #: client/settings/ai-storefront/product-selection.js:922
 #: client/settings/ai-storefront/product-selection.js:1135
 msgid "Products"
@@ -260,38 +260,38 @@ msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were i
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4068
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4079
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4295
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4306
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4299
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4310
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4303
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4314
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4305
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4316
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4307
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4318
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4311
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4322
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4313
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4324
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/JsonLdReturnPolicyTest.php
+++ b/tests/php/unit/JsonLdReturnPolicyTest.php
@@ -909,4 +909,107 @@ class JsonLdReturnPolicyTest extends \PHPUnit\Framework\TestCase {
 		);
 		$this->assertSame( 30, $result['merchantReturnDays'] );
 	}
+
+	// ------------------------------------------------------------------
+	// Emission-time allow-list validation (audit H-1)
+	// ------------------------------------------------------------------
+
+	public function test_unknown_fees_value_defaults_to_free_return_at_emission(): void {
+		// The save-time sanitizer rejects unknown fee values, but a
+		// direct DB write or import could bypass it. The emission-time
+		// allow-list must catch it and fall back to FreeReturn rather
+		// than concatenating an arbitrary string onto the schema.org URL.
+		$markup = [
+			'offers' => [
+				[
+					'@type' => 'Offer',
+				],
+			],
+		];
+
+		WC_AI_Storefront::$test_settings = [
+			'enabled'       => 'yes',
+			'return_policy' => [
+				'mode' => 'returns_accepted',
+				'days' => 30,
+				'fees' => 'EvilReturn',  // Not in allow-list.
+			],
+		];
+
+		$product = $this->make_product();
+		$result  = $this->jsonld->enhance_product_data( $markup, $product );
+
+		$block = $result['offers'][0]['hasMerchantReturnPolicy'];
+		$this->assertSame(
+			'https://schema.org/FreeReturn',
+			$block['returnFees'],
+			'Unknown fees value must be sanitized to FreeReturn at emission time.'
+		);
+	}
+
+	public function test_unknown_method_values_are_filtered_out_at_emission(): void {
+		// Non-allow-listed method strings must be silently dropped at
+		// emission time. If the only stored methods are invalid, the
+		// returnMethod property must be omitted entirely rather than
+		// emitting an empty array or an invalid schema.org URL.
+		$markup = [
+			'offers' => [
+				[
+					'@type' => 'Offer',
+				],
+			],
+		];
+
+		WC_AI_Storefront::$test_settings = [
+			'enabled'       => 'yes',
+			'return_policy' => [
+				'mode'    => 'returns_accepted',
+				'days'    => 30,
+				'fees'    => 'FreeReturn',
+				'methods' => [ 'ReturnByMail', 'NotAValidMethod', 'ReturnInStore' ],
+			],
+		];
+
+		$product = $this->make_product();
+		$result  = $this->jsonld->enhance_product_data( $markup, $product );
+
+		$block   = $result['offers'][0]['hasMerchantReturnPolicy'];
+		$methods = $block['returnMethod'];
+		$this->assertIsArray( $methods );
+		$this->assertCount( 2, $methods, 'Only the two valid methods should survive.' );
+		$this->assertContains( 'https://schema.org/ReturnByMail', $methods );
+		$this->assertContains( 'https://schema.org/ReturnInStore', $methods );
+		$this->assertNotContains( 'https://schema.org/NotAValidMethod', $methods );
+	}
+
+	public function test_duplicate_methods_are_deduped_at_emission(): void {
+		// A tampered or imported settings value could contain duplicate
+		// method entries. `array_unique()` at emission time must remove
+		// them so the JSON-LD doesn't emit repeated schema.org URLs.
+		$markup = [
+			'offers' => [
+				[
+					'@type' => 'Offer',
+				],
+			],
+		];
+
+		WC_AI_Storefront::$test_settings = [
+			'enabled'       => 'yes',
+			'return_policy' => [
+				'mode'    => 'returns_accepted',
+				'days'    => 30,
+				'fees'    => 'FreeReturn',
+				'methods' => [ 'ReturnByMail', 'ReturnByMail', 'ReturnInStore' ],
+			],
+		];
+
+		$product = $this->make_product();
+		$result  = $this->jsonld->enhance_product_data( $markup, $product );
+
+		$methods = $result['offers'][0]['hasMerchantReturnPolicy']['returnMethod'];
+		$this->assertIsArray( $methods );
+		$this->assertCount( 2, $methods, 'Duplicate methods must be deduped at emission.' );
+		$this->assertSame( array_unique( $methods ), $methods );
+	}
 }

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -811,4 +811,91 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertEquals( 'extension_value', $result['custom_field'] );
 	}
+
+	public function test_jsonld_product_filter_receives_safe_settings_subset(): void {
+		// M-4: the wc_ai_storefront_jsonld_product filter must pass a
+		// minimal settings subset — not the full settings array —
+		// so third-party callbacks cannot read security-sensitive fields
+		// like rate_limit_rpm, allowed_crawlers, or allow_unknown_ucp_agents.
+		// Pin the exact key set so a regression that passes the full
+		// array is caught immediately.
+		WC_AI_Storefront::$test_settings = [
+			'enabled'                => 'yes',
+			'product_selection_mode' => 'all',
+			'return_policy'          => [ 'mode' => 'unconfigured' ],
+			'rate_limit_rpm'         => 99,          // Must NOT reach the filter.
+			'allowed_crawlers'       => [ 'ChatGPT-User' ],  // Must NOT reach the filter.
+			'allow_unknown_ucp_agents' => 'yes',     // Must NOT reach the filter.
+		];
+
+		$captured_subset = null;
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $hook, $markup, $product, $subset ) use ( &$captured_subset ) {
+				if ( 'wc_ai_storefront_jsonld_product' === $hook ) {
+					$captured_subset = $subset;
+				}
+				return $markup;
+			}
+		);
+
+		$this->jsonld->enhance_product_data( [], $this->make_product() );
+
+		$this->assertIsArray( $captured_subset, 'Filter must fire and pass a settings subset.' );
+
+		// Keys that MUST be present.
+		$this->assertArrayHasKey( 'enabled', $captured_subset );
+		$this->assertArrayHasKey( 'product_selection_mode', $captured_subset );
+		$this->assertArrayHasKey( 'return_policy', $captured_subset );
+
+		// Security-sensitive keys that MUST NOT be present.
+		$this->assertArrayNotHasKey( 'rate_limit_rpm', $captured_subset );
+		$this->assertArrayNotHasKey( 'allowed_crawlers', $captured_subset );
+		$this->assertArrayNotHasKey( 'allow_unknown_ucp_agents', $captured_subset );
+		$this->assertArrayNotHasKey( 'selected_products', $captured_subset );
+	}
+
+	public function test_jsonld_store_filter_receives_safe_settings_subset(): void {
+		// Mirror of the above for the wc_ai_storefront_jsonld_store filter.
+		WC_AI_Storefront::$test_settings = [
+			'enabled'                => 'yes',
+			'product_selection_mode' => 'all',
+			'return_policy'          => [ 'mode' => 'unconfigured' ],
+			'rate_limit_rpm'         => 99,
+			'allowed_crawlers'       => [ 'ChatGPT-User' ],
+			'allow_unknown_ucp_agents' => 'yes',
+		];
+
+		$captured_subset = null;
+		Functions\when( 'is_front_page' )->justReturn( true );
+		Functions\when( 'is_shop' )->justReturn( false );
+		Functions\when( 'home_url' )->alias( static fn( $p = '' ) => 'https://example.com' . $p );
+		Functions\when( 'get_bloginfo' )->returnArg();
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		Functions\when( 'get_terms' )->justReturn( [] );
+		Functions\when( 'wp_json_encode' )->alias( 'json_encode' );
+		Functions\when( '__' )->returnArg( 1 );
+		Functions\when( 'apply_filters' )->alias(
+			static function ( string $tag, $value, ...$rest ) use ( &$captured_subset ) {
+				if ( 'wc_ai_storefront_jsonld_store' === $tag ) {
+					$captured_subset = $rest[0] ?? null;
+				}
+				return $value;
+			}
+		);
+
+		ob_start();
+		try {
+			$this->jsonld->output_store_jsonld();
+		} finally {
+			ob_end_clean();
+		}
+
+		$this->assertIsArray( $captured_subset, 'Store filter must fire and pass a settings subset.' );
+		$this->assertArrayHasKey( 'enabled', $captured_subset );
+		$this->assertArrayHasKey( 'product_selection_mode', $captured_subset );
+		$this->assertArrayHasKey( 'return_policy', $captured_subset );
+		$this->assertArrayNotHasKey( 'rate_limit_rpm', $captured_subset );
+		$this->assertArrayNotHasKey( 'allowed_crawlers', $captured_subset );
+		$this->assertArrayNotHasKey( 'allow_unknown_ucp_agents', $captured_subset );
+	}
 }

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -1062,6 +1062,44 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringNotContainsString( '/news-sitemap.xml', $output );
 	}
 
+	public function test_sitemap_probe_uses_sslverify_true_by_default(): void {
+		// L-2: sitemap HEAD probes must use sslverify => true in
+		// production (i.e. when WP_DEBUG is not true). Pin this so a
+		// future change that re-introduces unconditional sslverify=false
+		// is caught. WP_DEBUG is a compile-time constant that can't be
+		// redefined at test time, so we capture the args passed to
+		// wp_remote_head and assert on the sslverify value.
+		//
+		// In the test environment WP_DEBUG is undefined or false, so
+		// the expression `! ( defined('WP_DEBUG') && WP_DEBUG )` must
+		// resolve to true. We confirm the captured arg matches.
+		$captured_args = null;
+		Functions\when( 'wp_remote_head' )->alias(
+			static function ( string $url, array $args ) use ( &$captured_args ): array {
+				$captured_args = $args;
+				// Return a 200 so the probe succeeds and the llms.txt
+				// output includes a sitemap section we can assert on.
+				return [ 'response' => [ 'code' => 200 ] ];
+			}
+		);
+		Functions\when( 'wp_remote_retrieve_response_code' )->alias(
+			static fn( $response ) => (int) $response['response']['code']
+		);
+
+		$this->llms->generate();
+
+		$this->assertIsArray( $captured_args, 'wp_remote_head must have been called.' );
+
+		// In this test environment WP_DEBUG is not true, so sslverify
+		// must be true. This is the production-path assertion.
+		$expected_sslverify = ! ( defined( 'WP_DEBUG' ) && WP_DEBUG );
+		$this->assertSame(
+			$expected_sslverify,
+			$captured_args['sslverify'],
+			'sslverify must be true in production (WP_DEBUG off) and false only when WP_DEBUG is on.'
+		);
+	}
+
 	// ------------------------------------------------------------------
 	// UCP extension docs
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpCheckoutSessionsTest.php
+++ b/tests/php/unit/UcpCheckoutSessionsTest.php
@@ -1015,6 +1015,79 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
+	public function test_meta_source_over_253_chars_falls_back_to_sentinel(): void {
+		// Values longer than 253 characters (RFC 1035 FQDN max) are
+		// rejected at the charset/length gate in `resolve_agent_host()`
+		// and fall through to Path 4 (FALLBACK_SOURCE). This pins the
+		// length cap so a future refactor that raises or removes it
+		// doesn't silently start storing oversized strings in order meta.
+		$this->seed_simple_product( 1 );
+
+		$result = $this->call_handler(
+			[
+				'line_items' => [ [ 'item' => [ 'id' => 'prod_1' ], 'quantity' => 1 ] ],
+				'meta'       => [ 'source' => str_repeat( 'a', 254 ) ],
+			]
+		);
+
+		$this->assertStringContainsString(
+			'utm_source=' . WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE,
+			$result['data']['continue_url'],
+			'meta.source value exceeding 253 chars must fall through to FALLBACK_SOURCE.'
+		);
+		// No raw_host param for rejected values (same contract as
+		// whitespace-only / non-string paths).
+		$this->assertStringNotContainsString( 'ai_agent_host_raw=', $result['data']['continue_url'] );
+	}
+
+	public function test_meta_source_invalid_charset_falls_back_to_sentinel(): void {
+		// Values containing characters outside [A-Za-z0-9._-] (e.g.
+		// angle brackets, spaces, percent signs) fail the charset gate
+		// and fall through to Path 4. Pins the validation so a future
+		// regex change that accidentally widens the allowed set doesn't
+		// start storing attacker-controlled strings in order meta.
+		$this->seed_simple_product( 1 );
+
+		foreach ( [ '<script>', 'agent name', 'agent%2Fsource', 'agent/source' ] as $bad_source ) {
+			$result = $this->call_handler(
+				[
+					'line_items' => [ [ 'item' => [ 'id' => 'prod_1' ], 'quantity' => 1 ] ],
+					'meta'       => [ 'source' => $bad_source ],
+				]
+			);
+
+			$this->assertStringContainsString(
+				'utm_source=' . WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE,
+				$result['data']['continue_url'],
+				"meta.source value '{$bad_source}' contains disallowed characters and must fall through to FALLBACK_SOURCE."
+			);
+			$this->assertStringNotContainsString( 'ai_agent_host_raw=', $result['data']['continue_url'] );
+		}
+	}
+
+	public function test_meta_source_with_underscore_is_accepted(): void {
+		// Underscores are valid in product-name tokens (Path 2 accepts
+		// them via `extract_agent_product()`). The body fallback path
+		// (Path 3) must be equally permissive — a token like
+		// `my_agent` must not be silently rejected.
+		$this->seed_simple_product( 1 );
+
+		$result = $this->call_handler(
+			[
+				'line_items' => [ [ 'item' => [ 'id' => 'prod_1' ], 'quantity' => 1 ] ],
+				'meta'       => [ 'source' => 'my_agent' ],
+			]
+		);
+
+		// Should NOT fall back to FALLBACK_SOURCE — the token is valid.
+		$this->assertStringNotContainsString(
+			'utm_source=' . WC_AI_Storefront_UCP_Agent_Header::FALLBACK_SOURCE,
+			$result['data']['continue_url'],
+			'Underscore tokens must be accepted by the meta.source charset gate.'
+		);
+		$this->assertStringContainsString( 'ai_agent_host_raw=my_agent', $result['data']['continue_url'] );
+	}
+
 	public function test_malformed_ucp_agent_falls_back_to_sentinel_utm_source(): void {
 		// Header present but malformed (no profile= value). Treat as missing.
 		$this->seed_simple_product( 1 );


### PR DESCRIPTION
## Summary

- **H-2** (`allow_unknown_ucp_agents` dropped on save): add the field to the settings controller allow-list
- **H-1** (return policy schema.org injection): validate `returnFees` / `returnMethod` values against allow-lists at emission time, not only at save time
- **M-3** (`meta.source` body field unvalidated): cap at 253 chars and restrict to hostname-safe charset, matching the UCP-Agent header path
- **M-4** (JSON-LD filters expose full settings array): pass a minimal subset (enabled, product_selection_mode, return_policy) to third-party filter callbacks
- **L-2** (`sslverify` unconditionally false): enable SSL verification in production; disable only when `WP_DEBUG` is on

Closes #141
Closes #142
Closes #143
Closes #144
Closes #145

## Test plan

- [ ] All 944 existing unit tests pass (run `composer test`)
- [ ] Verify `allow_unknown_ucp_agents` toggle saves correctly from the admin UI
- [ ] Verify a crafted `meta.source` value longer than 253 chars or containing `<`, `>`, `%` falls through to Path 4 (empty agent)
- [ ] Verify `returnFees` / `returnMethod` with an unknown value defaults to FreeReturn / empty methods in the JSON-LD output
- [ ] Verify `sslverify` is true in a production context (WP_DEBUG not defined or false)

🤖 Generated with [Claude Code](https://claude.com/claude-code)