### PR TITLE
docs(release): bullet format for CHANGELOG entries and release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,16 +18,42 @@
 
 ### Features
 
-- **Discovery tab — crawler-side visibility stats.** Two new tables back a Discovery analytics surface: `wc_ai_storefront_crawl_log` (raw events, 30-day rolling retention) and `wc_ai_storefront_crawl_summary` (daily aggregates, 90-day retention). The plugin now records every identified AI-agent request hitting llms.txt, the UCP manifest, the UCP REST surface, robots.txt, and the Store API rate limiter. Writes are buffered in a static pending array and flushed on `shutdown` so per-request latency is unchanged. Schema is created/upgraded via dbDelta on plugin version bump and dropped on uninstall (single-site and multisite). Two daily WP cron jobs handle pruning and rollup. New admin endpoint `GET /wc/v3/ai-storefront/admin/crawl-stats?period={day|week|month|quarter}` returns aggregated counts (total requests, unique products seen, Store API queries, llms.txt and UCP hits, throttle count and rate, breakdown by agent, top search queries with the agents that issued them); response cached for 5 minutes via transient. The Discovery tab in the admin UI surfaces this data — AI activity log, top searches, and products seen by AI crawlers. Closes #254 via #257.
-- **UCP product search — taxonomy-aware natural-language matching.** The Store API's default search builds a single phrase LIKE on `post_title`, which fails on natural-language AI queries like "Hoodie with logo" or "Running shoes for men" because product titles rarely contain the exact multi-word string. Inside UCP dispatch, the plugin now hooks `posts_clauses` at priority 9 (one tick before WooCommerce's `add_query_clauses` at priority 10) and replaces the phrase LIKE with per-signal-term clauses. Each signal term is resolved against the store's own `product_cat`, `product_tag`, `product_brand`, and `pa_*` attribute taxonomies via two scoped `get_terms()` calls (`name__in` + `slug__in`, merged by term_id) plus a suffix-flip dictionary covering the most common English plural/singular morphology (`ies↔y`, `{ch,sh,x,s,z}es↔base`, `s↔drop`, `y→ies`, `+es`, `+s`). Taxonomy hits emit an EXISTS subquery scoped by `taxonomy IN (...)` to prevent false positives from WordPress sharing `term_id` values across unrelated taxonomies; misses fall through to a title LIKE expanded to both morphological forms (so "hoodies" also searches `%hoodie%`). Clauses combine OR per signal term and AND across all signal terms, preserving the merchant's syndication scope. Punctuation handling: apostrophes stripped in-place (`women's` → `womens`), hyphens and slashes split into separate tokens (`mid-layer` → `mid layer`). Only fires inside UCP dispatch on product queries — storefront, Cart, Checkout, and any non-product `WP_Query` inside dispatch are unaffected. Closes #255 via #256.
+- **Discovery tab — crawler-side visibility stats.** Closes #254 via #257.
+  - Two new tables: `wc_ai_storefront_crawl_log` (raw events, 30-day rolling retention) and `wc_ai_storefront_crawl_summary` (daily aggregates, 90-day retention).
+  - Records every identified AI-agent request hitting llms.txt, the UCP manifest, the UCP REST surface, robots.txt, and the Store API rate limiter.
+  - Writes are buffered in a static pending array and flushed on `shutdown` so per-request latency is unchanged.
+  - Schema created/upgraded via dbDelta on plugin version bump; dropped on uninstall (single-site and multisite).
+  - Two daily WP cron jobs handle pruning and rollup.
+  - New admin endpoint `GET /wc/v3/ai-storefront/admin/crawl-stats?period={day|week|month|quarter}` returns aggregated counts (total requests, unique products seen, Store API queries, llms.txt and UCP hits, throttle count and rate, breakdown by agent, top search queries with the agents that issued them). Response cached for 5 minutes via transient.
+  - The Discovery tab in the admin UI surfaces this data — AI activity log, top searches, and products seen by AI crawlers.
+
+- **UCP product search — taxonomy-aware natural-language matching.** Closes #255 via #256.
+  - The Store API's default search builds a single phrase LIKE on `post_title`, which fails on natural-language AI queries like "Hoodie with logo" or "Running shoes for men" because product titles rarely contain the exact multi-word string.
+  - Inside UCP dispatch, the plugin now hooks `posts_clauses` at priority 9 (one tick before WooCommerce's `add_query_clauses` at priority 10) and replaces the phrase LIKE with per-signal-term clauses.
+  - Each signal term is resolved against the store's own `product_cat`, `product_tag`, `product_brand`, and `pa_*` attribute taxonomies via two scoped `get_terms()` calls (`name__in` + `slug__in`, merged by term_id).
+  - A suffix-flip dictionary covers the most common English plural/singular morphology: `ies↔y`, `{ch,sh,x,s,z}es↔base`, `s↔drop`, `y→ies`, `+es`, `+s`.
+  - Taxonomy hits emit an EXISTS subquery scoped by `taxonomy IN (...)` to prevent false positives from WordPress sharing `term_id` values across unrelated taxonomies.
+  - Misses fall through to a title LIKE expanded to both morphological forms (so "hoodies" also searches `%hoodie%`).
+  - Clauses combine OR per signal term and AND across all signal terms, preserving the merchant's syndication scope.
+  - Punctuation handling: apostrophes stripped in-place (`women's` → `womens`), hyphens and slashes split into separate tokens (`mid-layer` → `mid layer`).
+  - Only fires inside UCP dispatch on product queries — storefront, Cart, Checkout, and any non-product `WP_Query` inside dispatch are unaffected.
 
 ### Fixes
 
-- **Updater — `WC_AI_STOREFRONT_GITHUB_TOKEN` PHP constant for internal-repo authentication.** The repo is internal on GitHub, so unauthenticated update-check API calls return 404 from inside `wp-env`. The updater now reads `WC_AI_STOREFRONT_GITHUB_TOKEN` as the filter default; the existing `wc_ai_storefront_github_token` filter still takes precedence so production sites that pass the token through Application Passwords or another secret manager are unchanged. Adds `.wp-env.override.json.example` as a template for local-development token setup; `.wp-env.override.json` is gitignored.
+- **Updater — `WC_AI_STOREFRONT_GITHUB_TOKEN` PHP constant for internal-repo authentication.**
+  - The repo is internal on GitHub, so unauthenticated update-check API calls return 404 from inside `wp-env`.
+  - The updater now reads `WC_AI_STOREFRONT_GITHUB_TOKEN` as the filter default; the existing `wc_ai_storefront_github_token` filter still takes precedence, so production sites that pass the token through Application Passwords or another secret manager are unchanged.
+  - Adds `.wp-env.override.json.example` as a template for local-development token setup; `.wp-env.override.json` is gitignored.
 
 ### Docs
 
-- **Engineering and merchant docs synced for 0.8.6.** DATA-MODEL gains a Custom tables section documenting the two crawl-log tables, their retention, and the new daily cron jobs; ARCHITECTURE adds a Crawler analytics section and expands the UCP store-api-filter description with the `posts_clauses` preprocessor; API-REFERENCE documents the new `GET /admin/crawl-stats` endpoint and notes the taxonomy-aware preprocessing on `POST /catalog/search`; UCP-BUY-FLOW updates Layer 2 catalog filtering; USER-GUIDE adds an AI activity log subsection to the Discovery tab section. AGENTS.md path-impact map and the docs-followup workflow YAML both gain a row for the new `crawl-logger.php` file. Closes #258.
+- **Engineering and merchant docs synced for 0.8.6.** Closes #258.
+  - **DATA-MODEL**: new Custom tables section documenting the two crawl-log tables, their retention, and the new daily cron jobs.
+  - **ARCHITECTURE**: new Crawler analytics section; expanded UCP store-api-filter description with the `posts_clauses` preprocessor.
+  - **API-REFERENCE**: documents the new `GET /admin/crawl-stats` endpoint and notes the taxonomy-aware preprocessing on `POST /catalog/search`.
+  - **UCP-BUY-FLOW**: Layer 2 catalog filtering updated.
+  - **USER-GUIDE**: new AI activity log subsection in the Discovery tab section.
+  - **AGENTS.md** path-impact map and the docs-followup workflow YAML both gain a row for the new `crawl-logger.php` file.
 
 ---
 

--- a/docs/engineering/RELEASE.md
+++ b/docs/engineering/RELEASE.md
@@ -124,10 +124,17 @@ We maintain two changelogs:
 ## [0.7.0] – 2026-05-12
 
 ### Features
-- **Title-case headline.** Body paragraph explaining what changed, why, and any merchant-facing implication. Code references in backticks. Closes #issue.
+
+- **Title-case headline.** Closes #issue.
+  - First detail bullet — what changed.
+  - Second detail bullet — why it changed or what tradeoff was made.
+  - Third detail bullet — merchant-facing impact, scope, or limitations.
 
 ### Fixes
-- **Title-case headline.** Body paragraph.
+
+- **Title-case headline.** Closes #issue.
+  - First detail bullet.
+  - Second detail bullet.
 
 ---
 
@@ -140,9 +147,12 @@ Conventions:
 - `## [X.Y.Z] – YYYY-MM-DD` for each released version. ISO date. En-dash separator.
 - `## [Unreleased]` block at the top accumulates entries between releases. Move under the next version header on release.
 - Subsections in this fixed order: `### Features`, `### Fixes`, `### Refactors`, `### Tests`, `### Docs`. Omit empty subsections.
-- Each entry: a bolded title sentence, then a body paragraph. Body explains _what_, _why_, and _impact_. Reference issue/PR numbers (`Closes #123`, `Addressed by #124`).
-- No truncation — long entries are fine. The CHANGELOG is for engineering memory and incident triage, not marketing.
+- Each entry uses **bold-headline + nested-bullets** format, not bold-headline + long-paragraph. The headline is one short bolded sentence (with the issue/PR reference appended, e.g. `Closes #N.`). Each subsequent fact gets its own nested bullet (2-space indent). This reads on GitHub's release page, in `gh release view`, and in the rendered CHANGELOG without forcing readers to parse a wall of prose.
+- Detail bullets explain _what_, _why_, and _impact_. Reference issue/PR numbers in the headline, not in every nested bullet.
+- No truncation — long entries are fine. Use as many nested bullets as the change deserves. The CHANGELOG is for engineering memory and incident triage, not marketing.
 - `---` separator between versions.
+
+This format also flows directly into GitHub release notes — the release-extraction step (`awk '/## \[X.Y.Z\]/,/^---$/' CHANGELOG.md`) copies the same Markdown verbatim, so the bullets render the same way on the Release page.
 
 ### `readme.txt` `== Changelog ==` format
 


### PR DESCRIPTION
## Summary

- **RELEASE.md** — updated the format spec so each entry is a bold-headline + nested-bullets, not bold-headline + long-paragraph. Adds rationale (release-extraction `awk` script copies the CHANGELOG verbatim, so the same format flows into the GitHub release page).
- **CHANGELOG.md** — reformats the 0.8.6 entry to the new format. Pre-0.8.6 entries stay in their old paragraph format on purpose; the convention applies going forward.

## Why

Long paragraphs on the GitHub release page are unscannable. Splitting each fact into its own nested bullet lets readers skim what changed without parsing prose.

The published v0.8.6 GitHub Release was already updated to this format earlier today; this PR just bakes the convention into the docs and the source CHANGELOG so future releases match.

## Test plan

- [x] Doc-only change. No code touched.
- [ ] Reviewer skim: does the new format example in RELEASE.md make the convention clear?
- [ ] Reviewer skim: does the reformatted 0.8.6 CHANGELOG entry read better than the prior paragraph form?

🤖 Generated with [Claude Code](https://claude.com/claude-code)