### PR TITLE
feat(ucp): add extension filters; fix impure product translator

### DIFF
--- a/docs/engineering/HOOKS.md
+++ b/docs/engineering/HOOKS.md
@@ -2,7 +2,7 @@
 
 Filters and actions exposed by WooCommerce AI Storefront for extending plugins.
 
-The plugin exposes a deliberately small surface — seven filters and two actions. Each was chosen because it intercepts a specific extension point that's hard or impossible to reach from outside (e.g. the merchant's `/llms.txt` content, the UCP manifest body, the JSON-LD product markup). Where WP/WC core filters already exist for the same surface, we don't duplicate them.
+The plugin exposes a deliberately small surface — eleven filters and two actions. Each was chosen because it intercepts a specific extension point that's hard or impossible to reach from outside (e.g. the merchant's `/llms.txt` content, the UCP manifest body, the JSON-LD product markup). Where WP/WC core filters already exist for the same surface, we don't duplicate them.
 
 ## Filters
 
@@ -160,6 +160,139 @@ add_filter( 'wc_ai_storefront_github_token', function() {
     return defined( 'GITHUB_PAT' ) ? GITHUB_PAT : '';
 } );
 ```
+
+### `wc_ai_storefront_ucp_product`
+
+Filter a translated UCP product shape before it is added to a catalog/search or catalog/lookup response.
+
+```php
+apply_filters( 'wc_ai_storefront_ucp_product', array $product, array $wc_product );
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `$product` | `array` | The translated UCP product shape. Required keys: `id`, `title`, `description`, `price_range`, `variants`. Optional: `url` (UTM-stamped permalink), `handle`, `status`, `seller`, `categories`, `tags`, `media`, `options`, `metadata`, `rating`, `published_at`, `updated_at`. |
+| `$wc_product` | `array` | The raw decoded Store API product response. Use this to read WC-native fields (e.g. custom meta surfaced via a Store API extension) that the translator did not map. |
+
+**Returns:** the (possibly modified) `array` UCP product shape.
+
+**When to use:** add custom product fields from a Store API extension (e.g. subscription billing period, pre-order date, rental availability), override price display for multi-currency setups, or inject an additional `categories` entry from a custom taxonomy.
+
+Fires in both `catalog/search` and `catalog/lookup` responses, once per product, after UTM attribution params have been stamped onto `$product['url']`. The translator is upstream of this filter and runs first; modifications made here are not visible to the translator.
+
+**Example — surface a subscription billing period:**
+
+```php
+add_filter( 'wc_ai_storefront_ucp_product', function( $product, $wc_product ) {
+    $ext = $wc_product['extensions']['com-woocommerce-subscriptions'] ?? array();
+    if ( ! empty( $ext['billing_period'] ) ) {
+        $product['metadata']['subscription'] = array(
+            'billing_period'    => $ext['billing_period'],
+            'billing_interval'  => (int) ( $ext['billing_interval'] ?? 1 ),
+        );
+    }
+    return $product;
+}, 10, 2 );
+```
+
+---
+
+### `wc_ai_storefront_ucp_variant`
+
+Filter a translated UCP variant shape before it is added to a product's `variants` array.
+
+```php
+apply_filters( 'wc_ai_storefront_ucp_variant', array $variant, array $wc_variation );
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `$variant` | `array` | The translated UCP variant shape. Required keys: `id`, `title`, `description`, `list_price`, `availability`. Optional: `options`, `compare_at_price`, `sku`, `barcodes`, `media`, `metadata`. |
+| `$wc_variation` | `array` | The raw decoded Store API variation response (or, for a synthesized default variant on a simple product, the product response). Use this to read WC-native fields that the translator did not map. |
+
+**Returns:** the (possibly modified) `array` UCP variant shape.
+
+**When to use:** add a custom availability signal (e.g. a pre-order date), surface a per-variation custom attribute, or override `list_price` with a subscription-adjusted amount.
+
+Fires once per variation for variable products, and once on the synthesized default variant for simple products.
+
+**Example — add a pre-order release date from a custom Store API extension:**
+
+```php
+add_filter( 'wc_ai_storefront_ucp_variant', function( $variant, $wc_variation ) {
+    $ext = $wc_variation['extensions']['com-acme-preorder'] ?? array();
+    if ( ! empty( $ext['release_date'] ) ) {
+        $variant['metadata']['preorder_release_date'] = $ext['release_date'];
+    }
+    return $variant;
+}, 10, 2 );
+```
+
+---
+
+### `wc_ai_storefront_ucp_continue_url`
+
+Filter the continue_url returned in a `POST /checkout-sessions` response before it is sent to the agent.
+
+```php
+apply_filters( 'wc_ai_storefront_ucp_continue_url', string $url, array $processed );
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `$url` | `string` | The fully-constructed continue URL including the `?products={id:qty,...}` payload and UTM attribution params (`utm_source`, `utm_medium`, `utm_id`, `ai_agent_host_raw`). |
+| `$processed` | `array` | The successfully-processed line items. Each entry contains at least `wc_id` (int), `ucp_id` (string), `quantity` (int), and `unit_price_minor` (int). Useful for conditionally redirecting based on cart contents. |
+
+**Returns:** the (possibly modified) continue URL string. Non-string returns are silently ignored and the pre-filter URL is used.
+
+**When to use:** redirect buyers to an alternative checkout entry point (e.g. a subscription sign-up page, a gift-purchase flow, a custom membership checkout) based on the cart contents, without changing the checkout-sessions handler itself.
+
+**Example — redirect subscription products to a dedicated checkout:**
+
+```php
+add_filter( 'wc_ai_storefront_ucp_continue_url', function( $url, $processed ) {
+    $wc_ids = array_column( $processed, 'wc_id' );
+    foreach ( $wc_ids as $id ) {
+        $product = wc_get_product( $id );
+        if ( $product && 'subscription' === $product->get_type() ) {
+            return home_url( '/subscribe-checkout/?products=' . implode( ',', $wc_ids ) );
+        }
+    }
+    return $url;
+}, 10, 2 );
+```
+
+---
+
+### `wc_ai_storefront_ucp_store_api_args`
+
+Filter the Store API query parameters before a `catalog/search` dispatch.
+
+```php
+apply_filters( 'wc_ai_storefront_ucp_store_api_args', array $store_params, string $endpoint );
+```
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `$store_params` | `array` | Associative array of Store API query parameters mapped from the UCP request. Keys include `search`, `per_page`, `page`, `category`, `on_sale`, `min_price`, `max_price`, `orderby`, `order`, and any others produced by `map_ucp_search_to_store_api()`. |
+| `$endpoint` | `string` | The Store API endpoint being dispatched (e.g. `'/wc/store/v1/products'`). Included for future-proofing so a single callback can branch by endpoint if new dispatch paths are added. |
+
+**Returns:** the (possibly modified) `array` of Store API params. Non-array returns are silently discarded and treated as an empty params array.
+
+**When to use:** inject a hidden catalog constraint (e.g. `category` filter for members-only products), add a custom `orderby` value registered by another Store API extension, or suppress a UCP-mapped parameter your plugin handles through a different filter.
+
+**Example — restrict catalog to a members-only category:**
+
+```php
+add_filter( 'wc_ai_storefront_ucp_store_api_args', function( $store_params, $endpoint ) {
+    if ( '/wc/store/v1/products' === $endpoint && current_user_can( 'member' ) ) {
+        $store_params['category'] = 'members-only';
+    }
+    return $store_params;
+}, 10, 2 );
+```
+
+---
 
 ## Actions
 

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
@@ -238,58 +238,13 @@ class WC_AI_Storefront_UCP_Product_Translator {
 		if ( ! empty( $wc_variations ) ) {
 			$variants = array();
 			foreach ( $wc_variations as $wc_variation ) {
-				$variant = WC_AI_Storefront_UCP_Variant_Translator::translate( $wc_variation );
-
-				/**
-				 * Filter a translated UCP variant before it is added to a product.
-				 *
-				 * Allows third-party plugins to augment or override any field of a
-				 * UCP variant shape produced from a WooCommerce Store API variation
-				 * response. Fires once per variation, in the order they appear in the
-				 * parent product's `variations[]` pointer list.
-				 *
-				 * @since 1.0.0
-				 *
-				 * @param array<string, mixed> $variant      The translated UCP variant shape.
-				 *                                           Required keys: `id`, `title`,
-				 *                                           `description`, `list_price`,
-				 *                                           `availability`. Optional: `options`,
-				 *                                           `compare_at_price`, `sku`,
-				 *                                           `barcodes`, `media`, `metadata`.
-				 * @param array<string, mixed> $wc_variation The raw decoded Store API variation
-				 *                                           response that was translated. Use this
-				 *                                           to read WC-native fields (e.g. custom
-				 *                                           meta surfaced via a Store API
-				 *                                           extension) that the translator did
-				 *                                           not map.
-				 *
-				 * @return array<string, mixed> The (possibly modified) UCP variant shape.
-				 */
-				$variants[] = apply_filters( 'wc_ai_storefront_ucp_variant', $variant, $wc_variation );
+				$variants[] = WC_AI_Storefront_UCP_Variant_Translator::translate( $wc_variation );
 			}
 			return $variants;
 		}
 
-		$default_variant = WC_AI_Storefront_UCP_Variant_Translator::synthesize_default( $wc_product );
-
-		/**
-		 * Filter the synthesized default UCP variant for a simple product.
-		 *
-		 * Simple WooCommerce products emit one synthesized variant (id suffix
-		 * `_default`) to satisfy the UCP schema `variants` minItems:1 constraint.
-		 * This filter fires on that synthesized variant, giving third-party plugins
-		 * the same mutation point they have for real variations.
-		 *
-		 * @since 1.0.0
-		 *
-		 * @param array<string, mixed> $default_variant The synthesized UCP variant shape.
-		 * @param array<string, mixed> $wc_product      The raw decoded Store API product
-		 *                                              response for the simple product.
-		 *
-		 * @return array<string, mixed> The (possibly modified) UCP variant shape.
-		 */
 		return array(
-			apply_filters( 'wc_ai_storefront_ucp_variant', $default_variant, $wc_product ),
+			WC_AI_Storefront_UCP_Variant_Translator::synthesize_default( $wc_product ),
 		);
 	}
 

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
@@ -51,6 +51,13 @@ class WC_AI_Storefront_UCP_Product_Translator {
 	 * infrastructure. Orchestration (detect type, fetch variations)
 	 * lives in the REST controller's search/lookup handlers.
 	 *
+	 * UTM attribution stamping is intentionally NOT done here. Callers
+	 * that operate in an agent context apply
+	 * `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` to `$product['url']`
+	 * after calling this method. Keeping stamping out of the translator
+	 * preserves the pure-function contract — the output is fully
+	 * determined by the inputs, with no side-effectful URL rewriting.
+	 *
 	 * @param array<string, mixed>             $wc_product    Decoded Store API product response.
 	 * @param array<int, array<string, mixed>> $wc_variations Optional pre-fetched Store API
 	 *                                                        variation responses. Empty = fall
@@ -60,41 +67,12 @@ class WC_AI_Storefront_UCP_Product_Translator {
 	 *                                                        in a request, so the controller
 	 *                                                        computes it once and passes it in —
 	 *                                                        keeps the translator WP-unaware.
-	 * @param string|null                      $source_host   Optional UTM source host for
-	 *                                                        stamping attribution params on the
-	 *                                                        product `url`. When non-null, the
-	 *                                                        permalink is rewritten through
-	 *                                                        `WC_AI_Storefront_Attribution::with_woo_ucp_utm()`
-	 *                                                        so a buyer who follows the link
-	 *                                                        directly (instead of going through
-	 *                                                        the agent's checkout-session
-	 *                                                        integration) still produces an
-	 *                                                        AI-attributed order. Empty string
-	 *                                                        is treated as "agent didn't
-	 *                                                        identify" — the helper substitutes
-	 *                                                        the FALLBACK_SOURCE sentinel.
-	 *                                                        `null` skips UTM stamping entirely
-	 *                                                        (preserves bare permalink); useful
-	 *                                                        for direct-call test contexts and
-	 *                                                        future internal callers that don't
-	 *                                                        have an agent context.
-	 * @param string                           $raw_host      Producer-side raw identifier from
-	 *                                                        the UCP-Agent header or body
-	 *                                                        fallback. Threaded through to the
-	 *                                                        UTM helper so the same
-	 *                                                        `ai_agent_host_raw` param continue_url
-	 *                                                        carries also lands on the
-	 *                                                        product-link path. Empty skips the
-	 *                                                        param entirely. Ignored when
-	 *                                                        `$source_host` is null.
 	 * @return array<string, mixed>                           UCP product shape.
 	 */
 	public static function translate(
 		array $wc_product,
-		array $wc_variations = [],
-		?array $seller = null,
-		?string $source_host = null,
-		string $raw_host = ''
+		array $wc_variations = array(),
+		?array $seller = null
 	): array {
 		$id = (int) ( $wc_product['id'] ?? 0 );
 
@@ -153,34 +131,13 @@ class WC_AI_Storefront_UCP_Product_Translator {
 		}
 
 		if ( ! empty( $wc_product['permalink'] ) ) {
-			// Stamp our canonical UTM payload onto the permalink when
-			// the controller threaded an agent context through. Buyers
-			// who click the product link in chat — instead of going
-			// through the agent's `/checkout-sessions` integration —
-			// otherwise land on the product page with no attribution
-			// markers, and WC Order Attribution buckets the resulting
-			// order as "direct" (or attributes it to the agent's HTTP
-			// referrer header, fragmenting AI-orders stats by referrer
-			// rather than rolling them up under the agent). See
-			// `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` for
-			// the canonical UTM contract; the same helper feeds
-			// `build_continue_url()` so the search-link and
-			// continue-url surfaces stay byte-identical on the
-			// attribution portion.
-			//
-			// `null` source_host is the "translator called outside an
-			// agent context" path — leave the permalink bare. Empty
-			// string source_host is "agent context exists, but agent
-			// didn't identify itself" — the helper substitutes the
-			// FALLBACK_SOURCE sentinel so the cohort stays observable
-			// in WC Origin breakdowns.
-			$product['url'] = null !== $source_host
-				? WC_AI_Storefront_Attribution::with_woo_ucp_utm(
-					$wc_product['permalink'],
-					$source_host,
-					$raw_host
-				)
-				: $wc_product['permalink'];
+			// Emit the bare permalink. UTM attribution is stamped by the
+			// controller after translation via
+			// `WC_AI_Storefront_Attribution::with_woo_ucp_utm()`, keeping
+			// this translator a pure function whose output depends only
+			// on its inputs. See the controller's `translate_products_for_search`
+			// and the catalog/lookup handler for the stamping call sites.
+			$product['url'] = $wc_product['permalink'];
 		}
 
 		// Taxonomies split (2.0.0+):
@@ -279,16 +236,61 @@ class WC_AI_Storefront_UCP_Product_Translator {
 	 */
 	private static function extract_variants( array $wc_product, array $wc_variations ): array {
 		if ( ! empty( $wc_variations ) ) {
-			$variants = [];
+			$variants = array();
 			foreach ( $wc_variations as $wc_variation ) {
-				$variants[] = WC_AI_Storefront_UCP_Variant_Translator::translate( $wc_variation );
+				$variant = WC_AI_Storefront_UCP_Variant_Translator::translate( $wc_variation );
+
+				/**
+				 * Filter a translated UCP variant before it is added to a product.
+				 *
+				 * Allows third-party plugins to augment or override any field of a
+				 * UCP variant shape produced from a WooCommerce Store API variation
+				 * response. Fires once per variation, in the order they appear in the
+				 * parent product's `variations[]` pointer list.
+				 *
+				 * @since 1.0.0
+				 *
+				 * @param array<string, mixed> $variant      The translated UCP variant shape.
+				 *                                           Required keys: `id`, `title`,
+				 *                                           `description`, `list_price`,
+				 *                                           `availability`. Optional: `options`,
+				 *                                           `compare_at_price`, `sku`,
+				 *                                           `barcodes`, `media`, `metadata`.
+				 * @param array<string, mixed> $wc_variation The raw decoded Store API variation
+				 *                                           response that was translated. Use this
+				 *                                           to read WC-native fields (e.g. custom
+				 *                                           meta surfaced via a Store API
+				 *                                           extension) that the translator did
+				 *                                           not map.
+				 *
+				 * @return array<string, mixed> The (possibly modified) UCP variant shape.
+				 */
+				$variants[] = apply_filters( 'wc_ai_storefront_ucp_variant', $variant, $wc_variation );
 			}
 			return $variants;
 		}
 
-		return [
-			WC_AI_Storefront_UCP_Variant_Translator::synthesize_default( $wc_product ),
-		];
+		$default_variant = WC_AI_Storefront_UCP_Variant_Translator::synthesize_default( $wc_product );
+
+		/**
+		 * Filter the synthesized default UCP variant for a simple product.
+		 *
+		 * Simple WooCommerce products emit one synthesized variant (id suffix
+		 * `_default`) to satisfy the UCP schema `variants` minItems:1 constraint.
+		 * This filter fires on that synthesized variant, giving third-party plugins
+		 * the same mutation point they have for real variations.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array<string, mixed> $default_variant The synthesized UCP variant shape.
+		 * @param array<string, mixed> $wc_product      The raw decoded Store API product
+		 *                                              response for the simple product.
+		 *
+		 * @return array<string, mixed> The (possibly modified) UCP variant shape.
+		 */
+		return array(
+			apply_filters( 'wc_ai_storefront_ucp_variant', $default_variant, $wc_product ),
+		);
 	}
 
 	/**

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -832,12 +832,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		 *
 		 * @return array<string, mixed> The (possibly modified) Store API params array.
 		 */
-		$store_params = apply_filters( 'wc_ai_storefront_ucp_store_api_args', $store_params, '/wc/store/v1/products' );
+		$store_params_before_filter = $store_params;
+		$store_params               = apply_filters( 'wc_ai_storefront_ucp_store_api_args', $store_params, '/wc/store/v1/products' );
 		// Guard: the filter must return an array. A misbehaving callback
-		// returning null/false would cause set_param() to loop over a
-		// non-iterable. Fall back to an empty array rather than fataling.
+		// returning a non-array would silently discard all search constraints.
+		// Fall back to the pre-filter value to preserve query semantics.
 		if ( ! is_array( $store_params ) ) {
-			$store_params = array();
+			$store_params = $store_params_before_filter;
 		}
 
 		$store_request = new WP_REST_Request( 'GET', '/wc/store/v1/products' );
@@ -970,7 +971,7 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			// is complete. Hoisted out of the translator to preserve its
 			// pure-function contract (see issue #176). The translator emits the
 			// bare permalink; the controller owns agent-context side-effects.
-			if ( ! empty( $product['url'] ) && null !== $agent_source_host ) {
+			if ( ! empty( $product['url'] ) ) {
 				$product['url'] = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
 					$product['url'],
 					$agent_source_host,
@@ -1510,7 +1511,7 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			// is complete. Hoisted out of the translator to preserve its
 			// pure-function contract (see issue #176). The translator emits the
 			// bare permalink; the controller owns agent-context side-effects.
-			if ( ! empty( $product['url'] ) && null !== $agent_source_host ) {
+			if ( ! empty( $product['url'] ) ) {
 				$product['url'] = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
 					$product['url'],
 					$agent_source_host,

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -798,6 +798,48 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * @return array{error: WP_REST_Response|null, wc_products: array, store_response: WP_REST_Response|null}
 	 */
 	private static function fetch_wc_products_for_search( array $store_params, string $capability ): array {
+		/**
+		 * Filter the Store API query arguments before a catalog/search dispatch.
+		 *
+		 * The UCP catalog/search handler maps the incoming UCP search payload
+		 * (query, filters, pagination) to WooCommerce Store API parameters
+		 * (`search`, `per_page`, `page`, `category`, etc.) and then dispatches
+		 * an internal `GET /wc/store/v1/products` request. This filter fires
+		 * immediately before that dispatch, giving third-party plugins a chance
+		 * to add, override, or remove any parameter before the Store API
+		 * processes it.
+		 *
+		 * Common use-cases: inject a hidden `category` constraint for
+		 * subscription-only catalogs, add a custom `orderby` that a Store API
+		 * extension registers, or strip a parameter your plugin handles
+		 * differently via a separate `woocommerce_product_query` hook.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param array<string, mixed> $store_params The associative array of Store API
+		 *                                           query parameters. Keys are Store API
+		 *                                           param names (e.g. `search`, `per_page`,
+		 *                                           `page`, `category`, `on_sale`,
+		 *                                           `min_price`, `max_price`, `orderby`,
+		 *                                           `order`). Values are the mapped values
+		 *                                           from the UCP request.
+		 * @param string               $endpoint     The Store API endpoint being dispatched:
+		 *                                           always `'/wc/store/v1/products'` for
+		 *                                           catalog/search. Included so future
+		 *                                           multi-endpoint dispatch paths share one
+		 *                                           filter hook and callbacks can branch by
+		 *                                           endpoint.
+		 *
+		 * @return array<string, mixed> The (possibly modified) Store API params array.
+		 */
+		$store_params = apply_filters( 'wc_ai_storefront_ucp_store_api_args', $store_params, '/wc/store/v1/products' );
+		// Guard: the filter must return an array. A misbehaving callback
+		// returning null/false would cause set_param() to loop over a
+		// non-iterable. Fall back to an empty array rather than fataling.
+		if ( ! is_array( $store_params ) ) {
+			$store_params = array();
+		}
+
 		$store_request = new WP_REST_Request( 'GET', '/wc/store/v1/products' );
 		foreach ( $store_params as $k => $v ) {
 			$store_request->set_param( $k, $v );
@@ -918,13 +960,52 @@ class WC_AI_Storefront_UCP_REST_Controller {
 					$variation_fetch['skipped']
 				);
 			}
-			$products[] = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$product = WC_AI_Storefront_UCP_Product_Translator::translate(
 				$wc_product,
 				$variation_fetch['variations'],
-				$seller,
-				$agent_source_host,
-				$agent_raw_host
+				$seller
 			);
+
+			// Stamp UTM attribution onto the product URL now that translation
+			// is complete. Hoisted out of the translator to preserve its
+			// pure-function contract (see issue #176). The translator emits the
+			// bare permalink; the controller owns agent-context side-effects.
+			if ( ! empty( $product['url'] ) && null !== $agent_source_host ) {
+				$product['url'] = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+					$product['url'],
+					$agent_source_host,
+					$agent_raw_host
+				);
+			}
+
+			/**
+			 * Filter a translated UCP product before it is added to the catalog
+			 * search response.
+			 *
+			 * Fires once per product after UTM attribution has been stamped onto
+			 * `$product['url']`. Third-party plugins can augment, override, or
+			 * strip any field of the UCP product shape without subclassing the
+			 * translator.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param array<string, mixed> $product    The translated UCP product shape.
+			 *                                         Required keys: `id`, `title`,
+			 *                                         `description`, `price_range`,
+			 *                                         `variants`. Optional: `url`,
+			 *                                         `handle`, `status`, `seller`,
+			 *                                         `categories`, `tags`, `media`,
+			 *                                         `options`, `metadata`, `rating`,
+			 *                                         `published_at`, `updated_at`.
+			 * @param array<string, mixed> $wc_product The raw decoded Store API product
+			 *                                         response. Use this to read WC-native
+			 *                                         fields (e.g. custom meta surfaced via
+			 *                                         a Store API extension) that the
+			 *                                         translator did not map.
+			 *
+			 * @return array<string, mixed> The (possibly modified) UCP product shape.
+			 */
+			$products[] = apply_filters( 'wc_ai_storefront_ucp_product', $product, $wc_product );
 		}
 
 		return array(
@@ -1365,13 +1446,52 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				);
 			}
 
-			$products[] = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$product = WC_AI_Storefront_UCP_Product_Translator::translate(
 				$wc_product,
 				$variation_fetch['variations'],
-				$seller,
-				$agent_source_host,
-				$agent_raw_host
+				$seller
 			);
+
+			// Stamp UTM attribution onto the product URL now that translation
+			// is complete. Hoisted out of the translator to preserve its
+			// pure-function contract (see issue #176). The translator emits the
+			// bare permalink; the controller owns agent-context side-effects.
+			if ( ! empty( $product['url'] ) && null !== $agent_source_host ) {
+				$product['url'] = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+					$product['url'],
+					$agent_source_host,
+					$agent_raw_host
+				);
+			}
+
+			/**
+			 * Filter a translated UCP product before it is added to the catalog
+			 * lookup response.
+			 *
+			 * Fires once per product after UTM attribution has been stamped onto
+			 * `$product['url']`. Third-party plugins can augment, override, or
+			 * strip any field of the UCP product shape without subclassing the
+			 * translator.
+			 *
+			 * @since 1.0.0
+			 *
+			 * @param array<string, mixed> $product    The translated UCP product shape.
+			 *                                         Required keys: `id`, `title`,
+			 *                                         `description`, `price_range`,
+			 *                                         `variants`. Optional: `url`,
+			 *                                         `handle`, `status`, `seller`,
+			 *                                         `categories`, `tags`, `media`,
+			 *                                         `options`, `metadata`, `rating`,
+			 *                                         `published_at`, `updated_at`.
+			 * @param array<string, mixed> $wc_product The raw decoded Store API product
+			 *                                         response. Use this to read WC-native
+			 *                                         fields (e.g. custom meta surfaced via
+			 *                                         a Store API extension) that the
+			 *                                         translator did not map.
+			 *
+			 * @return array<string, mixed> The (possibly modified) UCP product shape.
+			 */
+			$products[] = apply_filters( 'wc_ai_storefront_ucp_product', $product, $wc_product );
 		}
 
 		$response_body = array(
@@ -4440,7 +4560,7 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 *                                                      for diagnostic / graduation purposes.
 	 */
 	private static function build_continue_url( array $processed, string $source_host, string $raw_host ): string {
-		$segments = [];
+		$segments = array();
 		foreach ( $processed as $p ) {
 			$segments[] = $p['wc_id'] . ':' . $p['quantity'];
 		}
@@ -4458,11 +4578,43 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// for the canonical UTM contract.
 		$url_with_products = $base . '?products=' . implode( ',', $segments );
 
-		return WC_AI_Storefront_Attribution::with_woo_ucp_utm(
+		$url = WC_AI_Storefront_Attribution::with_woo_ucp_utm(
 			$url_with_products,
 			$source_host,
 			$raw_host
 		);
+
+		/**
+		 * Filter the continue_url returned in a checkout-sessions response.
+		 *
+		 * The continue_url is the Shareable Checkout Link the agent redirects
+		 * the buyer to after a successful `POST /checkout-sessions` call. By
+		 * default it points at `{home_url}/checkout-link/?products={id:qty,...}`
+		 * with UTM attribution params appended. Plugins can rewrite the URL to
+		 * an alternative checkout entry point (e.g. a subscription upsell page,
+		 * a custom checkout flow) while preserving the attribution query string.
+		 *
+		 * @since 1.0.0
+		 *
+		 * @param string                           $url       The fully-constructed continue URL
+		 *                                                    including the `?products=` payload
+		 *                                                    and UTM attribution params.
+		 * @param array<int, array<string, mixed>> $processed The successfully-processed line
+		 *                                                    items. Each entry contains at least
+		 *                                                    `wc_id` (int), `ucp_id` (string),
+		 *                                                    `quantity` (int), and
+		 *                                                    `unit_price_minor` (int). Useful
+		 *                                                    for conditionally redirecting based
+		 *                                                    on the cart contents.
+		 *
+		 * @return string The (possibly modified) continue URL.
+		 */
+		$filtered = apply_filters( 'wc_ai_storefront_ucp_continue_url', $url, $processed );
+
+		// Guard against misbehaving callbacks that return a non-string.
+		// Only accept string returns; fall back to the pre-filter URL for
+		// anything else to avoid a fatal on the redirect path.
+		return is_string( $filtered ) ? $filtered : $url;
 	}
 
 	/**

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -978,6 +978,59 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				);
 			}
 
+			// Apply the per-variant filter now that translation is complete.
+			// Moved here from UCP_Product_Translator::extract_variants() so
+			// the translator stays a pure function (no WP API calls). Fires
+			// once per variant in document order.
+			//
+			// Two sources feed this loop:
+			//   - Variable products: one real WC variation per entry; the
+			//     second arg ($wc_variation_or_product) is the decoded
+			//     Store API variation response.
+			//   - Simple products: one synthesized default variant; no
+			//     per-variation object is available, so the second arg is
+			//     the parent WC Store API product response. Hooks can
+			//     distinguish these via the variant id suffix: real
+			//     variations use `var_{id}`, synthesized defaults use
+			//     `var_{id}_default`.
+			if ( isset( $product['variants'] ) && is_array( $product['variants'] ) ) {
+				$has_real_variations = ! empty( $variation_fetch['variations'] );
+				foreach ( $product['variants'] as $idx => $variant ) {
+					// For variable products pass the matching variation
+					// response; for simple products pass the parent product.
+					$second_arg = $has_real_variations
+						? ( $variation_fetch['variations'][ $idx ] ?? $wc_product )
+						: $wc_product;
+
+					/**
+					 * Filter a translated UCP variant before it is added to a product.
+					 *
+					 * Fires once per variant after translation, in document order.
+					 * For variable products the second arg is the decoded Store API
+					 * variation response. For simple products (synthesized default
+					 * variant, id suffix `_default`) the second arg is the parent
+					 * product response — no per-variation object is available.
+					 *
+					 * @since 1.0.0
+					 *
+					 * @param array<string, mixed> $variant                    The translated UCP variant shape.
+					 *                                                          Required keys: `id`, `title`,
+					 *                                                          `description`, `list_price`,
+					 *                                                          `availability`. Optional: `options`,
+					 *                                                          `compare_at_price`, `sku`,
+					 *                                                          `barcodes`, `media`, `metadata`.
+					 * @param array<string, mixed> $second_arg                 For variable products: the raw
+					 *                                                          decoded Store API variation
+					 *                                                          response. For simple products:
+					 *                                                          the parent product response.
+					 *
+					 * @return array<string, mixed> The (possibly modified) UCP variant shape.
+					 */
+					$filtered                    = apply_filters( 'wc_ai_storefront_ucp_variant', $variant, $second_arg );
+					$product['variants'][ $idx ] = is_array( $filtered ) ? $filtered : $variant;
+				}
+			}
+
 			/**
 			 * Filter a translated UCP product before it is added to the catalog
 			 * search response.
@@ -1005,7 +1058,8 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			 *
 			 * @return array<string, mixed> The (possibly modified) UCP product shape.
 			 */
-			$products[] = apply_filters( 'wc_ai_storefront_ucp_product', $product, $wc_product );
+			$filtered_product = apply_filters( 'wc_ai_storefront_ucp_product', $product, $wc_product );
+			$products[]       = is_array( $filtered_product ) ? $filtered_product : $product;
 		}
 
 		return array(
@@ -1464,6 +1518,59 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				);
 			}
 
+			// Apply the per-variant filter now that translation is complete.
+			// Moved here from UCP_Product_Translator::extract_variants() so
+			// the translator stays a pure function (no WP API calls). Fires
+			// once per variant in document order.
+			//
+			// Two sources feed this loop:
+			//   - Variable products: one real WC variation per entry; the
+			//     second arg ($second_arg) is the decoded Store API variation
+			//     response.
+			//   - Simple products: one synthesized default variant; no
+			//     per-variation object is available, so the second arg is
+			//     the parent WC Store API product response. Hooks can
+			//     distinguish these via the variant id suffix: real
+			//     variations use `var_{id}`, synthesized defaults use
+			//     `var_{id}_default`.
+			if ( isset( $product['variants'] ) && is_array( $product['variants'] ) ) {
+				$has_real_variations = ! empty( $variation_fetch['variations'] );
+				foreach ( $product['variants'] as $idx => $variant ) {
+					// For variable products pass the matching variation
+					// response; for simple products pass the parent product.
+					$second_arg = $has_real_variations
+						? ( $variation_fetch['variations'][ $idx ] ?? $wc_product )
+						: $wc_product;
+
+					/**
+					 * Filter a translated UCP variant before it is added to a product.
+					 *
+					 * Fires once per variant after translation, in document order.
+					 * For variable products the second arg is the decoded Store API
+					 * variation response. For simple products (synthesized default
+					 * variant, id suffix `_default`) the second arg is the parent
+					 * product response — no per-variation object is available.
+					 *
+					 * @since 1.0.0
+					 *
+					 * @param array<string, mixed> $variant    The translated UCP variant shape.
+					 *                                         Required keys: `id`, `title`,
+					 *                                         `description`, `list_price`,
+					 *                                         `availability`. Optional: `options`,
+					 *                                         `compare_at_price`, `sku`,
+					 *                                         `barcodes`, `media`, `metadata`.
+					 * @param array<string, mixed> $second_arg For variable products: the raw
+					 *                                         decoded Store API variation
+					 *                                         response. For simple products:
+					 *                                         the parent product response.
+					 *
+					 * @return array<string, mixed> The (possibly modified) UCP variant shape.
+					 */
+					$filtered                    = apply_filters( 'wc_ai_storefront_ucp_variant', $variant, $second_arg );
+					$product['variants'][ $idx ] = is_array( $filtered ) ? $filtered : $variant;
+				}
+			}
+
 			/**
 			 * Filter a translated UCP product before it is added to the catalog
 			 * lookup response.
@@ -1491,7 +1598,8 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			 *
 			 * @return array<string, mixed> The (possibly modified) UCP product shape.
 			 */
-			$products[] = apply_filters( 'wc_ai_storefront_ucp_product', $product, $wc_product );
+			$filtered_product = apply_filters( 'wc_ai_storefront_ucp_product', $product, $wc_product );
+			$products[]       = is_array( $filtered_product ) ? $filtered_product : $product;
 		}
 
 		$response_body = array(

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T06:14:34+00:00\n"
+"POT-Creation-Date: 2026-04-29T13:12:03+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -117,181 +117,181 @@ msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:594
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1247
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1515
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1328
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1635
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:828
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:851
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:870
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:893
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1406
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1526
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1416
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1536
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1434
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1554
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1526
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1646
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1536
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1656
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: agent's UCP product ID, 2: summed quantity after merging duplicates, 3: maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1650
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1770
 #, php-format
 msgid "Summed quantity %2$d for \"%1$s\" (after merging duplicate line items) exceeds the per-line cap of %3$d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1684
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1804
 msgid "Duplicate line items targeting the same product were merged. Quantities have been summed; the response shows one line per product."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1792
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1912
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1811
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1931
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1865
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1985
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2315
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2435
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2884
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3004
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2955
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3075
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2986
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3106
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3006
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3126
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3031
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3151
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3064
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3184
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3100
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3220
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3131
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3251
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3203
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3323
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3254
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3374
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3284
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3404
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3374
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3494
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3613
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3733
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3648
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3768
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4350
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4470
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4559
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4711
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4563
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4715
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4567
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4719
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4569
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4721
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4571
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4723
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4575
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4727
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4577
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4729
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T13:12:03+00:00\n"
+"POT-Creation-Date: 2026-04-29T13:25:41+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -117,8 +117,8 @@ msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:594
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1328
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1635
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1382
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1743
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
@@ -127,171 +127,171 @@ msgstr ""
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1526
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1634
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1536
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1644
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1554
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1662
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1646
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1754
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1656
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1764
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: agent's UCP product ID, 2: summed quantity after merging duplicates, 3: maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1770
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1878
 #, php-format
 msgid "Summed quantity %2$d for \"%1$s\" (after merging duplicate line items) exceeds the per-line cap of %3$d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1804
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1912
 msgid "Duplicate line items targeting the same product were merged. Quantities have been summed; the response shows one line per product."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1912
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2020
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1931
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2039
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1985
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2093
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2435
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2543
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3004
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3112
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3075
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3183
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3106
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3214
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3126
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3234
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3151
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3259
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3184
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3292
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3220
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3328
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3251
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3359
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3323
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3431
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3374
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3482
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3404
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3512
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3494
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3602
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3733
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3841
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3768
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3876
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4470
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4578
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4711
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4819
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4715
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4823
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4719
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4827
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4721
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4829
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4723
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4831
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4727
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4835
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4729
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4837
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-29T13:25:41+00:00\n"
+"POT-Creation-Date: 2026-04-29T13:41:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -117,181 +117,181 @@ msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:594
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1382
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1743
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1383
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1744
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:870
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:893
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:871
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:894
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1634
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1635
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1644
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1645
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1662
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1663
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1754
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1755
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1764
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1765
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: agent's UCP product ID, 2: summed quantity after merging duplicates, 3: maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1878
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1879
 #, php-format
 msgid "Summed quantity %2$d for \"%1$s\" (after merging duplicate line items) exceeds the per-line cap of %3$d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1912
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1913
 msgid "Duplicate line items targeting the same product were merged. Quantities have been summed; the response shows one line per product."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2020
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2021
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2039
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2040
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2093
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2094
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2543
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2544
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3112
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3113
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3183
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3184
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3214
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3215
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3234
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3235
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3259
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3260
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3292
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3293
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3328
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3329
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3359
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3360
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3431
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3432
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3482
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3483
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3512
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3513
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3602
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3603
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3841
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3842
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3876
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3877
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4578
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4579
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4819
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4820
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4823
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4824
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4827
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4828
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4829
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4830
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4831
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4832
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4835
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4836
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4837
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4838
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -581,118 +581,26 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
-	// URL UTM stamping (attribution)
+	// URL — the translator always returns the bare permalink.
 	//
-	// When the controller threads an agent context through
-	// (`$source_host` non-null), the translator stamps our canonical
-	// UTM payload onto the product `url`. This is the buyer-clicks-the-
-	// link-in-chat path: without it, those orders bucket as "direct"
-	// in WC Order Attribution rather than rolling up under the agent.
+	// UTM attribution stamping was moved to the REST controller (after
+	// translate() returns) to preserve the translator's pure-function
+	// contract. The translator never calls WP API functions, so its
+	// output is fully determined by its inputs alone.
 	//
-	// `null` source_host (default, the existing call shape) preserves
-	// the bare permalink — covered by `test_url_from_permalink` above.
+	// The controller stamps UTM via
+	// `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` after calling
+	// translate(). That stamping is tested at the controller level.
+	// Here we simply lock in that the translator always returns the
+	// bare permalink, regardless of what context surrounds the call.
 	// ------------------------------------------------------------------
 
-	public function test_url_stamped_with_utm_when_source_host_provided(): void {
+	public function test_url_always_bare_no_utm_stamped_by_translator(): void {
+		// Translator must return the bare permalink — no UTM params.
+		// UTM stamping is the controller's job (see issue #176).
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
 			$this->simple_product_fixture(),
 			[],
-			null,
-			'chatgpt.com'
-		);
-
-		// Order is enforced by the helper's string-concat append:
-		// utm_source first, then utm_medium, then utm_id (then the
-		// optional ai_agent_host_raw, when raw_host is non-empty).
-		// See `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` for
-		// why this is string concat rather than `add_query_arg()` —
-		// `add_query_arg()`'s `urlencode_deep` would re-encode
-		// existing query params, changing the wire shape.
-		$this->assertEquals(
-			'https://example.com/product/widget/'
-				. '?utm_source=chatgpt.com'
-				. '&utm_medium=referral'
-				. '&utm_id=woo_ucp',
-			$result['url']
-		);
-	}
-
-	public function test_url_includes_ai_agent_host_raw_when_provided(): void {
-		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
-			$this->simple_product_fixture(),
-			[],
-			null,
-			'chatgpt.com',
-			'chatgpt.com'
-		);
-
-		$this->assertStringContainsString( 'utm_source=chatgpt.com', $result['url'] );
-		$this->assertStringContainsString( 'ai_agent_host_raw=chatgpt.com', $result['url'] );
-	}
-
-	public function test_url_omits_ai_agent_host_raw_when_empty(): void {
-		// Default `$raw_host = ''` — no `ai_agent_host_raw` param
-		// should appear in the URL.
-		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
-			$this->simple_product_fixture(),
-			[],
-			null,
-			'chatgpt.com'
-		);
-
-		$this->assertStringNotContainsString( 'ai_agent_host_raw', $result['url'] );
-	}
-
-	public function test_url_substitutes_fallback_source_when_source_host_empty(): void {
-		// Empty string source_host = "agent context exists but no
-		// hostname could be resolved". The helper substitutes the
-		// FALLBACK_SOURCE sentinel so the cohort stays observable
-		// in WC Origin breakdowns rather than collapsing into "direct".
-		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
-			$this->simple_product_fixture(),
-			[],
-			null,
-			''
-		);
-
-		$this->assertStringContainsString( 'utm_source=ucp_unknown', $result['url'] );
-		$this->assertStringContainsString( 'utm_id=woo_ucp', $result['url'] );
-	}
-
-	public function test_url_preserves_existing_query_params_on_permalink(): void {
-		// Polylang/WPML language plugins, custom rewrite rules, and
-		// paginated archives can put query strings on permalinks.
-		// The UTM helper detects an existing `?` in the URL and uses
-		// `&` as its separator (string concat, not `add_query_arg()` —
-		// see the helper's docblock for why), so a permalink like
-		// `/product/widget/?lang=fr` should land as
-		// `/product/widget/?lang=fr&utm_source=...&utm_medium=...&utm_id=...`
-		// rather than the broken `/product/widget/?lang=fr?utm_source=...`.
-		$fixture              = $this->simple_product_fixture();
-		$fixture['permalink'] = 'https://example.com/product/widget/?lang=fr';
-
-		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
-			$fixture,
-			[],
-			null,
-			'chatgpt.com'
-		);
-
-		$this->assertStringContainsString( 'lang=fr', $result['url'] );
-		$this->assertStringContainsString( 'utm_source=chatgpt.com', $result['url'] );
-		// One `?`, the rest must be `&`. Two `?` would mean we broke
-		// the URL.
-		$this->assertEquals( 1, substr_count( $result['url'], '?' ) );
-	}
-
-	public function test_url_left_bare_when_source_host_null(): void {
-		// The default-null case is the "no agent context" path —
-		// future internal callers and direct-call test contexts.
-		// Permalink should pass through verbatim, no UTMs.
-		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
-			$this->simple_product_fixture(),
-			[],
-			null,
 			null
 		);
 
@@ -700,6 +608,25 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 			'https://example.com/product/widget/',
 			$result['url']
 		);
+		$this->assertStringNotContainsString( 'utm_', $result['url'] );
+	}
+
+	public function test_url_bare_permalink_preserved_verbatim_with_existing_query_params(): void {
+		// A permalink that already carries query params (e.g. lang=fr
+		// from Polylang/WPML) must be forwarded verbatim. The controller
+		// is responsible for appending UTM params; the translator must
+		// not modify the URL shape.
+		$fixture              = $this->simple_product_fixture();
+		$fixture['permalink'] = 'https://example.com/product/widget/?lang=fr';
+
+		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
+			$fixture,
+			[],
+			null
+		);
+
+		$this->assertEquals( 'https://example.com/product/widget/?lang=fr', $result['url'] );
+		$this->assertStringNotContainsString( 'utm_', $result['url'] );
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #176. Closes #179.

**Problem:** Third-party plugins (WooCommerce Subscriptions, multi-vendor, regional pricing, ML feature stores) had no hook to augment UCP product/variant output. Additionally, `UCP_Product_Translator::translate()` was calling `WC_AI_Storefront_Attribution::with_woo_ucp_utm()` directly, breaking the pure-translator contract — translators should be pure functions of their inputs.

**Changes:**

1. **UTM hoisting** — Removed `$source_host`/`$raw_host` params from `UCP_Product_Translator::translate()`. UTM stamping moved to the controller after translation. Behavior is externally identical; translator is now a pure function.

2. **Four new filters:**

| Filter | When | Args |
|---|---|---|
| `wc_ai_storefront_ucp_product` | After product translation + UTM stamp | `($product_shape, $wc_product)` |
| `wc_ai_storefront_ucp_variant` | After variant translation | `($variant_shape, $wc_variation)` |
| `wc_ai_storefront_ucp_continue_url` | After `build_continue_url()` constructs the redirect URL | `($url, $processed_items)` |
| `wc_ai_storefront_ucp_store_api_args` | Before Store API dispatch in catalog search | `($store_params, $endpoint)` |

All filters include full docblocks with `@since 1.0.0`, param descriptions, and type guards against misbehaving callbacks. `HOOKS.md` updated.

## Test plan
- [ ] PHPCS passes
- [ ] All PHP unit tests pass
- [ ] UTM params still appear on product URLs in catalog/search and catalog/lookup responses
- [ ] `wc_ai_storefront_ucp_product` filter can add a custom field to a product shape
- [ ] `wc_ai_storefront_ucp_continue_url` filter can replace the redirect URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)