### PR TITLE
docs: baseline update for 0.6.6 — sync docs with merged code

### DIFF
--- a/docs/engineering/API-REFERENCE.md
+++ b/docs/engineering/API-REFERENCE.md
@@ -85,7 +85,7 @@ The product `url` carries the canonical 0.5.0+ UTM payload (`utm_source=<hostnam
 **Errors:**
 - `503` `ucp_disabled` — syndication paused.
 - `400` `ucp_invalid_request` — body fails JSON Schema validation.
-- `429` — Store API rate limit exceeded for the user-agent.
+- `429` `ucp_rate_limit_exceeded` — outer-UCP-request rate limit exceeded. One slot is consumed per outer request (not per inner Store API call). The limit is the merchant's `rate_limit_rpm` setting; window is 60 seconds. Response includes `retry_after: 60`.
 
 **Curl:**
 
@@ -141,7 +141,7 @@ Validate a cart and return a redirect URL to WooCommerce's native Shareable Chec
 
 | Field | Type | Required | Description |
 |-------|------|----------|-------------|
-| `items` | array | yes | `variant_id` (string), `quantity` (int >=1). Max 100 items. |
+| `items` | array | yes | `variant_id` (string), `quantity` (int >=1). Max 100 items. Duplicate entries targeting the same product ID are collapsed before validation — quantities are summed, and the response echoes one line per product. A `merged_duplicate_items` info message is included when collapsing occurs so agents can reconcile their sent payload. |
 | `shipping_address` | object | no | UCP address block. Used for shipping/tax preview. |
 | `context` | object | no | UCP context block (currency, locale). |
 

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -107,7 +107,7 @@ Agent name is surfaced in WC core's "Origin" column (fed by `_wc_order_attributi
 
 | File | Purpose |
 |------|---------|
-| `class-wc-ai-storefront-store-api-rate-limiter.php` | Enables WC Store API rate limiting for AI bot traffic via the `woocommerce_store_api_rate_limit_options` and `woocommerce_store_api_rate_limit_id` filters. Fingerprints by user-agent matched against the robots.txt crawler list. Regular customer traffic is unaffected. UCP REST traffic inherits because the controller dispatches via `rest_do_request()`. |
+| `class-wc-ai-storefront-store-api-rate-limiter.php` | Two-layer rate limiting for AI bot traffic. (1) **Outer layer:** `check_outer_rate_limit()` is called by `check_agent_access()` and counts exactly one slot per logical outer UCP request (e.g. one `/catalog/lookup` with 50 IDs = 1 slot). Uses a per-fingerprint WP transient with a 60-second sliding window. (2) **Inner layer suppression:** `configure_rate_limits()` returns `enabled: false` when `WC_AI_Storefront_UCP_Store_API_Filter::is_in_ucp_dispatch()` is true, so WC's built-in per-Store-API-call counter is disabled for inner `rest_do_request()` dispatches. Fingerprints AI bots by user-agent via `woocommerce_store_api_rate_limit_id`. Regular customer traffic is unaffected; direct `/wc/store/v1/` requests from AI bot UAs outside the UCP bracket remain subject to WC's default counter. The merchant's `rate_limit_rpm` setting reflects outer-request semantics. |
 
 ### Cache invalidation
 
@@ -232,13 +232,13 @@ woocommerce-ai-storefront/
 
 4. **Standard WooCommerce attribution.** Uses the built-in Order Attribution system. The UCP REST adapter auto-stamps `utm_source=<agent hostname>&utm_medium=referral&utm_id=woo_ucp` on every continue_url AND on every product `url` field returned by `/catalog/search` and `/catalog/lookup`, so merchants see agent-sourced traffic regardless of which URL the buyer follows.
 
-5. **Store API rate limiting.** Uses WC's built-in `woocommerce_store_api_rate_limit_options` and `_id` filters. AI bots fingerprinted by user-agent; regular customer traffic unaffected. UCP REST traffic inherits limits because the controller dispatches via `rest_do_request()`.
+5. **Store API rate limiting.** Two-layer design: (a) one slot consumed per outer UCP request via a transient-backed counter in `check_outer_rate_limit()`; (b) WC's per-Store-API-call counter suppressed for inner `rest_do_request()` dispatches inside the UCP bracket. AI bots fingerprinted by user-agent; regular customer traffic unaffected. The merchant's `rate_limit_rpm` setting reflects outer-request semantics — 1 outer UCP call = 1 slot regardless of how many inner Store API calls it fans out to.
 
 6. **Product selection enforced at every layer.** The `product_selection_mode` setting applies to llms.txt, JSON-LD, robots.txt, AND Store API query results dispatched through the UCP controller — enforced via a `pre_get_posts` action gated on UCP dispatch depth + `post_type === 'product'`. A product excluded from syndication won't appear in UCP-mediated responses; direct Store API access (front-end Cart, themes, third-party plugins) is intentionally NOT scoped because Store API doesn't conform to UCP and merchants have legitimate non-AI consumers of it.
 
 7. **Pure translators, caller-orchestrated dispatch.** Product and variant translators are pure functions — they transform data shape, never dispatch. The REST controller orchestrates fetching (detect variable products, pre-fetch variations, assemble) before handing data to translators. Keeps translators hermetically testable without stubbing WP's REST pipeline.
 
-8. **Cache invalidation.** llms.txt and UCP manifest use transient caching with event-driven invalidation. Version-based cache bust on plugin updates. UCP REST responses are not cached — every dispatch computes fresh because per-request attribution and session IDs vary.
+8. **Cache invalidation.** llms.txt uses a host-keyed transient (`CACHE_KEY + '_' + md5(HTTP_HOST)`) with event-driven invalidation and a `Vary: Host` response header so CDN/proxy and PHP-layer caches stay in sync across virtual-host boundaries. The UCP manifest is now **generated per-request** (cheap — no HTTP probes, no unbounded queries); `Vary: Host` handles HTTP-layer caching. UCP REST responses are not cached — every dispatch computes fresh because per-request attribution and session IDs vary.
 
 9. **No MCP (Model Context Protocol) support, intentionally.** MCP requires a server surface reachable by external, non-admin clients — neither WordPress core nor WooCommerce scaffold one. AI Storefront targets UCP, which works with the public HTTP/REST surfaces WP/WC already expose. MCP support will be evaluated if WP or WC grow native MCP-server primitives.
 

--- a/docs/engineering/DATA-MODEL.md
+++ b/docs/engineering/DATA-MODEL.md
@@ -19,8 +19,8 @@ wp_options ──── triggers ────► WC_AI_Storefront_Cache_Invalida
                                          │
                                          │  delete_transient(...)
                                          ▼
-                                    wc_ai_storefront_llms_txt
-                                    wc_ai_storefront_ucp
+                                    wc_ai_storefront_llms_txt_{md5(host)}
+                                    (wc_ai_storefront_ucp — no-op, manifest is per-request)
                                          │
                                          │  schedule cron
                                          ▼
@@ -32,7 +32,7 @@ AI agent fetches /llms.txt
     ▼
 WC_AI_Storefront_Llms_Txt::serve_llms_txt()
     │
-    │  get_transient('wc_ai_storefront_llms_txt')
+    │  get_transient(host_cache_key())  ← 'wc_ai_storefront_llms_txt_{md5(HTTP_HOST)}'
     ▼
 HIT → return cached
 MISS → regenerate, set_transient, return
@@ -121,25 +121,24 @@ The version check runs in the rewrite path (not the activation hook) because Wor
 
 ## Transients (wp_options or persistent object cache)
 
-### `wc_ai_storefront_llms_txt`
+### `wc_ai_storefront_llms_txt` (and host-keyed variant)
 
 Cached `/llms.txt` Markdown body. Avoids regenerating on every crawler hit.
 
 - **TTL:** 1 hour (`HOUR_IN_SECONDS`)
-- **Defined in:** `WC_AI_Storefront_Llms_Txt::CACHE_KEY`
+- **Base key defined in:** `WC_AI_Storefront_Llms_Txt::CACHE_KEY`
+- **Actual storage key:** `CACHE_KEY . '_' . md5(HTTP_HOST)` — per-virtual-host segmentation so two WordPress instances sharing a Redis/Memcached object cache (e.g. multisite) never serve each other's cached bodies. The base constant is kept for backward-compat; all read/write calls use `WC_AI_Storefront_Llms_Txt::host_cache_key()`.
 - **Written by:** `serve_llms_txt()` after generating; eagerly written on settings save when `enabled` flips on
 - **Invalidated by:** `WC_AI_Storefront_Cache_Invalidator` on product/category/settings changes
 - **Uninstall:** deleted by `uninstall.php`
 
 ### `wc_ai_storefront_ucp`
 
-Cached `/.well-known/ucp` JSON manifest body.
+Constant (`WC_AI_Storefront_Ucp::CACHE_KEY`) retained for backward compatibility — referenced by the cache invalidator and any third-party code that reads it. The UCP manifest is now **generated per-request** rather than cached: the generation path is cheap (no external HTTP probes, no unbounded DB queries) and per-request computation eliminates the Host-keying problem entirely. The transient is **never written** by the current code; the `Vary: Host` response header handles HTTP-layer caching separately.
 
-- **TTL:** 1 hour
-- **Defined in:** `WC_AI_Storefront_Ucp::CACHE_KEY`
-- **Written by:** `serve_manifest()`; eagerly written on settings save when `enabled` flips on
-- **Invalidated by:** `WC_AI_Storefront_Cache_Invalidator` on product/category/settings changes; version-based bust on plugin update
-- **Uninstall:** deleted by `uninstall.php`
+- **Previously:** cached `/.well-known/ucp` JSON body with 1-hour TTL.
+- **Currently:** not used. `delete_transient( CACHE_KEY )` calls in the cache invalidator are harmless no-ops.
+- **Uninstall:** `uninstall.php` still deletes it (defensive, covers any stale value from a pre-0.6.6 install).
 
 ### `wc_ai_storefront_flush_rewrite`
 

--- a/docs/engineering/HOOKS.md
+++ b/docs/engineering/HOOKS.md
@@ -2,7 +2,7 @@
 
 Filters and actions exposed by WooCommerce AI Storefront for extending plugins.
 
-The plugin exposes a deliberately small surface — seven filters and one action. Each was chosen because it intercepts a specific extension point that's hard or impossible to reach from outside (e.g. the merchant's `/llms.txt` content, the UCP manifest body, the JSON-LD product markup). Where WP/WC core filters already exist for the same surface, we don't duplicate them.
+The plugin exposes a deliberately small surface — seven filters and two actions. Each was chosen because it intercepts a specific extension point that's hard or impossible to reach from outside (e.g. the merchant's `/llms.txt` content, the UCP manifest body, the JSON-LD product markup). Where WP/WC core filters already exist for the same surface, we don't duplicate them.
 
 ## Filters
 
@@ -18,7 +18,7 @@ apply_filters( 'wc_ai_storefront_jsonld_product', array $markup, WC_Product $pro
 |-------|------|-------------|
 | `$markup` | `array` | The Schema.org `Product` structure with our enhancements (BuyAction, inventory, attributes, return policy). |
 | `$product` | `WC_Product` | The product being rendered. |
-| `$settings` | `array` | The plugin's resolved settings (see [`DATA-MODEL.md`](DATA-MODEL.md)). |
+| `$settings` | `array` | A minimal 3-key subset of the plugin's settings: `enabled`, `product_selection_mode`, `return_policy`. Security-sensitive fields (`rate_limit_rpm`, `allowed_crawlers`, `allow_unknown_ucp_agents`, per-product selection arrays) are intentionally excluded. |
 
 **Returns:** the (possibly modified) `array` to encode and emit.
 
@@ -47,7 +47,7 @@ apply_filters( 'wc_ai_storefront_jsonld_store', array $store_data, array $settin
 | Param | Type | Description |
 |-------|------|-------------|
 | `$store_data` | `array` | The Schema.org `OnlineStore` structure (name, url, sameAs, etc.). |
-| `$settings` | `array` | The plugin's resolved settings. |
+| `$settings` | `array` | A minimal 3-key subset of the plugin's settings: `enabled`, `product_selection_mode`, `return_policy`. Security-sensitive fields are intentionally excluded (same subset as `wc_ai_storefront_jsonld_product`). |
 
 **Returns:** modified `array`.
 
@@ -194,6 +194,30 @@ add_action( 'wc_ai_storefront_attribution_captured', function( $order, $agent, $
 ```
 
 > **Don't** rely on `$canonical_agent` to switch business logic by gate — the rule is path-independent. A STRICT-gate capture whose `utm_source` happens to be a known hostname gets canonicalized to the brand name same as a LENIENT-gate capture would. Listeners that need the raw host should read `_wc_ai_storefront_agent_host_raw` from the order directly.
+
+### `wc_ai_storefront_ucp_access_denied`
+
+Fires whenever a UCP REST request is rejected by the agent-access gate.
+
+```php
+do_action( 'wc_ai_storefront_ucp_access_denied', string $raw_id, string $reason, WP_REST_Request $request );
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `$raw_id` | `string` | The raw agent identifier extracted from the `UCP-Agent` header (hostname for profile-URL form, lowercased product token for Product/Version form). Empty string when no header was present. |
+| `$reason` | `string` | Why access was denied: `'unknown_agent'` (host not recognized and `allow_unknown_ucp_agents=no`) or `'brand_blocked'` (agent's brand is absent from the merchant's `allowed_crawlers` list). |
+| `$request` | `WP_REST_Request` | The denied request, for listeners that need route or header data. |
+
+**When to use:** security plugins and analytics pipelines that need to track gate denials without polling logs. Fires on every 403 from the `check_agent_access()` permission callback, regardless of denial reason — subscribe once to cover both the unknown-agent and brand-blocked paths.
+
+**Example — record denied agents to a custom audit log:**
+
+```php
+add_action( 'wc_ai_storefront_ucp_access_denied', function( $raw_id, $reason, $request ) {
+    error_log( sprintf( '[audit] UCP access denied — reason=%s raw_id=%s route=%s', $reason, $raw_id, $request->get_route() ) );
+}, 10, 3 );
+```
 
 ## Hooks we consume (not exposed)
 

--- a/docs/user-guide/USER-GUIDE.md
+++ b/docs/user-guide/USER-GUIDE.md
@@ -147,7 +147,7 @@ Unchecking adds a `Disallow:` directive for that user-agent. This is a cooperati
 
 ### Rate limit
 
-Controls requests per minute the Store API accepts from each AI crawler before serving HTTP 429.
+Controls how many AI commerce requests per minute each AI crawler can make before receiving HTTP 429. One request counts as one slot regardless of how many products are in the request (a catalog lookup for 50 products counts the same as a lookup for 1).
 
 - **Default:** 25 RPM per crawler. Balanced for catalogs of any size.
 - **Lower** (down to 1 RPM) if you've seen spikes on a small hosting plan.


### PR DESCRIPTION
Auto follow-up to the 0.6.6 release cycle. The `docs-followup` workflow had the wrong action reference (`anthropic/` instead of `anthropics/`) and fired zero times across all 0.6.6 PRs. This PR manually applies the updates those runs should have made.

## Changes

| Doc | Change | Driven by |
|-----|--------|-----------|
| `docs/engineering/HOOKS.md` | `wc_ai_storefront_jsonld_product` and `wc_ai_storefront_jsonld_store` filter `$settings` param description updated: the full settings array is no longer passed; only a 3-key subset (`enabled`, `product_selection_mode`, `return_policy`) is passed. Filter callbacks that read removed keys will silently receive `null`. | PR #144 |
| `docs/engineering/HOOKS.md` | Added missing `wc_ai_storefront_ucp_access_denied` action (fires on every UCP 403 — both unknown-agent and brand-blocked paths). Hook count in intro updated from "one action" to "two actions". | PR #131 |
| `docs/engineering/ARCHITECTURE.md` | Rate limiting section and design decision #5 updated to describe the new two-layer design: outer UCP requests counted via `check_outer_rate_limit()` (1 slot per outer request regardless of inner fan-out); inner `rest_do_request()` dispatches suppressed from WC's built-in counter. Old description said UCP traffic "inherits because the controller dispatches via `rest_do_request()`" — that was the behavior that caused single large lookups to drain all slots. | PR #137 |
| `docs/engineering/ARCHITECTURE.md` | Cache invalidation design decision #8 updated: UCP manifest is now generated per-request (not cached in a transient); `llms.txt` transient is now host-keyed. | PR #134 |
| `docs/engineering/DATA-MODEL.md` | `wc_ai_storefront_llms_txt` transient: documents the host-specific key (`CACHE_KEY + '_' + md5(HTTP_HOST)`) and `host_cache_key()` method. Data flow diagram updated to show host-specific key. | PR #134 |
| `docs/engineering/DATA-MODEL.md` | `wc_ai_storefront_ucp` transient: documents that the manifest is now generated per-request and the transient is no longer written. The constant and `uninstall.php` delete are retained for backward compatibility. | PR #134 |
| `docs/engineering/API-REFERENCE.md` | `POST /checkout-sessions` `items[]` field: documents duplicate line item collapsing (quantities summed, one line per product in response, `merged_duplicate_items` info message on collapse). | PR #133 |
| `docs/engineering/API-REFERENCE.md` | `/catalog/search` 429 error: updated from "Store API rate limit exceeded" to `ucp_rate_limit_exceeded` with outer-request semantics description. | PR #137 |
| `docs/user-guide/USER-GUIDE.md` | Rate limit section: "Controls requests per minute the Store API accepts" replaced with accurate description of outer-request semantics (1 request = 1 slot regardless of how many products are in the lookup). | PR #137 |

## What was NOT changed

- `CART-MODELS.md` and `UCP-BUY-FLOW.md`: the 0.6.6 changes do not alter the models or buy-flow sequence described in those docs.
- `DATA-MODEL.md` attribution STRICT gate note: the code comment describes the change (reads only stored order meta, not `$_GET` at creation time) but the DATA-MODEL.md flow diagram only shows the attribution capture path generically — no per-gate detail to update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)