### PR TITLE
docs: sync unreleased docs for #261 (hourly rollup cron)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,7 +136,7 @@ When you change a code file, update the corresponding doc(s) in the same PR. The
 | `includes/ai-storefront/class-wc-ai-storefront-robots.php` | ARCHITECTURE.md, HOOKS.md, USER-GUIDE.md |
 | `includes/ai-storefront/class-wc-ai-storefront-store-api-rate-limiter.php` | ARCHITECTURE.md, USER-GUIDE.md |
 | `includes/ai-storefront/class-wc-ai-storefront-cache-invalidator.php` | DATA-MODEL.md, ARCHITECTURE.md |
-| `includes/ai-storefront/class-wc-ai-storefront-crawl-logger.php` | DATA-MODEL.md, ARCHITECTURE.md, API-REFERENCE.md, USER-GUIDE.md |
+| `includes/ai-storefront/class-wc-ai-storefront-crawl-logger.php` | DATA-MODEL.md, ARCHITECTURE.md, API-REFERENCE.md, USER-GUIDE.md, HOOKS.md |
 | `includes/ai-storefront/class-wc-ai-storefront-logger.php` | HOOKS.md |
 | `includes/ai-storefront/class-wc-ai-storefront-return-policy.php` | DATA-MODEL.md, USER-GUIDE.md |
 | `includes/admin/class-wc-ai-storefront-product-meta-box.php` | DATA-MODEL.md, USER-GUIDE.md |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,22 +4,53 @@
 
 ### Features
 
-- **Discovery stats — hourly rollup cron with developer interval filter.** The crawl-log rollup cron now runs hourly instead of daily, so today's AI agent activity appears in the Discovery tab within ~1 hour of occurring. A new `wc_ai_storefront_rollup_interval` filter lets developers change the recurrence to `hourly`, `twicedaily`, or `daily` — slower cadences are rejected because `rollup()` only covers a 2-day window and would silently lose data. Invalid slugs and intervals slower than `daily` fall back to `hourly`. The top-searches query no longer excludes today's rows, so the full rolling window is always visible. Closes #260 via #261.
+- **Discovery stats — hourly rollup cron with developer interval filter.** Closes #260 via #261.
+  - The crawl-log rollup cron now runs hourly instead of daily, so today's AI agent activity appears in the Discovery tab within ~1 hour of occurring.
+  - New `wc_ai_storefront_rollup_interval` filter lets developers change the recurrence to `hourly`, `twicedaily`, or `daily`. Slower cadences are rejected because `rollup()` only covers a 2-day window and would silently lose data; invalid slugs fall back to `hourly`.
+  - `schedule_crons()` runs on every request (not just admin) and auto-migrates an existing event whose recurrence no longer matches the filtered value, so filter changes take effect on the very next request without manual `wp cron` intervention. A re-read pattern after `wp_clear_scheduled_hook()` prevents duplicate events when the clear silently fails.
+  - The top-searches SQL no longer excludes today's rows, so the full rolling window is always visible.
+  - The Discovery tab subtitle adapts to the live cadence: "Updated hourly." / "Updated every 12 hours." / "Updated daily." (with "Updated periodically." as a fallback for unknown values).
 
 ### Fixes
 
+- **`/crawl-stats` — `rollup_interval` is now live, not cached.**
+  - Previously `rollup_interval` was baked into the 5-minute crawl-stats transient, so a filter change wouldn't show up in the Discovery subtitle until the cache expired or the next rollup ran. This defeated the "takes effect on the next request" contract for the new filter.
+  - The field is now excluded from the transient and injected live on every response — both the cache-hit path and the fresh-computation path call `get_effective_rollup_interval()` after `set_transient()`.
+
+- **`/crawl-stats` — `raw_event_count` field for pre-rollup empty-state suppression.**
+  - The Discovery empty state ("No AI agent activity recorded…") would render even when raw-log traffic existed but the first rollup hadn't run yet — a brand-new install with llms.txt or UCP hits but no search queries would falsely look idle.
+  - The `/crawl-stats` response now includes a new `raw_event_count` field that runs `COUNT(*)` on the raw log directly (live, never cached). The empty-state guard checks all three signals — `total_requests`, `top_queries`, and `raw_event_count` — before rendering, so any kind of raw activity suppresses it.
+
 - **Top searches — clamp lookback to raw-log retention.** `top_queries` reads from the raw log (query strings aren't aggregated into the summary table), and the raw log retains only 30 days. For `period=quarter` the SQL would previously ask for 90 days back but receive at most 30, creating an internal inconsistency between the search list and the rest of the card. The lower bound is now clamped to `min(period_days, RAW_RETENTION_DAYS=30)`, the response surfaces a new `top_queries_window_days` field, and the UI labels the effective window when it differs from the selected period.
+
+- **`get_crawl_stats()` — period-window off-by-one.** The lower bound was computed as `time() - N * DAY_IN_SECONDS`, which floored to a mid-day timestamp and combined with the open-ended upper bound to span N+1 calendar dates. The window now anchors to today's midnight and counts back `(N - 1)` full days, so each period covers exactly N calendar dates inclusive of today.
 
 ### Refactors
 
+- **`get_effective_rollup_interval()` — single source of truth for the recurrence slug.** Extracted the allowlist-validated, filter-aware interval resolution into a new public static helper on `WC_AI_Storefront_Crawl_Logger`. Both `schedule_crons()` (cron registration) and `get_crawl_stats()` (REST response) call this helper, so they cannot disagree about what "the effective rollup interval" is.
+
+- **JS — pure helpers extracted from `endpoint-info.js`.** `getRollupIntervalLabel(interval)` (slug → localised "Updated X." subtitle) and `shouldShowCrawlStatsEmptyState(crawlStats, isLoading, error)` are now exported pure functions, unit-tested independently of the React render tree.
+
 ### Tests
 
-- **`schedule_crons()` covered by four Brain Monkey unit tests.** New tests assert the default `hourly` interval (and the rollup's first-fire timestamp is now, not midnight), that a valid filter override (`twicedaily`) is respected, that an invalid filter value (`gibberish`) falls back to `hourly`, and that registered-but-too-slow intervals (`weekly`) are rejected. Each test asserts the filter hook tag and default argument so a regression in the hook contract is caught. Each test uses `@runInSeparateProcess` to avoid the one-shot static guard inside `schedule_crons()`.
-- **`get_crawl_stats()` top_queries SQL contract.** New `AdminCrawlStatsTest` pins two contracts: the SQL must use only a lower-bound date filter (no `crawled_at < %s` upper bound), and the lower-bound timestamp for `period=quarter` must be clamped to ~30 days back so the parameter matches the raw log's actual retention.
+- **`schedule_crons()` covered by six Brain Monkey unit tests.** Asserts: default `hourly` interval (with rollup's first-fire timestamp set to now, not midnight); valid filter override (`twicedaily`) is respected; invalid filter value (`gibberish`) falls back to `hourly`; registered-but-too-slow intervals (`weekly`) are rejected; an existing event with the wrong recurrence is auto-migrated on the next run; if `wp_clear_scheduled_hook()` silently fails, no duplicate event is registered. Each test asserts the filter hook tag and default argument so a regression in the hook contract is caught, and each uses `@runInSeparateProcess` to bypass the one-shot static guard inside `schedule_crons()`.
+
+- **`get_effective_rollup_interval()` — three direct unit tests.** Verifies the default value, that a valid filter override is propagated, and that an invalid value falls back to `hourly`.
+
+- **`AdminCrawlStatsTest` — four tests pin the `/crawl-stats` SQL and response contracts.** The top_queries SQL must use only a lower-bound date filter (no `crawled_at < %s` upper bound); the lower-bound timestamp for `period=quarter` must be clamped to ~30 days back so the parameter matches the raw log's retention; the response must include `rollup_interval` reflecting the filtered value; the response must include `raw_event_count`.
+
+- **`CrawlLoggerTest` — `crawl_date` per-day SQL contract.** New test pins that the rollup SQL uses `DATE(crawled_at) AS crawl_date` in both SELECT and GROUP BY so yesterday's and today's rows materialize as separate `crawl_date` values rather than collapsing into one row.
+
+- **JS — eleven tests across `shouldShowCrawlStatsEmptyState` and `getRollupIntervalLabel`.** Covers all empty-state suppression paths (loading, error, non-zero `total_requests`, populated `top_queries`, non-zero `raw_event_count`) and all label mappings (`hourly`, `twicedaily`, `daily`, fallback).
 
 ### Docs
 
-- **Engineering and merchant docs synced for #261.** `DATA-MODEL.md` updated: rollup runs hourly by default (configurable via filter), GROUP BY description includes `product_id`, auto-migration note added. `HOOKS.md` gains a `wc_ai_storefront_rollup_interval` filter entry with usage examples and notes that filter changes take effect on the next page load. `ARCHITECTURE.md` updated to reflect the configurable rollup cadence. `USER-GUIDE.md` updated: "Stats refresh on every rollup run (hourly by default) — today's traffic appears in the dashboard within one rollup cycle of occurring."
+- **Engineering and merchant docs synced for #261.**
+  - `HOOKS.md` — `wc_ai_storefront_rollup_interval` filter entry with usage example, allowlist rationale, and the corrected note that the filter takes effect on the very next request (not just admin requests).
+  - `DATA-MODEL.md` — rollup runs hourly by default (configurable via filter); auto-migration note clarifies that `schedule_crons()` runs on every request, not only admin.
+  - `API-REFERENCE.md` — new `raw_event_count` field, expanded `rollup_interval` description, and explicit cache contract: rolled-up aggregates cached 5 min, `raw_event_count` and `rollup_interval` queried live on every response.
+  - `ARCHITECTURE.md` — configurable rollup cadence reflected in the analytics overview.
+  - `USER-GUIDE.md` — stats refresh hourly by default; today's traffic appears within one rollup cycle.
 
 ---
 

--- a/docs/engineering/API-REFERENCE.md
+++ b/docs/engineering/API-REFERENCE.md
@@ -377,7 +377,7 @@ Discovery endpoint URLs for the Discovery tab.
 
 ### `GET /crawl-stats`
 
-Aggregated crawler-visibility stats for the Discovery tab. Reads from the summary table (`{prefix}wc_ai_storefront_crawl_summary`) — refreshed on every rollup run (hourly by default, overridable via the `wc_ai_storefront_rollup_interval` filter). Today's in-progress events appear within one rollup cycle. Response is cached for 5 minutes via the `wc_ai_storefront_crawl_stats_{period}` transient.
+Aggregated crawler-visibility stats for the Discovery tab. Reads from the summary table (`{prefix}wc_ai_storefront_crawl_summary`) — refreshed on every rollup run (hourly by default, overridable via the `wc_ai_storefront_rollup_interval` filter). Today's in-progress events appear within one rollup cycle. The rolled-up aggregates are cached for 5 minutes via the `wc_ai_storefront_crawl_stats_{period}` transient. Two fields — `rollup_interval` and `raw_event_count` — are explicitly excluded from the transient and queried live on every response so a filter change or a fresh raw-log hit takes effect immediately, without waiting for the cache to expire.
 
 **Query params:**
 
@@ -407,6 +407,7 @@ Aggregated crawler-visibility stats for the Discovery tab. Reads from the summar
     { "query": "hoodies",       "count": 31, "agents": ["ChatGPT"] }
   ],
   "top_queries_window_days": 30,
+  "raw_event_count": 12891,
   "rollup_interval": "hourly"
 }
 ```
@@ -415,7 +416,9 @@ Aggregated crawler-visibility stats for the Discovery tab. Reads from the summar
 
 `top_queries_window_days` is the effective lookback for `top_queries` (always `min(period_days, RAW_RETENTION_DAYS=30)`). Top searches read from the raw log (query strings aren't aggregated into the summary table), and the raw log retains only 30 days, so for `period=quarter` (90d) this value is `30` while every other field reflects the full 90-day period.
 
-`rollup_interval` is the validated cron recurrence slug currently in use: one of `"hourly"` (default), `"twicedaily"`, or `"daily"`. This is the value returned by `WC_AI_Storefront_Crawl_Logger::get_effective_rollup_interval()` — the same logic used by `schedule_crons()`. Clients use this to render a specific subtitle ("Updated hourly.", "Updated every 12 hours.", "Updated daily.") rather than a generic fallback.
+`raw_event_count` is `COUNT(*)` over the raw log (`{prefix}wc_ai_storefront_crawl_log`) for the requested period. This field is **not cached** — it runs on every response, before the transient cache check, so brand-new traffic (llms.txt, UCP, product-page hits) becomes visible immediately even if the rollup hasn't fired yet. The Discovery tab's empty-state guard checks this in addition to `total_requests` and `top_queries`, so a fresh install that already has raw activity doesn't falsely render "no AI agent activity recorded".
+
+`rollup_interval` is the validated cron recurrence slug currently in use: one of `"hourly"` (default), `"twicedaily"`, or `"daily"`. This is the value returned by `WC_AI_Storefront_Crawl_Logger::get_effective_rollup_interval()` — the same logic used by `schedule_crons()`. Like `raw_event_count`, this field is **not cached** in the transient — it's injected live on every response (cache-hit and fresh paths alike) so a `wc_ai_storefront_rollup_interval` filter change is reflected on the very next request. Clients use this to render a specific subtitle ("Updated hourly.", "Updated every 12 hours.", "Updated daily.") rather than a generic fallback.
 
 ---
 

--- a/docs/engineering/DATA-MODEL.md
+++ b/docs/engineering/DATA-MODEL.md
@@ -323,7 +323,7 @@ Daily cron that deletes raw log rows older than `RAW_RETENTION_DAYS` (30) and su
 
 Hourly cron that rolls yesterday's and today's raw log into the summary table, keeping stats within ~1 hour of real-time.
 
-- **Schedule:** `hourly` by default. Override with the `wc_ai_storefront_rollup_interval` filter; allowed values are `hourly`, `twicedaily`, and `daily` — only these three cadences are safe within the 2-day rollup window. Any other value silently falls back to `hourly`. `schedule_crons()` compares the existing event's recurrence to the filtered value on every admin request and auto-migrates mismatches, so filter changes take effect on the next page load without manual intervention.
+- **Schedule:** `hourly` by default. Override with the `wc_ai_storefront_rollup_interval` filter; allowed values are `hourly`, `twicedaily`, and `daily` — only these three cadences are safe within the 2-day rollup window. Any other value silently falls back to `hourly`. `schedule_crons()` runs on every request (it's wired into plugin bootstrap, not gated to admin), so each request compares the existing event's recurrence to the filtered value and auto-migrates mismatches. Filter changes therefore take effect on the very next request — no manual `wp cron` commands needed.
 - **Defined in:** `WC_AI_Storefront_Crawl_Logger`
 - **Uninstall:** cleared by `uninstall.php`
 

--- a/docs/engineering/HOOKS.md
+++ b/docs/engineering/HOOKS.md
@@ -310,7 +310,7 @@ apply_filters( 'wc_ai_storefront_rollup_interval', string $interval );
 
 **When to use:** high-traffic stores that want to reduce DB load (`'twicedaily'` or `'daily'`), or to keep the default `'hourly'` cadence on low-traffic stores.
 
-**Applying a change:** `schedule_crons()` compares the existing event's recurrence to the filtered value on every admin request and automatically clears and re-registers the event when they differ. Filter changes take effect on the next page load — no manual `wp cron` commands needed.
+**Applying a change:** `schedule_crons()` runs unconditionally during plugin bootstrap (via `WC_AI_Storefront::init_components()`), so it executes on every WordPress request — admin or front-end. On each call it compares the existing event's recurrence to the filtered value and automatically clears and re-registers the event when they differ. Filter changes therefore take effect on the very next request without any manual `wp cron` commands. The `/crawl-stats` REST response also surfaces the live `rollup_interval` value (never cached in the transient), so the Discovery tab subtitle reflects the current cadence on the next refresh.
 
 **Example — switch to twice-daily rollup:**
 


### PR DESCRIPTION
## Summary

Doc-only sweep across the unreleased delta from v0.8.6. The implementation in #261 has stabilized; this PR catches the docs up to it.

Two PRs sit between v0.8.6 and main:
- #259 — CHANGELOG/release-notes bullet-format change (already merged)
- #261 — hourly rollup cron + interval filter (merged in 678900a)

## Changes

**CHANGELOG.md** — Replaced the early single-paragraph #261 entry with a complete bullet breakdown matching the #259 format. Specifically:
- Test counts corrected: `schedule_crons()` is covered by 6 tests (was 4), `AdminCrawlStatsTest` pins 4 contracts (was 2), plus the `crawl_date` per-day SQL contract test in `CrawlLoggerTest` and 3 direct tests for `get_effective_rollup_interval()`.
- Added the `rollup_interval`-live-not-cached fix.
- Added the `raw_event_count` empty-state fix.
- Added the period-window off-by-one fix.
- Added the `get_effective_rollup_interval()` refactor and the JS pure-helper extraction (`getRollupIntervalLabel`, `shouldShowCrawlStatsEmptyState`).

**HOOKS.md, DATA-MODEL.md** — Fixed the "every admin request" wording that Copilot flagged across three review iterations. `schedule_crons()` runs on every request (admin and front-end) because it's wired into plugin bootstrap, so filter changes take effect on the very next request — not only after an admin hit.

**API-REFERENCE.md** — Added `raw_event_count` to the example `/crawl-stats` response and documented the cache contract: rolled-up aggregates cached 5 min via the `wc_ai_storefront_crawl_stats_{period}` transient; `raw_event_count` and `rollup_interval` queried live on every response so fresh raw-log traffic and filter changes apply immediately.

**AGENTS.md** — Added `HOOKS.md` to the `crawl-logger.php` path-impact row since that file defines the `wc_ai_storefront_rollup_interval` filter.

## Test plan

- [ ] CI green (no PHP/JS changes — should pass trivially: PHPCS, PHPStan, PHP/JS test suites all pass)
- [ ] i18n .pot freshness check passes (no translatable string changes in this PR)
- [ ] CHANGELOG renders correctly on GitHub
- [ ] Linked anchors in API-REFERENCE.md still resolve (no heading renames here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)