### PR TITLE
fix: drop deprecated args from spl_autoload_register call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- **Removed PHP 8.3 deprecation notice from the autoloader.** The standalone `includes/autoload.php` was passing the now-no-op `$do_throw = false` argument to `spl_autoload_register()`, which PHP 8.3 surfaces as a deprecation notice on every CLI invocation. PHP 8.0 already made registration failure always throw regardless of this argument, so dropping it (along with the trailing default `$prepend = false`) is purely cosmetic. No behavior change.
+
 ### Refactors
 
 ### Tests

--- a/includes/autoload.php
+++ b/includes/autoload.php
@@ -47,7 +47,5 @@ spl_autoload_register(
 		if ( isset( $classmap[ $class_name ] ) ) {
 			require_once __DIR__ . $classmap[ $class_name ];
 		}
-	},
-	false, // do not throw on registration failure
-	false  // append, not prepend
+	}
 );


### PR DESCRIPTION
## Summary

`includes/autoload.php` was passing the second argument (`$do_throw = false`) to `spl_autoload_register()`. That argument has been a no-op since PHP 8.0 (registration failure always throws regardless), and PHP 8.3 surfaces a deprecation notice on every call. It was visible as

```
Notice: spl_autoload_register(): Argument #2 ($do_throw) has been ignored, spl_autoload_register() will always throw in /var/www/html/wp-content/plugins/woocommerce-ai-storefront/includes/autoload.php on line 19
```

on every `wp` invocation through the wp-env cli container.

## Change

Drop the second and third arguments. The third (`$prepend = false`) was already the default, so passing it explicitly added no information. The trailing line-comments are removed since they describe arguments that no longer exist.

```diff
-	},
-	false, // do not throw on registration failure
-	false  // append, not prepend
+	}
 );
```

No behavior change — `spl_autoload_register()` has thrown on registration failure unconditionally since PHP 8.0, and the closure is registered identically.

## Test plan

- [ ] `vendor/bin/phpcs includes/autoload.php` passes
- [ ] `vendor/bin/phpstan analyse includes/autoload.php --memory-limit=512M` passes
- [ ] `npm run env:cli -- plugin list --status=active` no longer prints the deprecation notice
- [ ] Plugin still autoloads on a fresh `npm run env:destroy && npm run env:start`

🤖 Generated with [Claude Code](https://claude.com/claude-code)