### PR TITLE
docs: sync merchant + engineering docs for unified admin header (#238)

### DIFF
--- a/docs/engineering/UI-CONVENTIONS.md
+++ b/docs/engineering/UI-CONVENTIONS.md
@@ -100,7 +100,7 @@ The admin UI uses React components with inline `style={ ... }` props (no stylesh
 `tokens.js` exports five scales:
 
 - **`colors`** — semantic color tokens (`textPrimary`, `borderSubtle`, `infoBg`, `accent`, etc.). Mapped to WordPress admin palette values where possible.
-- **`typography`** — typed text variants (`eyebrowLabel`, `adminTitle`, `sectionHeading`, `statValue`, `heroHeadline`). Each entry bundles `fontSize`, `fontWeight`, `lineHeight`, and (where relevant) `letterSpacing` or `textTransform`. Spread directly into `style`.
+- **`typography`** — typed text variants (`eyebrowLabel`, `adminTitle`, `sectionHeading`, `statValue`, `heroHeadline`, `brandHeading`, `brandTagline`). Each entry bundles `fontSize`, `fontWeight`, `lineHeight`, and (where relevant) `letterSpacing` or `textTransform`. Spread directly into `style`. `brandHeading` (15px / 500 / lh 1.2) is the visible h2 in the unified page-header strip — sits one step below `sectionHeading` because the strip is decorative chrome, not the canonical title. `brandTagline` (13px / lh 1.4) is the line beneath it on the disabled/PreEnable state only; the tab nav replaces it once the plugin is enabled.
 - **`spacing`** — `s1` through `s10`, a modular scale.
 - **`radii`** — `xs`, `sm`, `md`, `lg`, `pill`.
 - **`shadows`** — `sm`, `lg`.

--- a/docs/user-guide/USER-GUIDE.md
+++ b/docs/user-guide/USER-GUIDE.md
@@ -40,7 +40,7 @@ You **don't** need an AI account, an API key, or a developer.
 
 ![Plugins screen with WooCommerce AI Storefront activated](screenshots/01-plugins-screen.png)
 
-A new menu item appears under **WooCommerce → AI Storefront** in the sidebar. (The page heading inside reads "Woo AI Storefront" -- the longer form is what you'll see on screenshots and in support tickets.) If you don't see it, confirm WooCommerce itself is active. AI Storefront depends on it.
+A new menu item appears under **WooCommerce → AI Storefront** in the sidebar. The page opens with a unified header strip — small Woo logo + the title "AI Storefront" — and the section nav (Overview, Visibility, Policies, Discovery) inline directly below in the same bordered strip. On the disabled state, a tagline ("List once. Sell everywhere AI shops.") sits beneath the title; once you enable the plugin, the nav takes the tagline's place. If you don't see the menu item, confirm WooCommerce itself is active. AI Storefront depends on it.
 
 ---
 
@@ -108,7 +108,7 @@ A working setup returns real product names with prices and links to your store w
 
 ## 5. Choose which products to expose
 
-The **Product visibility** tab controls what AI agents can see. Three modes:
+The **Visibility** tab controls what AI agents can see. Three modes:
 
 | Mode | What AI agents see | Use when |
 |------|--------------------|----------|
@@ -118,15 +118,15 @@ The **Product visibility** tab controls what AI agents can see. Three modes:
 
 **Steps:**
 
-1. Open the **Product visibility** tab.
+1. Open the **Visibility** tab.
 2. Pick the mode.
 3. For **Products by category, tag, or brand**, switch between the **Categories**, **Tags**, and **Brands** sub-tabs and check what you want included. The **Brands** sub-tab only appears if your store has a `product_brand` taxonomy registered (typically via WooCommerce Brands or a similar plugin); without one, you'll see only Categories and Tags. Taxonomies with 20+ terms have a search bar. Checkboxes render in a 2-column grid. The product-count pill updates live.
 4. For **Specific products only**, use the typeahead search box to find products by name or SKU. Click a match to add a chip; already-added items appear disabled with a checkmark. Chips show the product name and SKU.
 5. Click **Save changes** at the bottom-right.
 
-![Product visibility tab, by-taxonomy mode](screenshots/04-products-by-taxonomy.png)
+![Visibility tab, by-taxonomy mode](screenshots/04-products-by-taxonomy.png)
 
-![Product visibility tab, specific products mode](screenshots/05-products-selected.png)
+![Visibility tab, specific products mode](screenshots/05-products-selected.png)
 
 Visibility applies consistently across `/llms.txt`, the UCP catalog endpoints, and JSON-LD on product pages. Excluded products cannot be returned by an AI agent's catalog query; exclusion is enforced at the data layer, not by hiding links.
 


### PR DESCRIPTION
Brings `docs/user-guide/USER-GUIDE.md` and `docs/engineering/UI-CONVENTIONS.md` in sync with PR #238 (commit \`99cb784\`, closes #237).

## Summary
- **USER-GUIDE.md** — Updated the page-heading description to reflect the unified header (logo + title + tagline on disabled state; section nav inline below the title once enabled). Renamed "Product visibility" → "Visibility" in tab references, step instructions, and screenshot alt text.
- **UI-CONVENTIONS.md** — Added \`brandHeading\` (15px / 500 / lh 1.2) and \`brandTagline\` (13px / lh 1.4) to the typography token enumeration, with rationale on where each is used and why \`brandHeading\` sits below \`sectionHeading\`.

Surgical edits only — no new sections, no rewrites of unaffected prose.

## Stale screenshots flagged for human recapture

Alt text is now correct, but these PNGs still depict the old tab label and/or the previous header treatment:

- \`02-enable-toggle.png\` — disabled-state hero
- \`03-overview-cards.png\` — Overview tab (new header strip)
- \`04-products-by-taxonomy.png\` — Visibility tab (old "Product visibility" label visible)
- \`05-products-selected.png\` — same tab, specific-products mode
- \`06-discovery-tab.png\` — Discovery tab (new header)
- \`07-policies-tab.png\` — Policies tab (new header)
- \`09-endpoints-info.png\` — Discovery card (new header above)
- \`11-per-agent-stats.png\`, \`12-recent-ai-orders.png\` — Overview content (new header above)

\`08-product-final-sale.png\` and \`10-orders-origin.png\` are core WC screens, unaffected.

## Test plan

- [ ] Read both updated files to confirm tone matches surrounding prose
- [ ] Verify all "Product visibility" references in user-guide are gone (\`grep -i "product visibility" docs/\`)
- [ ] Confirm \`brandHeading\` / \`brandTagline\` callouts in UI-CONVENTIONS match the actual token definitions in \`tokens.js\`
- [ ] Recapture screenshots listed above (separate task)

🤖 Generated with [Claude Code](https://claude.com/claude-code)