### PR TITLE
perf(attribution): cache get_stats() result for 5 minutes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [Unreleased]
 
+### Performance
+
+- **`get_stats()` now caches its result in a transient for 5 minutes, keyed by period.** Pre-fix, every admin settings page load ran two `$wpdb` queries (one joining across orders and meta tables, one counting all-store orders) regardless of how recently the data had been computed. On stores with large order volumes the joins were visibly slow. Post-fix, the first call populates a `wc_ai_storefront_stats_{period}` transient; subsequent calls within the 5-minute window read directly from cache with zero DB queries. The cache is busted automatically on `woocommerce_order_status_completed` and `woocommerce_order_status_processing` events, so the dashboard reflects new order completions within one TTL cycle (at most 5 minutes). All four period transients are also deleted on plugin uninstall, including in multisite network uninstalls. Closes #160.
+
 ### Fixed
 
 - **`parse_ucp_id_to_wc_int()` now rejects malformed IDs with trailing non-digit characters.** Pre-fix, the `(int)` cast silently truncated `prod_123abc` to `123`, potentially resolving a spoofed or corrupted ID to a real product. A `ctype_digit()` guard now rejects any suffix that contains non-decimal characters, returning 0 (not-found) instead. The known `_default` suffix on synthesized default-variant IDs (e.g. `var_123_default`) is stripped before the check so legitimate round-trips continue to work. Closes #154.

--- a/includes/ai-storefront/class-wc-ai-storefront-attribution.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-attribution.php
@@ -291,10 +291,12 @@ class WC_AI_Storefront_Attribution {
 		// Display AI attribution data in admin order view.
 		add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'display_attribution_in_admin' ], 20, 1 );
 
-		// Bust stats transient cache when order status changes so the admin
-		// dashboard reflects new completions within one cache TTL cycle.
+		// Bust stats transient cache when order status changes or an order is
+		// removed so the admin dashboard stays accurate within one TTL cycle.
 		add_action( 'woocommerce_order_status_completed', array( __CLASS__, 'bust_stats_cache' ) );
 		add_action( 'woocommerce_order_status_processing', array( __CLASS__, 'bust_stats_cache' ) );
+		add_action( 'woocommerce_delete_order', array( __CLASS__, 'bust_stats_cache' ), 10, 0 );
+		add_action( 'woocommerce_trash_order', array( __CLASS__, 'bust_stats_cache' ), 10, 0 );
 	}
 
 	/**

--- a/includes/ai-storefront/class-wc-ai-storefront-attribution.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-attribution.php
@@ -290,6 +290,11 @@ class WC_AI_Storefront_Attribution {
 
 		// Display AI attribution data in admin order view.
 		add_action( 'woocommerce_admin_order_data_after_billing_address', [ $this, 'display_attribution_in_admin' ], 20, 1 );
+
+		// Bust stats transient cache when order status changes so the admin
+		// dashboard reflects new completions within one cache TTL cycle.
+		add_action( 'woocommerce_order_status_completed', array( __CLASS__, 'bust_stats_cache' ) );
+		add_action( 'woocommerce_order_status_processing', array( __CLASS__, 'bust_stats_cache' ) );
 	}
 
 	/**
@@ -662,6 +667,16 @@ class WC_AI_Storefront_Attribution {
 	 * @return array
 	 */
 	public static function get_stats( $period = 'month' ) {
+		// Normalize period first so the transient key is consistent.
+		$valid_periods = array( 'day', 'week', 'month', 'year' );
+		$period        = in_array( $period, $valid_periods, true ) ? $period : 'month';
+
+		$transient_key = 'wc_ai_storefront_stats_' . $period;
+		$cached        = get_transient( $transient_key );
+		if ( false !== $cached && is_array( $cached ) ) {
+			return $cached;
+		}
+
 		global $wpdb;
 
 		$date_map = [
@@ -671,7 +686,8 @@ class WC_AI_Storefront_Attribution {
 			'year'  => '1 year ago',
 		];
 
-		$after    = $date_map[ $period ] ?? $date_map['month'];
+		// $period is already validated to one of the four keys above.
+		$after    = $date_map[ $period ];
 		$after_ts = strtotime( $after );
 		if ( false === $after_ts ) {
 			$after_ts = strtotime( '1 month ago' );
@@ -796,7 +812,7 @@ class WC_AI_Storefront_Attribution {
 		// separator.
 		$currency_code = get_woocommerce_currency();
 
-		return [
+		$result_array = array(
 			'period'           => $period,
 			'ai_orders'        => $total_orders,
 			'ai_revenue'       => $total_revenue,
@@ -811,7 +827,20 @@ class WC_AI_Storefront_Attribution {
 				: '',
 			'by_agent'         => $by_agent,
 			'top_agent'        => $derived['top_agent'],
-		];
+		);
+
+		set_transient( $transient_key, $result_array, 5 * MINUTE_IN_SECONDS );
+		return $result_array;
+	}
+
+	/**
+	 * Invalidate all cached stats transients. Called when order attribution
+	 * data changes (e.g., after a new order is attributed or via admin reset).
+	 */
+	public static function bust_stats_cache(): void {
+		foreach ( array( 'day', 'week', 'month', 'year' ) as $period ) {
+			delete_transient( 'wc_ai_storefront_stats_' . $period );
+		}
 	}
 
 	/**

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T02:31:03+00:00\n"
+"POT-Creation-Date: 2026-04-29T02:31:07+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -53,19 +53,19 @@ msgstr ""
 msgid "Override the store-wide return policy for this product. AI agents will see \"no returns\" regardless of your store policy. Use for clearance items, custom orders, or any product whose return terms diverge from the store default."
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:644
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:646
 msgid "AI Agent Attribution"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:645
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:647
 msgid "Agent:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:653
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:655
 msgid "Agent host:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:657
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:659
 msgid "Session ID:"
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T02:27:34+00:00\n"
+"POT-Creation-Date: 2026-04-29T02:31:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -53,19 +53,19 @@ msgstr ""
 msgid "Override the store-wide return policy for this product. AI agents will see \"no returns\" regardless of your store policy. Use for clearance items, custom orders, or any product whose return terms diverge from the store default."
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:639
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:644
 msgid "AI Agent Attribution"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:640
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:645
 msgid "Agent:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:648
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:653
 msgid "Agent host:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:652
+#: includes/ai-storefront/class-wc-ai-storefront-attribution.php:657
 msgid "Session ID:"
 msgstr ""
 

--- a/tests/php/bootstrap.php
+++ b/tests/php/bootstrap.php
@@ -15,6 +15,10 @@ if ( ! defined( 'ABSPATH' ) ) {
 	define( 'ABSPATH', '/tmp/wordpress/' );
 }
 
+if ( ! defined( 'MINUTE_IN_SECONDS' ) ) {
+	define( 'MINUTE_IN_SECONDS', 60 );
+}
+
 if ( ! defined( 'HOUR_IN_SECONDS' ) ) {
 	define( 'HOUR_IN_SECONDS', 3600 );
 }

--- a/tests/php/unit/AttributionTest.php
+++ b/tests/php/unit/AttributionTest.php
@@ -1098,4 +1098,142 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 			$result
 		);
 	}
+
+	// ------------------------------------------------------------------
+	// get_stats() transient caching
+	// ------------------------------------------------------------------
+	//
+	// These tests verify: (a) the second call to get_stats('month') returns
+	// the cached result without running DB queries (get_transient returns the
+	// cached value, so the DB code is never reached); (b) bust_stats_cache()
+	// deletes all four period transients.
+
+	public function test_get_stats_returns_cached_result_on_second_call(): void {
+		// The cached value returned by get_transient simulates a warm cache.
+		// When the transient is present, get_stats() must return it directly
+		// without touching $wpdb. We verify this by expecting get_transient
+		// to return a valid array and asserting set_transient is never called
+		// (which would only happen if the DB path ran and re-cached).
+		$cached_stats = array(
+			'period'           => 'month',
+			'ai_orders'        => 5,
+			'ai_revenue'       => 250.0,
+			'ai_aov'           => 50.0,
+			'all_orders'       => 20,
+			'ai_share_percent' => 25.0,
+			'currency'         => 'USD',
+			'currency_symbol'  => '$',
+			'by_agent'         => array(),
+			'top_agent'        => null,
+		);
+
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'wc_ai_storefront_stats_month' )
+			->andReturn( $cached_stats );
+
+		// set_transient must NOT fire — the DB path (which would re-cache)
+		// must be skipped entirely on a cache hit.
+		Functions\expect( 'set_transient' )->never();
+
+		$result = WC_AI_Storefront_Attribution::get_stats( 'month' );
+
+		$this->assertSame( $cached_stats, $result );
+	}
+
+	public function test_get_stats_stores_result_in_transient_on_cache_miss(): void {
+		// On a cache miss get_transient returns false, the DB path runs,
+		// and set_transient is called with the 5-minute TTL.
+		// We stub all WP/WC functions the DB path calls so the test
+		// doesn't require a real database.
+		global $wpdb;
+		$wpdb = \Mockery::mock( 'wpdb' );
+		$wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
+		$wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+		$wpdb->posts    = 'wp_posts';
+		$wpdb->postmeta = 'wp_postmeta';
+		$wpdb->prefix   = 'wp_';
+
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'wc_ai_storefront_stats_month' )
+			->andReturn( false );
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with(
+				'wc_ai_storefront_stats_month',
+				\Mockery::type( 'array' ),
+				5 * MINUTE_IN_SECONDS
+			);
+
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		// `Automattic\WooCommerce\Utilities\OrderUtil` is not loaded in the
+		// test environment, so `class_exists()` naturally returns false and
+		// the legacy post-based query path runs. No stubbing needed.
+
+		WC_AI_Storefront_Attribution::get_stats( 'month' );
+
+		// Restore $wpdb to a safe state for subsequent tests.
+		$wpdb = null;
+	}
+
+	public function test_get_stats_normalizes_invalid_period_to_month(): void {
+		// An unrecognized period value must be silently normalized to 'month'
+		// so the transient key is always one of the four valid values. Without
+		// normalization a caller passing 'quarter' would read and write a
+		// transient key that bust_stats_cache() never deletes.
+		Functions\expect( 'get_transient' )
+			->once()
+			->with( 'wc_ai_storefront_stats_month' )
+			->andReturn( false );
+
+		global $wpdb;
+		$wpdb = \Mockery::mock( 'wpdb' );
+		$wpdb->shouldReceive( 'prepare' )->andReturn( 'SQL' );
+		$wpdb->shouldReceive( 'get_results' )->once()->andReturn( array() );
+		$wpdb->shouldReceive( 'get_var' )->once()->andReturn( '0' );
+		$wpdb->posts    = 'wp_posts';
+		$wpdb->postmeta = 'wp_postmeta';
+		$wpdb->prefix   = 'wp_';
+
+		Functions\expect( 'set_transient' )
+			->once()
+			->with( 'wc_ai_storefront_stats_month', \Mockery::type( 'array' ), \Mockery::type( 'int' ) );
+
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		// `Automattic\WooCommerce\Utilities\OrderUtil` is not loaded in the
+		// test environment, so `class_exists()` naturally returns false and
+		// the legacy post-based query path runs. No stubbing needed.
+
+		$result = WC_AI_Storefront_Attribution::get_stats( 'quarter' );
+
+		$this->assertSame( 'month', $result['period'] );
+
+		$wpdb = null;
+	}
+
+	// ------------------------------------------------------------------
+	// bust_stats_cache()
+	// ------------------------------------------------------------------
+
+	public function test_bust_stats_cache_deletes_all_four_period_transients(): void {
+		$deleted = array();
+		Functions\expect( 'delete_transient' )
+			->times( 4 )
+			->andReturnUsing(
+				static function ( $key ) use ( &$deleted ) {
+					$deleted[] = $key;
+					return true;
+				}
+			);
+
+		WC_AI_Storefront_Attribution::bust_stats_cache();
+
+		$this->assertContains( 'wc_ai_storefront_stats_day', $deleted );
+		$this->assertContains( 'wc_ai_storefront_stats_week', $deleted );
+		$this->assertContains( 'wc_ai_storefront_stats_month', $deleted );
+		$this->assertContains( 'wc_ai_storefront_stats_year', $deleted );
+	}
 }

--- a/tests/php/unit/AttributionTest.php
+++ b/tests/php/unit/AttributionTest.php
@@ -1218,6 +1218,37 @@ class AttributionTest extends \PHPUnit\Framework\TestCase {
 	// bust_stats_cache()
 	// ------------------------------------------------------------------
 
+	public function test_init_hooks_bust_stats_cache_on_delete_and_trash(): void {
+		$hooks = array();
+		Functions\when( 'add_action' )->alias(
+			static function ( $hook, $callback, $priority = 10, $accepted_args = 1 ) use ( &$hooks ) {
+				$hooks[] = array( $hook, $callback, $accepted_args );
+			}
+		);
+		Functions\when( 'add_filter' )->alias( static function () {} );
+
+		$this->attribution->init();
+
+		$bust_hooks = array_filter(
+			$hooks,
+			static function ( $entry ) {
+				return is_array( $entry[1] ) && 'bust_stats_cache' === $entry[1][1];
+			}
+		);
+		$registered = array_column( $bust_hooks, 0 );
+
+		$this->assertContains( 'woocommerce_delete_order', $registered, 'woocommerce_delete_order should bust stats cache' );
+		$this->assertContains( 'woocommerce_trash_order', $registered, 'woocommerce_trash_order should bust stats cache' );
+
+		// All delete/trash hook entries must pass 0 accepted args so the
+		// order-ID parameter WC passes is not forwarded to bust_stats_cache().
+		foreach ( $bust_hooks as $entry ) {
+			if ( in_array( $entry[0], array( 'woocommerce_delete_order', 'woocommerce_trash_order' ), true ) ) {
+				$this->assertSame( 0, $entry[2], "{$entry[0]} bust_stats_cache binding must use accepted_args=0" );
+			}
+		}
+	}
+
 	public function test_bust_stats_cache_deletes_all_four_period_transients(): void {
 		$deleted = array();
 		Functions\expect( 'delete_transient' )

--- a/uninstall.php
+++ b/uninstall.php
@@ -53,6 +53,11 @@ delete_transient( 'wc_ai_storefront_llms_txt' );
 delete_transient( 'wc_ai_storefront_ucp' );
 delete_transient( 'wc_ai_storefront_flush_rewrite' );
 
+foreach ( array( 'day', 'week', 'month', 'year' ) as $wc_ai_storefront_period ) {
+	delete_transient( 'wc_ai_storefront_stats_' . $wc_ai_storefront_period );
+}
+unset( $wc_ai_storefront_period );
+
 /*
  * --------------------------------------------------------------------------
  * Scheduled events
@@ -89,6 +94,10 @@ if ( ! function_exists( 'wc_ai_storefront_uninstall_multisite' ) ) {
 			delete_transient( 'wc_ai_storefront_llms_txt' );
 			delete_transient( 'wc_ai_storefront_ucp' );
 			delete_transient( 'wc_ai_storefront_flush_rewrite' );
+			foreach ( array( 'day', 'week', 'month', 'year' ) as $_period ) {
+				delete_transient( 'wc_ai_storefront_stats_' . $_period );
+			}
+			unset( $_period );
 			wp_clear_scheduled_hook( 'wc_ai_storefront_warm_llms_txt_cache' );
 
 			restore_current_blog();


### PR DESCRIPTION
## Summary

- Wraps `WC_AI_Storefront_Attribution::get_stats()` with a 5-minute transient cache keyed by period, eliminating two raw `$wpdb` queries on every admin settings page load for stores that have not had a new order since the last cache write.
- Adds `bust_stats_cache()` to invalidate all four period transients, hooked to `woocommerce_order_status_completed` and `woocommerce_order_status_processing` so the dashboard reflects new completions within one TTL cycle.
- Deletes the four stats transients in both single-site and multisite uninstall paths.

## Test plan

- [x] `composer test` passes (all 48 `AttributionTest` assertions, including 4 new caching tests).
- [x] `vendor/bin/phpcs` passes.
- [x] `vendor/bin/phpstan analyse --memory-limit=512M` passes (no errors).
- [x] `./bin/make-pot.sh` runs cleanly.

Closes #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)