### PR TITLE
chore(admin): shorten sidebar menu label to "AI Storefront"

### DIFF
--- a/includes/class-wc-ai-storefront.php
+++ b/includes/class-wc-ai-storefront.php
@@ -314,7 +314,11 @@ class WC_AI_Storefront {
 			// tickets where the wp-admin chrome isn't visible.
 			// Match this exactly in render_admin_page() below.
 			__( 'Woo AI Storefront', 'woocommerce-ai-storefront' ),
-			__( 'Woo AI Storefront', 'woocommerce-ai-storefront' ),
+			// Menu title: shorter "AI Storefront" — the WooCommerce
+			// section already provides the "Woo" context in the
+			// sidebar, and the shorter form fits the cramped admin
+			// menu width without truncation.
+			__( 'AI Storefront', 'woocommerce-ai-storefront' ),
 			'manage_woocommerce',
 			'wc-ai-storefront',
 			[ $this, 'render_admin_page' ]

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-04-30T21:42:35+00:00\n"
+"POT-Creation-Date: 2026-04-30T21:48:54+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -296,9 +296,12 @@ msgid "Line item could not be processed."
 msgstr ""
 
 #: includes/class-wc-ai-storefront.php:316
-#: includes/class-wc-ai-storefront.php:317
-#: includes/class-wc-ai-storefront.php:329
+#: includes/class-wc-ai-storefront.php:333
 msgid "Woo AI Storefront"
+msgstr ""
+
+#: includes/class-wc-ai-storefront.php:321
+msgid "AI Storefront"
 msgstr ""
 
 #: woocommerce-ai-storefront.php:90


### PR DESCRIPTION
## Summary

Renames the WP admin sidebar nav label from **Woo AI Storefront** to **AI Storefront**.

The WooCommerce section already provides the "Woo" context in the sidebar, and the shorter form fits the cramped admin-menu width without truncation. The page title (`<title>` element) and the in-page `<h1>` remain "Woo AI Storefront" so the feature stays identifiable in screenshots and support tickets where the wp-admin chrome isn't visible.

`add_submenu_page()` takes `$page_title` and `$menu_title` as separate args precisely for this split — WC core uses the same pattern (e.g. "Marketing" sidebar → "WooCommerce marketing" page title).

## Test plan

- [ ] WP admin sidebar under WooCommerce shows "AI Storefront" instead of "Woo AI Storefront"
- [ ] Browser tab title on the settings page still reads "Woo AI Storefront"
- [ ] In-page `<h1>` still reads "Woo AI Storefront"

🤖 Generated with [Claude Code](https://claude.com/claude-code)