### PR TITLE
docs: refresh user guide and CHANGELOG for #229

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixes
 
+- **Overview tab fixes: pagination, new stat cards, mobile UX, Discovery tab responsiveness.** Recent AI Orders table moved to true server-side pagination -- the table now fetches only the current page rather than the full result set, with `page`, `orderby`, `order`, `search`, `agent`, and `status` params forwarded to the REST endpoint and real `totalItems`/`totalPages` returned. Two new stat cards: **AI Order Rate** (derived `ai_orders / all_orders` percentage; shows `0.0%` when orders exist but none are AI-attributed) and **AI Revenue** now shows a `$X / $Y` reference (revenue / total store revenue, no decimals on the denominator). The Products Exposed card now renders on a `surfaceSubtle` background to distinguish a configuration value from the performance stats below. Custom rate card: separate `customRpm` state prevents preset clicks from bleeding into the badge/input value. DataViews pagination row's `SelectControl` vertical alignment fixed via scoped CSS overrides. Discovery tab endpoints table is responsive at ≤600px (stacked grid layout, path-only URLs, redundant copy removed). Product visibility tab: badges wrap correctly at narrow widths; warning notice spacing fixed. Defensive fixes from review: `sanitize_text_field` on the status filter (preserves hyphens in `on-hold`); `enableSorting: false` on unsupported columns; status filter aligned with the PHP `$allowed_statuses` allow-list; `customRpm` initializer condition corrected. Closes #227. Refs #228, #229.
+
 ### Refactors
 
 ### Tests

--- a/docs/user-guide/USER-GUIDE.md
+++ b/docs/user-guide/USER-GUIDE.md
@@ -65,9 +65,10 @@ To pause, click **Disable AI Storefront** at the bottom of the page. Discovery e
 
 The Overview tab populates with stat cards once data flows in:
 
-- **Products exposed**: products AI agents can currently see (matches your visibility settings).
+- **Products exposed**: products AI agents can currently see (matches your visibility settings). Shown on a tinted background to distinguish a configuration value from the performance stats below.
 - **AI orders**: AI-attributed volume in the period, shown as `N / M` where M is the total orders denominator.
-- **AI revenue**: gross revenue from AI-referred orders.
+- **AI Order Rate**: percentage of all orders in the period that came from AI agents (`AI orders / all orders`). Shows `0.0%` when orders exist but none are AI-attributed.
+- **AI revenue**: gross revenue from AI-referred orders, shown as `$X / $Y` where Y is total store revenue in the period (no decimals on the denominator).
 - **AI AOV**: average order value from AI-referred orders.
 - **Top agent**: which agent drives the most AI volume.
 - **Top agent share**: what share of AI revenue the top agent represents.
@@ -214,7 +215,7 @@ The Discovery tab shows a reachability indicator in the card intro. The note "Re
 
 ![Overview tab per-agent stat cards](screenshots/11-per-agent-stats.png)
 
-**Recent AI Orders table** (Overview tab). The most recent AI-attributed orders with order number, date, status, agent, and total. Clicking the order number opens the WC order edit screen. Search, column-sort, and pagination controls are included.
+**Recent AI Orders table** (Overview tab). The most recent AI-attributed orders with order number, date, status, agent, and total. Clicking the order number opens the WC order edit screen. Search, column-sort, and pagination work server-side -- the table fetches only the current page, so large order volumes don't slow the Overview tab. Filters by **agent** and by **status** narrow the result set without leaving the table.
 
 ![Recent AI Orders table](screenshots/12-recent-ai-orders.png)
 


### PR DESCRIPTION
## Summary

Picks up the documentation tail from #229 (`fix(overview): DataViews pagination, stat cards, rate card, mobile UX, discovery tab`), which merged after the v0.8.0 release tag. Pure docs PR -- no code, no tests.

## Reflected changes

| Source | Doc updated |
|--------|-------------|
| #229 — Two new stat cards (AI Order Rate, AI Revenue with denominator) and Products Exposed background tint | `USER-GUIDE.md` section 3 stat-card list (now 7 entries) |
| #229 — Server-side pagination on Recent AI Orders table; agent + status filter params | `USER-GUIDE.md` section 8 "Recent AI Orders table" description |
| #229 — full PR scope (server-side pagination, stat cards, custom rate card, DataViews alignment, Discovery responsive, Product visibility mobile fixes, defensive review fixes) | `CHANGELOG.md` `[Unreleased]` Fixes entry |

## What's not in this PR

- **Mobile-responsive section in the user guide.** PR #229 did real mobile UX work (Discovery tab stacked layout at ≤600px, Product visibility badge wrap), but admin-UI mobile support is a baseline expectation. A dedicated user-guide section would over-emphasize it for a merchant-facing doc; the CHANGELOG entry captures the technical detail for contributors and support engineers.
- **Engineering doc updates.** #229 didn't change the surface area covered by ARCHITECTURE.md, TESTING.md, UI-CONVENTIONS.md, or CONTRIBUTING.md. Spot-checked.
- **Screenshot regeneration.** `screenshots/03-overview-cards.png` is now stale (6 cards visible vs. 7 in current UI), but per the v0.8.0 thread, screenshot regen is deferred to a post-release pass.

## Test plan

- [ ] CI green
- [ ] `docs/user-guide/USER-GUIDE.md` and `CHANGELOG.md` render cleanly in GitHub markdown view
- [ ] Spot-check the new "AI Order Rate" bullet renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)