### PR TITLE
fix(ucp): reject malformed product IDs, replace JSON round-trip with recursive cast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Fixed
+
+- **`parse_ucp_id_to_wc_int()` now rejects malformed IDs with trailing non-digit characters.** Pre-fix, the `(int)` cast silently truncated `prod_123abc` to `123`, potentially resolving a spoofed or corrupted ID to a real product. A `ctype_digit()` guard now rejects any suffix that contains non-decimal characters, returning 0 (not-found) instead. The known `_default` suffix on synthesized default-variant IDs (e.g. `var_123_default`) is stripped before the check so legitimate round-trips continue to work. Closes #154.
+- **`normalize_store_api_data()` now uses a recursive cast instead of a JSON round-trip.** Pre-fix, the method encoded the Store API response to JSON then decoded it, allocating a large intermediate string for no semantic benefit. Replaced with an O(N) recursive closure that casts `stdClass` objects to arrays in place. Output is identical; allocations are lower on large product payloads. Closes #171.
+
 ---
 
 ## [0.6.6] – 2026-04-28

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -2276,13 +2276,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * Parse a UCP ID string (`prod_N`, `var_N`, `var_N_default`) into
 	 * the underlying WC post/variation ID.
 	 *
-	 * The prefix strip + `(int)` cast is deliberately lenient: PHP's
-	 * int cast truncates at the first non-numeric character, so
-	 * `var_123_default` → `123` cleanly, and malformed input like
-	 * `"abc"` or `"prod_"` → 0 (which the caller treats as not-found).
+	 * After stripping the known prefix and the `_default` suffix, the
+	 * remaining string must consist entirely of decimal digits (`ctype_digit`).
+	 * Malformed suffixes like `123abc` return 0 (not-found) instead of
+	 * silently truncating to 123. Pure decimal suffixes like `prod_123`
+	 * and `var_456` are unaffected.
 	 *
-	 * Non-string input returns 0 too, so callers don't have to type-
-	 * check before calling.
+	 * Non-string input and an empty post-strip string both return 0 too,
+	 * so callers don't have to type-check before calling.
 	 *
 	 * @param mixed $raw_id
 	 */

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -2303,6 +2303,23 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		);
 
 		$stripped = preg_replace( $prefix_re, '', $raw_id );
+
+		// Strip the optional `_default` suffix that the variant translator
+		// appends to synthesized default-variant IDs (e.g. `var_123_default`
+		// is a valid UCP ID for WC product 123). The suffix is the only
+		// non-digit trailer that is part of the legitimate ID format.
+		$default_suffix = WC_AI_Storefront_UCP_Variant_Translator::DEFAULT_VARIANT_SUFFIX;
+		if ( str_ends_with( $stripped, $default_suffix ) ) {
+			$stripped = substr( $stripped, 0, -strlen( $default_suffix ) );
+		}
+
+		// Reject strings like '123abc' that would otherwise cast to 123.
+		// After removing the known `_default` suffix, a valid UCP
+		// product/variant ID suffix is always a plain decimal integer.
+		// Anything else indicates a malformed or spoofed ID.
+		if ( '' === $stripped || ! ctype_digit( $stripped ) ) {
+			return 0;
+		}
 		return (int) $stripped;
 	}
 
@@ -2507,12 +2524,22 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		if ( ! is_array( $data ) && ! is_object( $data ) ) {
 			return null;
 		}
-		$json = wp_json_encode( $data );
-		if ( false === $json ) {
-			return null;
-		}
-		$decoded = json_decode( $json, true );
-		return is_array( $decoded ) ? $decoded : null;
+		// Recursively cast all stdClass objects to arrays. The WC Store API's
+		// internal REST dispatcher returns stdClass for nested structures; the
+		// UCP translator expects plain array access. Previously this used a
+		// JSON round-trip (encode + decode) which allocated a large string
+		// for no benefit. The recursive cast is O(N) with no string allocation.
+		$cast   = static function ( $value ) use ( &$cast ) {
+			if ( is_object( $value ) ) {
+				$value = (array) $value;
+			}
+			if ( is_array( $value ) ) {
+				return array_map( $cast, $value );
+			}
+			return $value;
+		};
+		$result = $cast( $data );
+		return is_array( $result ) ? $result : null;
 	}
 
 	/**

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T00:51:31+00:00\n"
+"POT-Creation-Date: 2026-04-29T01:33:14+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -180,118 +180,118 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2770
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2797
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2841
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2868
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2872
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2899
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2892
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2919
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2917
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2944
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2950
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2977
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2986
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3013
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3017
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3044
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3089
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3116
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3140
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3167
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3170
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3197
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3260
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3287
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3499
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3526
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3534
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3561
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4085
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4112
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4312
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4339
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4316
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4343
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4320
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4347
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4322
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4349
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4324
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4351
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4328
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4355
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4330
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4357
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T01:33:14+00:00\n"
+"POT-Creation-Date: 2026-04-29T02:08:22+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -180,118 +180,118 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2797
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2798
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2868
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2869
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2899
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2900
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2919
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2920
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2944
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2945
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2977
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2978
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3013
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3014
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3044
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3045
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3116
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3117
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3167
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3168
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3197
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3198
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3287
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3288
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3526
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3527
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3561
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3562
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4112
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4113
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4339
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4340
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4343
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4344
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4347
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4348
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4349
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4350
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4351
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4352
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4355
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4356
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4357
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4358
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/UcpRestControllerTest.php
+++ b/tests/php/unit/UcpRestControllerTest.php
@@ -494,4 +494,151 @@ class UcpRestControllerTest extends \PHPUnit\Framework\TestCase {
 	// UcpCatalogLookupTest, and UcpCheckoutSessionsTest respectively.
 	// This file retains only the route-registration contract tests +
 	// the extension-schema handler tests.
+
+	// ------------------------------------------------------------------
+	// parse_ucp_id_to_wc_int — regression tests for #154
+	// ------------------------------------------------------------------
+
+	/**
+	 * Helper to invoke the private static parse_ucp_id_to_wc_int() method
+	 * via reflection, matching the pattern used for format_signal_keys_for_log.
+	 *
+	 * @param mixed $raw_id
+	 */
+	private function parse_ucp_id( $raw_id ): int {
+		$reflection = new \ReflectionClass( WC_AI_Storefront_UCP_REST_Controller::class );
+		$method     = $reflection->getMethod( 'parse_ucp_id_to_wc_int' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $raw_id );
+	}
+
+	public function test_parse_ucp_id_valid_prod_prefix_returns_int(): void {
+		// Happy path: prod_123 should yield 123.
+		$this->assertSame( 123, $this->parse_ucp_id( 'prod_123' ) );
+	}
+
+	public function test_parse_ucp_id_valid_var_prefix_returns_int(): void {
+		// Happy path: var_456 should yield 456.
+		$this->assertSame( 456, $this->parse_ucp_id( 'var_456' ) );
+	}
+
+	public function test_parse_ucp_id_malformed_trailing_alpha_returns_zero(): void {
+		// Regression for #154: before the fix, (int)'123abc' = 123, silently
+		// resolving a garbage ID to a real product. Now returns 0.
+		$this->assertSame( 0, $this->parse_ucp_id( 'prod_123abc' ) );
+	}
+
+	public function test_parse_ucp_id_malformed_var_trailing_alpha_returns_zero(): void {
+		// Same regression guard for the var_ prefix.
+		$this->assertSame( 0, $this->parse_ucp_id( 'var_456xyz' ) );
+	}
+
+	public function test_parse_ucp_id_non_string_returns_zero(): void {
+		// Non-string input should return 0.
+		$this->assertSame( 0, $this->parse_ucp_id( 42 ) );
+		$this->assertSame( 0, $this->parse_ucp_id( null ) );
+		$this->assertSame( 0, $this->parse_ucp_id( array() ) );
+	}
+
+	public function test_parse_ucp_id_empty_string_returns_zero(): void {
+		// Empty string has no prefix and no digit suffix.
+		$this->assertSame( 0, $this->parse_ucp_id( '' ) );
+	}
+
+	public function test_parse_ucp_id_prefix_only_returns_zero(): void {
+		// 'prod_' after stripping the prefix leaves '', which is not a
+		// valid integer — must return 0 rather than (int)'' = 0 via
+		// the old cast path (coincidentally the same, but now explicit).
+		$this->assertSame( 0, $this->parse_ucp_id( 'prod_' ) );
+	}
+
+	public function test_parse_ucp_id_default_suffix_variant_returns_parent_int(): void {
+		// var_123_default is the synthesized default-variant ID emitted
+		// by the variant translator. It must resolve to WC product 123
+		// so catalog/lookup can round-trip it correctly.
+		$this->assertSame( 123, $this->parse_ucp_id( 'var_123_default' ) );
+	}
+
+	public function test_parse_ucp_id_bare_numeric_string_returns_int(): void {
+		// Bare numeric strings without a prefix are accepted (lenient v1
+		// behavior): the prefix regex is a no-op for '123', leaving the
+		// full string for ctype_digit() to pass through.
+		$this->assertSame( 123, $this->parse_ucp_id( '123' ) );
+	}
+
+	// ------------------------------------------------------------------
+	// normalize_store_api_data — regression tests for #171
+	// ------------------------------------------------------------------
+
+	/**
+	 * Helper to invoke the private static normalize_store_api_data() method
+	 * via reflection.
+	 *
+	 * @param mixed $data
+	 * @return mixed
+	 */
+	private function normalize_store_api( $data ) {
+		$reflection = new \ReflectionClass( WC_AI_Storefront_UCP_REST_Controller::class );
+		$method     = $reflection->getMethod( 'normalize_store_api_data' );
+		$method->setAccessible( true );
+		return $method->invoke( null, $data );
+	}
+
+	public function test_normalize_store_api_data_converts_nested_stdclass_to_array(): void {
+		// Regression for #171: previously used a JSON round-trip; now uses
+		// a recursive cast. Both must produce identical output. This test
+		// pins the output contract so a future refactor that changes the
+		// mechanism can't silently alter the returned structure.
+		$inner        = new \stdClass();
+		$inner->price = '19.99';
+		$inner->name  = 'Widget';
+
+		$outer         = new \stdClass();
+		$outer->id     = 42;
+		$outer->nested = $inner;
+
+		$result = $this->normalize_store_api( $outer );
+
+		$this->assertIsArray( $result );
+		$this->assertSame( 42, $result['id'] );
+		$this->assertIsArray( $result['nested'] );
+		$this->assertSame( '19.99', $result['nested']['price'] );
+		$this->assertSame( 'Widget', $result['nested']['name'] );
+	}
+
+	public function test_normalize_store_api_data_plain_array_passthrough(): void {
+		// Arrays should be returned as-is (with their nested stdClass
+		// children also cast). A plain PHP array coming in must survive
+		// the function unchanged at the top level.
+		$data = array(
+			'id'   => 1,
+			'meta' => array( 'key' => 'value' ),
+		);
+
+		$result = $this->normalize_store_api( $data );
+
+		$this->assertSame( $data, $result );
+	}
+
+	public function test_normalize_store_api_data_scalar_returns_null(): void {
+		// Scalars are not array or object, so the function should return null.
+		$this->assertNull( $this->normalize_store_api( 'string' ) );
+		$this->assertNull( $this->normalize_store_api( 42 ) );
+		$this->assertNull( $this->normalize_store_api( null ) );
+	}
+
+	public function test_normalize_store_api_data_array_of_stdclass_items(): void {
+		// Arrays whose values are stdClass objects (e.g. a Store API
+		// products list) must have each item cast to an array.
+		$item        = new \stdClass();
+		$item->sku   = 'WIDGET-1';
+		$item->stock = 10;
+
+		$result = $this->normalize_store_api( array( $item ) );
+
+		$this->assertIsArray( $result );
+		$this->assertIsArray( $result[0] );
+		$this->assertSame( 'WIDGET-1', $result[0]['sku'] );
+		$this->assertSame( 10, $result[0]['stock'] );
+	}
 }


### PR DESCRIPTION
## Summary

- **#154 (MEDIUM):** `parse_ucp_id_to_wc_int()` now guards the stripped suffix with `ctype_digit()` before casting to int. Previously `prod_123abc` silently resolved to `123` via `(int)` truncation, potentially mapping a spoofed or corrupted ID to a real product. The known `_default` suffix on synthesized default-variant IDs (`var_123_default`) is stripped before the check so legitimate round-trips are unaffected.
- **#171 (LOW-MEDIUM):** `normalize_store_api_data()` replaces a JSON encode + decode round-trip with a recursive closure that casts `stdClass` objects to arrays in place. Output is identical; no large intermediate string is allocated. O(N) with no extra string allocations.

Regression tests added to `UcpRestControllerTest` for both fixes using `ReflectionClass` (matching the existing pattern for `format_signal_keys_for_log`). 13 new test methods, all green.

Closes #154
Closes #171

## Test plan

- [ ] `composer test` passes (967 tests, including 13 new regression tests)
- [ ] `vendor/bin/phpcs` passes with no errors or warnings in changed files
- [ ] `vendor/bin/phpstan analyse --memory-limit=1G` passes with no errors
- [ ] `./bin/make-pot.sh` completes without errors
- [ ] `prod_123abc` returns 0 (not 123) in the parse helper
- [ ] `var_123_default` still resolves to 123 (default-variant round-trip)
- [ ] `normalize_store_api_data` with nested stdClass returns equivalent nested array

🤖 Generated with [Claude Code](https://claude.com/claude-code)