### PR TITLE
fix(llms.txt): announce UCP API instead of raw Store API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@
 
 ### Fixes
 
+- **`/llms.txt` now announces the UCP API instead of the raw Store API.** Closes #271.
+  - The "API Access" section was pointing AI agents at `/wp-json/wc/store/v1` (WooCommerce's raw Store API), which bypasses the UCP layer's agent fingerprinting, rate limiting, and access control.
+  - Now announces `/wp-json/wc/ucp/v1` (the plugin's purpose-built UCP REST surface) as the AI-agent front door, paired with the existing `/.well-known/ucp` Commerce Protocol Manifest.
+  - Stale comment in the generator that claimed the plugin "does NOT expose its own authenticated API" updated to describe the actual UCP-on-top-of-Store-API architecture.
+  - Pinned test renamed from `test_api_access_section_points_to_store_api_and_ucp` to `test_api_access_section_points_to_ucp_api_and_manifest`; new regression guard asserts `wc/store/v1` does NOT appear in the output so a future change can't quietly re-announce it.
+
 - **Discovery tab — relabel "UCP API hits" to "UCP manifest hits".** The card was summing `ENDPOINT_UCP` events, which only fire when an agent reads the static `/.well-known/ucp` manifest — not when it calls the UCP REST surface (`catalog/search`, `catalog/lookup`). Those calls are recorded under `ENDPOINT_STORE_API_*` and roll up into the "Catalog queries" card. The previous label suggested API traffic was being counted, which led merchants to read a 0 there as "no UCP API activity" when it really meant "no fresh manifest fetches". The label now matches what the field counts, parallel to the adjacent "llms.txt hits" card. Underlying API field name (`ucp_hits`) and recording behavior are unchanged.
 
 ### Refactors

--- a/includes/ai-storefront/class-wc-ai-storefront-llms-txt.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-llms-txt.php
@@ -330,22 +330,27 @@ class WC_AI_Storefront_Llms_Txt {
 		$lines[] = "- **Currency**: {$currency}";
 		$lines[] = '';
 
-		// API access. This plugin does NOT expose its own authenticated
-		// API — AI agents use WooCommerce's public Store API directly.
-		// The UCP manifest describes capabilities + store_context in
-		// machine-readable form; agents that want structured data
-		// fetch that document.
+		// API access. This plugin's AI-agent front door is the UCP REST
+		// surface at `/wp-json/wc/ucp/v1/` — a normalized commerce
+		// protocol that wraps the underlying WooCommerce Store API with
+		// agent fingerprinting, rate limiting, access control, and the
+		// shapes UCP-aware agents expect. The raw Store API is what
+		// UCP is built on but is not the surface we announce here:
+		// pointing agents at it bypasses the protections and structured
+		// shapes the UCP layer adds.
 		//
-		// Description text kept tight — agents use the Store API +
-		// UCP manifest directly; don't advertise anything the
-		// manifest no longer carries.
-		$lines[]   = '## API Access';
-		$lines[]   = '';
-		$store_api = rest_url( 'wc/store/v1' );
-		$ucp_url   = $site_url . '.well-known/ucp';
-		$lines[]   = "- **Store API**: `{$store_api}` — public WooCommerce Store API for product search and cart operations (no authentication required)";
-		$lines[]   = "- **Commerce Protocol Manifest**: `{$ucp_url}` — declares capabilities, checkout policy, and store_context (currency, locale, country, tax/shipping posture)";
-		$lines[]   = '';
+		// The Commerce Protocol Manifest at `/.well-known/ucp` is the
+		// capability-discovery document agents read first to learn
+		// what the store supports (search, lookup, checkout) and the
+		// store_context (currency, locale, country, tax/shipping
+		// posture).
+		$lines[] = '## API Access';
+		$lines[] = '';
+		$ucp_api = rest_url( 'wc/ucp/v1' );
+		$ucp_url = $site_url . '.well-known/ucp';
+		$lines[] = "- **UCP API**: `{$ucp_api}` — Universal Commerce Protocol endpoints for product search, lookup, and checkout (no authentication required for public catalog reads)";
+		$lines[] = "- **Commerce Protocol Manifest**: `{$ucp_url}` — declares capabilities, checkout policy, and store_context (currency, locale, country, tax/shipping posture)";
+		$lines[] = '';
 
 		// Sitemaps section. Surfaces exhaustive URL enumeration
 		// paths for agents doing deep catalog discovery — parallel

--- a/tests/php/unit/LlmsTxtTest.php
+++ b/tests/php/unit/LlmsTxtTest.php
@@ -154,19 +154,30 @@ class LlmsTxtTest extends \PHPUnit\Framework\TestCase {
 		$this->assertStringContainsString( '## Attribution', $output );
 	}
 
-	public function test_api_access_section_points_to_store_api_and_ucp(): void {
-		// The plugin does NOT expose its own authenticated API. llms.txt
-		// must advertise WooCommerce's public Store API and the UCP
-		// manifest — NOT the removed `wc/v3/ai-storefront/*` endpoints
-		// or the `X-AI-Agent-Key` header (both existed in a pre-1.0
-		// draft of the architecture).
+	public function test_api_access_section_points_to_ucp_api_and_manifest(): void {
+		// The plugin's AI-agent front door is the UCP REST surface at
+		// `/wp-json/wc/ucp/v1/` — a normalized commerce protocol that
+		// wraps the underlying WooCommerce Store API with agent
+		// fingerprinting, rate limiting, and structured shapes. llms.txt
+		// must advertise the UCP API and the Commerce Protocol Manifest
+		// — NOT the raw Store API (which UCP is built on but isn't the
+		// agent-facing surface), NOT the removed `wc/v3/ai-storefront/*`
+		// endpoints, and NOT the `X-AI-Agent-Key` header (both existed
+		// in a pre-1.0 draft of the architecture).
 		$output = $this->llms->generate();
 
 		// Correct endpoints advertised.
-		$this->assertStringContainsString( 'wc/store/v1', $output );
+		$this->assertStringContainsString( 'wc/ucp/v1', $output );
 		$this->assertStringContainsString( '.well-known/ucp', $output );
 
-		// Regression guard: the deleted endpoints must NEVER appear again.
+		// Regression guard: the raw Store API was previously announced
+		// here. Pointing agents at it bypasses the UCP layer's agent
+		// fingerprinting, rate limiting, and access control. Don't
+		// re-announce it.
+		$this->assertStringNotContainsString( 'wc/store/v1', $output );
+
+		// Regression guard: the deleted pre-1.0 endpoints/headers must
+		// NEVER appear again.
 		$this->assertStringNotContainsString( 'X-AI-Agent-Key', $output );
 		$this->assertStringNotContainsString( 'wc/v3/ai-syndication', $output );
 		$this->assertStringNotContainsString( 'Product Catalog', $output );


### PR DESCRIPTION
Closes #271.

## Problem

\`/llms.txt\` was announcing \`/wp-json/wc/store/v1\` as the AI-agent entry point — the raw WooCommerce Store API — which bypasses the UCP layer's agent fingerprinting, rate limiting, and access control. The plugin's actual AI-agent front door is the UCP REST surface at \`/wp-json/wc/ucp/v1/\`.

## Fix

Replace the \`Store API\` line in the API Access section with a \`UCP API\` line pointing at \`/wp-json/wc/ucp/v1\`. The Commerce Protocol Manifest line stays. The outdated comment claiming the plugin "does NOT expose its own authenticated API" is rewritten to describe the actual UCP-on-top-of-Store-API architecture.

## Test

\`test_api_access_section_points_to_store_api_and_ucp\` renamed to \`test_api_access_section_points_to_ucp_api_and_manifest\`, with a new regression guard asserting \`wc/store/v1\` does **not** appear in the output so a future change can't quietly re-announce it.

PR-only diff is ~45 lines (PHP + test + CHANGELOG); no JS, no admin UI, no .pot, no migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)