### PR TITLE
docs(design): drop "AI Storefront is active" banner from post-enable mockup

### DIFF
--- a/docs/design/settings-redesign-final.html
+++ b/docs/design/settings-redesign-final.html
@@ -1043,7 +1043,7 @@ details.crawler-group .group-body {
   <!-- ============================================================== -->
   <section class="tab-section">
     <h2>Tab 1 — Overview (post-enable state)</h2>
-    <p class="rationale">Chip-style date range replaces the SelectControl. Six stat cards at 20px display weight with green reserved for AI-attributed metrics only. Order numbers in the recent-orders table render in JetBrains Mono. The Disable affordance moves out of the success banner and into a quiet footer at the bottom of the panel.</p>
+    <p class="rationale">No success banner: a populated dashboard (chip-row, stat cards, AI orders table) is the active-state signal, so an explicit "AI Storefront is active" notice is redundant chrome. Chip-style date range replaces the SelectControl. Six stat cards at 20px display weight with green reserved for AI-attributed metrics only. Order numbers in the recent-orders table render in JetBrains Mono. The Disable affordance lives as a quiet footer at the bottom of the panel.</p>
 
     <div class="panel">
       <div class="wrap-head"><h1>AI Storefront</h1></div>
@@ -1058,11 +1058,6 @@ details.crawler-group .group-body {
         <div class="section-head">
           <h2>AI traffic and orders</h2>
           <p class="description">Live dashboard of your AI-attributed traffic and orders.</p>
-        </div>
-
-        <div class="notice">
-          <strong>AI Storefront is active</strong>
-          <p>Your store is ready for AI shopping assistants. Checkout and customer data stay on your store.</p>
         </div>
 
         <div class="flex end">
@@ -1595,10 +1590,10 @@ details.crawler-group .group-body {
         <li>Stat cards in <code>PostEnableView</code>: change values from 24px green to 20px / 700 / -0.005em. <strong>Green ONLY on AI-attributed cards</strong> (AI orders, AI revenue, AI AOV, Top agent share). Total orders / Products exposed / Top agent become neutral <code>--fg-1</code>. Add <code>overflow-wrap: anywhere</code> for long agent names.</li>
         <li><strong>Note: this is an intentional deviation from the strict design-system rule that all stat values are neutral.</strong> Document the reasoning in a comment near the stat-card render.</li>
         <li>Date-range selector: replace <code>&lt;SelectControl&gt;</code> with chip-style segmented control (this IS filtering, chip pattern is correct).</li>
-        <li>Status banner: 4px green left-border + tiny shadow + 2px radius. Drop the redundant 1px outer border.</li>
+        <li><strong>Drop the success status banner entirely.</strong> A populated dashboard (chip-row, stat cards, recent orders) is the active-state signal; an explicit "AI Storefront is active" banner is redundant chrome and creates a visual conflict between a positive status signal at the top of the page and the destructive Disable affordance at the bottom. Remove the banner markup from <code>PostEnableView</code>; keep the <code>.notice</code> CSS pattern in case future warning/error notices use it.</li>
         <li><strong>Disable affordance</strong>:
           <ul>
-            <li>Strip the <code>&lt;Button&gt;</code> from the <code>PostEnableView</code> status banner, banner becomes purely informational.</li>
+            <li>With the success banner removed (see above), there is no banner button to relocate; the Disable lever sits exclusively at the bottom of the panel.</li>
             <li>After <code>&lt;AIOrdersTable /&gt;</code>, append <code>.disable-row</code> footer block (hairline divider top, two-column flex, label/description on the left, <code>.btn-danger-outline</code> Disable button on the right).</li>
             <li>Single click disables, keep the existing <code>onChange({ enabled: 'no' }); onSave();</code> chain unchanged. <strong>No confirmation modal</strong>, disabling is reversible (re-enable restores all settings). Confirmation friction would just train users to dismiss dialogs.</li>
             <li>Button uses standalone <code>class="btn-danger-outline"</code> (NOT composed with <code>class="btn"</code>, the <code>.btn</code> class hard-codes blue overrides that fight the red).</li>


### PR DESCRIPTION
## Summary

Two independent UI design reviewers converged on the same recommendation: remove the green "AI Storefront is active" banner from the post-enable view. Both cited the same principle ("don't narrate state the UI already shows") and the same external references (GitHub repo Settings Danger Zone, Stripe Dashboard).

The banner was creating a perceived disconnect: a positive status signal at the top of the page, separated by ~600px of dashboard content (chip-row, 7 stat cards, orders table) from the destructive Disable affordance at the bottom. Removing the banner dissolves the perceived split — there's nothing for the Disable footer to argue with.

## What changed

- **Mockup**: removed the `<div class="notice">` block with the "AI Storefront is active" message from the Overview post-enable panel. The `.notice` CSS rule stays (potential reuse for warnings/errors).
- **Tab 1 post-enable rationale paragraph**: updated to explain why the banner is gone.
- **Implementation Handoff section** (`settings-page.js` card):
  - Replaced "Status banner: tweak border/shadow" bullet with "Drop the success status banner entirely" bullet, including the design rationale.
  - Updated the Disable affordance sub-list to note that there is no banner button to relocate.

## What did NOT change

- Pre-enable hero is untouched.
- All other panels (Product visibility, Policies, Discovery) are unchanged.
- The `.notice` CSS pattern stays in the stylesheet for future use.

## Test plan

- [ ] CI passes
- [ ] Open `docs/design/settings-redesign-final.html` and verify the post-enable panel no longer has the green banner
- [ ] Verify the Implementation Handoff section's `settings-page.js` card reflects the new "drop the banner" guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)