### PR TITLE
feat(jsonld): emit shippingRate: 0 when unconditional free shipping exists

### DIFF
--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -36,7 +36,7 @@ class WC_AI_Storefront_JsonLd {
 	 *
 	 * @var array<string, bool>
 	 */
-	private array $free_shipping_cache = [];
+	private array $free_shipping_cache = array();
 
 	/**
 	 * Initialize hooks.

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -407,6 +407,12 @@ class WC_AI_Storefront_JsonLd {
 	 * Returns true when the zone covers the given country or has no
 	 * location restrictions (Rest of World zone).
 	 *
+	 * Known gap: continent-type locations (type === 'continent') are not
+	 * matched. A continent zone whose continent contains the store country
+	 * would be skipped here. Continent matching requires resolving the
+	 * country to its WC continent code via WC_Countries and is left for
+	 * a follow-up.
+	 *
 	 * @param WC_Shipping_Zone $zone    Shipping zone.
 	 * @param string           $country ISO country code.
 	 * @return bool

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -31,6 +31,14 @@ class WC_AI_Storefront_JsonLd {
 	private $dimension_unit_code_cache = null;
 
 	/**
+	 * Per-request cache for the free-shipping lookup keyed by country code.
+	 * `true` = unconditional free shipping found, `false` = not found.
+	 *
+	 * @var array<string, bool>
+	 */
+	private array $free_shipping_cache = [];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public function init() {
@@ -325,6 +333,13 @@ class WC_AI_Storefront_JsonLd {
 	 * A DefinedRegion without addressCountry is meaningless — no emission
 	 * when $country is empty.
 	 *
+	 * Emits shippingRate (value: 0) when an unconditionally free shipping
+	 * method (WC_Shipping_Free_Shipping with requires === '') exists in any
+	 * zone that covers the store's base country or has no location
+	 * restrictions (Rest of World zone). Threshold-gated free shipping
+	 * (requires: 'min_amount') is intentionally excluded — it is not
+	 * unconditionally free.
+	 *
 	 * @param array  $markup  Markup array, modified by reference.
 	 * @param string $country ISO country code from the WC store base location.
 	 */
@@ -332,13 +347,95 @@ class WC_AI_Storefront_JsonLd {
 		if ( ! $country || ! isset( $markup['offers'][0] ) || ! is_array( $markup['offers'][0] ) ) {
 			return;
 		}
-		$markup['offers'][0]['shippingDetails'] = array(
+
+		$block = array(
 			'@type'               => 'OfferShippingDetails',
 			'shippingDestination' => array(
 				'@type'          => 'DefinedRegion',
 				'addressCountry' => $country,
 			),
 		);
+
+		if ( $this->has_unconditional_free_shipping( $country ) ) {
+			$block['shippingRate'] = array(
+				'@type'    => 'MonetaryAmount',
+				'value'    => 0,
+				'currency' => get_woocommerce_currency(),
+			);
+		}
+
+		$markup['offers'][0]['shippingDetails'] = $block;
+	}
+
+	/**
+	 * Returns true when an unconditionally free shipping method exists for
+	 * the given country. Result is cached per country for the request
+	 * lifetime so archive pages with many products don't re-walk zones.
+	 *
+	 * @param string $country ISO country code.
+	 * @return bool
+	 */
+	private function has_unconditional_free_shipping( string $country ): bool {
+		if ( array_key_exists( $country, $this->free_shipping_cache ) ) {
+			return $this->free_shipping_cache[ $country ];
+		}
+
+		$found = false;
+		foreach ( $this->get_shipping_zones() as $zone ) {
+			if ( ! ( $zone instanceof WC_Shipping_Zone ) ) {
+				continue;
+			}
+			if ( ! $this->zone_covers_country( $zone, $country ) ) {
+				continue;
+			}
+			foreach ( $zone->get_shipping_methods( true ) as $method ) {
+				if (
+					$method instanceof WC_Shipping_Free_Shipping
+					&& '' === $method->requires
+				) {
+					$found = true;
+					break 2;
+				}
+			}
+		}
+
+		$this->free_shipping_cache[ $country ] = $found;
+		return $found;
+	}
+
+	/**
+	 * Returns true when the zone covers the given country or has no
+	 * location restrictions (Rest of World zone).
+	 *
+	 * @param WC_Shipping_Zone $zone    Shipping zone.
+	 * @param string           $country ISO country code.
+	 * @return bool
+	 */
+	private function zone_covers_country( WC_Shipping_Zone $zone, string $country ): bool {
+		$locations = $zone->get_zone_locations();
+		if ( empty( $locations ) ) {
+			return true; // Rest of World — covers everything.
+		}
+		foreach ( $locations as $location ) {
+			if ( 'country' === $location->type && $country === $location->code ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Returns all shipping zones including the Rest of World zone (id 0).
+	 *
+	 * Extracted as a protected method so tests can override it without
+	 * needing to call the static WC_Shipping_Zones API.
+	 *
+	 * @return WC_Shipping_Zone[]
+	 */
+	protected function get_shipping_zones(): array {
+		$zones   = array_values( WC_Shipping_Zones::get_zones() );
+		$zones[] = new WC_Shipping_Zone( 0 ); // Rest of World.
+		return $zones;
 	}
 
 	/**

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -433,7 +433,10 @@ class WC_AI_Storefront_JsonLd {
 	 * @return WC_Shipping_Zone[]
 	 */
 	protected function get_shipping_zones(): array {
-		$zones   = array_values( WC_Shipping_Zones::get_zones() );
+		// `get_shipping_zones()` returns WC_Shipping_Zone objects keyed by id.
+		// `get_zones()` returns data arrays (used by the admin UI) and must NOT
+		// be used here — those arrays fail `instanceof WC_Shipping_Zone`.
+		$zones   = array_values( WC_Shipping_Zones::get_shipping_zones() );
 		$zones[] = new WC_Shipping_Zone( 0 ); // Rest of World.
 		return $zones;
 	}

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-04T20:11:38+00:00\n"
+"POT-Creation-Date: 2026-05-04T20:18:20+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:511
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:514
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-04T20:18:20+00:00\n"
+"POT-Creation-Date: 2026-05-04T20:49:54+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:514
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:520
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:414
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:511
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -556,6 +556,40 @@ if ( ! class_exists( 'wpdb' ) ) {
 	}
 }
 
+if ( ! class_exists( 'WC_Shipping_Zone' ) ) {
+	class WC_Shipping_Zone {
+		private int $id;
+		public function __construct( int $id = 0 ) {
+			$this->id = $id;
+		}
+		public function get_zone_locations(): array {
+			return [];
+		}
+		/** @return WC_Shipping_Method[] */
+		public function get_shipping_methods( bool $enabled_only = false ): array {
+			return [];
+		}
+	}
+}
+
+if ( ! class_exists( 'WC_Shipping_Zones' ) ) {
+	class WC_Shipping_Zones {
+		public static function get_zones(): array {
+			return [];
+		}
+	}
+}
+
+if ( ! class_exists( 'WC_Shipping_Method' ) ) {
+	class WC_Shipping_Method {}
+}
+
+if ( ! class_exists( 'WC_Shipping_Free_Shipping' ) ) {
+	class WC_Shipping_Free_Shipping extends WC_Shipping_Method {
+		public string $requires = '';
+	}
+}
+
 if ( ! class_exists( 'WC_DateTime_Stub' ) ) {
 	/**
 	 * Minimal stub for WC_DateTime — just the two methods the admin

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -577,6 +577,11 @@ if ( ! class_exists( 'WC_Shipping_Zones' ) ) {
 		public static function get_zones(): array {
 			return [];
 		}
+
+		/** @return WC_Shipping_Zone[] Keyed by zone id — mirrors WooCommerce core. */
+		public static function get_shipping_zones(): array {
+			return [];
+		}
 	}
 }
 

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -574,13 +574,16 @@ if ( ! class_exists( 'WC_Shipping_Zone' ) ) {
 
 if ( ! class_exists( 'WC_Shipping_Zones' ) ) {
 	class WC_Shipping_Zones {
+		/** @var array<int, WC_Shipping_Zone> Keyed by zone id. Set in tests to inject zones without a DB. */
+		public static array $test_zones = [];
+
 		public static function get_zones(): array {
 			return [];
 		}
 
 		/** @return WC_Shipping_Zone[] Keyed by zone id — mirrors WooCommerce core. */
 		public static function get_shipping_zones(): array {
-			return [];
+			return self::$test_zones;
 		}
 	}
 }

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -924,6 +924,113 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( 'EUR', $rate['currency'] );
 	}
 
+	public function test_shipping_rate_omitted_when_method_is_not_free_shipping_type(): void {
+		// A flat-rate method in a matching zone must not trigger the free-shipping
+		// rate — only WC_Shipping_Free_Shipping instances qualify.
+		$flat_rate           = Mockery::mock( 'WC_Shipping_Flat_Rate' );
+		$flat_rate->requires = '';
+		$zone                = $this->make_zone( [ 'US' ], [ $flat_rate ] );
+		$jsonld              = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+	}
+
+	/**
+	 * @dataProvider requires_values_that_prevent_free_rate
+	 */
+	public function test_shipping_rate_omitted_when_requires_is_not_empty( string $requires ): void {
+		$zone   = $this->make_zone( [ 'US' ], [ $this->make_free_method( $requires ) ] );
+		$jsonld = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+	}
+
+	public static function requires_values_that_prevent_free_rate(): array {
+		return array(
+			'coupon' => array( 'coupon' ),
+			'either' => array( 'either' ),
+			'both'   => array( 'both' ),
+		);
+	}
+
+	public function test_shipping_rate_cache_stores_negative_result(): void {
+		// A zone that covers US but has only conditional free shipping must write
+		// false into the cache so a second call does NOT re-walk the zones.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$zone       = Mockery::mock( 'WC_Shipping_Zone' );
+		$call_count = 0;
+		$zone->shouldReceive( 'get_zone_locations' )->andReturnUsing(
+			static function () use ( &$call_count ) {
+				++$call_count;
+				$loc       = new stdClass();
+				$loc->type = 'country';
+				$loc->code = 'US';
+				return [ $loc ];
+			}
+		);
+		$zone->shouldReceive( 'get_shipping_methods' )->with( true )
+			->andReturn( [ $this->make_free_method( 'min_amount' ) ] );
+
+		$jsonld  = $this->make_jsonld_with_zones( [ $zone ] );
+		$product = $this->make_product();
+		$input   = [ 'offers' => [ [ '@type' => 'Offer' ] ] ];
+
+		$jsonld->enhance_product_data( $input, $product );
+		$jsonld->enhance_product_data( $input, $product );
+
+		$this->assertSame( 1, $call_count, 'Negative result must be cached — zone walk must not repeat' );
+	}
+
+	public function test_non_zone_entry_in_zone_list_is_skipped(): void {
+		// get_shipping_zones() could return non-WC_Shipping_Zone values
+		// (e.g. raw associative arrays from WC_Shipping_Zones::get_zones()).
+		// The implementation guards with instanceof — verify no crash and no rate.
+		$not_a_zone = [ 'id' => 1, 'zone_name' => 'Test' ];
+		$jsonld     = $this->make_jsonld_with_zones( [ $not_a_zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+	}
+
+	public function test_zone_with_state_location_type_does_not_match_country(): void {
+		// A zone whose only location is a state entry must NOT be treated as
+		// covering the whole country — zone_covers_country checks type === 'country'.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$loc       = new stdClass();
+		$loc->type = 'state';
+		$loc->code = 'US:NY';
+
+		$zone = Mockery::mock( 'WC_Shipping_Zone' );
+		$zone->shouldReceive( 'get_zone_locations' )->andReturn( [ $loc ] );
+		$zone->shouldReceive( 'get_shipping_methods' )->with( true )
+			->andReturn( [ $this->make_free_method( '' ) ] );
+
+		$jsonld = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+	}
+
 	public function test_shipping_rate_cache_avoids_redundant_zone_walk(): void {
 		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
 

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -847,6 +847,54 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		};
 	}
 
+	public function test_get_shipping_zones_returns_zone_objects_not_data_arrays(): void {
+		// Regression guard for the get_zones() vs get_shipping_zones() mix-up.
+		// WC_Shipping_Zones::get_zones() returns data arrays; only
+		// get_shipping_zones() returns WC_Shipping_Zone objects. If the
+		// production method ever regresses to get_zones(), every normal zone
+		// will fail the instanceof check and free-shipping detection silently
+		// breaks for all non-RoW zones.
+		//
+		// We can't call WC_Shipping_Zones::get_shipping_zones() in a unit test
+		// (no DB), so we subclass to inject a keyed-by-id array of mock zone
+		// objects — the same shape the real static call returns — and assert
+		// that the production method unwraps them correctly into a flat array
+		// of WC_Shipping_Zone instances with the RoW zone appended at the end.
+		$zone_42 = Mockery::mock( 'WC_Shipping_Zone' );
+		$zone_99 = Mockery::mock( 'WC_Shipping_Zone' );
+
+		// Keyed by zone id — exactly the shape WC_Shipping_Zones::get_shipping_zones() uses.
+		$keyed_zones = array( 42 => $zone_42, 99 => $zone_99 );
+
+		$jsonld = new class( $keyed_zones ) extends WC_AI_Storefront_JsonLd {
+			public function __construct( private array $raw ) {}
+
+			protected function get_shipping_zones(): array {
+				// Mirrors the production implementation exactly, but uses the
+				// injected $raw array instead of calling the static WC API.
+				$zones   = array_values( $this->raw );
+				$zones[] = new WC_Shipping_Zone( 0 );
+				return $zones;
+			}
+
+			// Expose the protected method for direct assertion.
+			public function call_get_shipping_zones(): array {
+				return $this->get_shipping_zones();
+			}
+		};
+
+		$result = $jsonld->call_get_shipping_zones();
+
+		$this->assertCount( 3, $result, 'Two named zones plus RoW' );
+		$this->assertSame( $zone_42, $result[0] );
+		$this->assertSame( $zone_99, $result[1] );
+		$this->assertInstanceOf( WC_Shipping_Zone::class, $result[2], 'Last entry must be the RoW WC_Shipping_Zone(0)' );
+		// If get_zones() had been used instead, $result[0] and $result[1] would
+		// be plain arrays — this assertion catches that regression.
+		$this->assertInstanceOf( WC_Shipping_Zone::class, $result[0] );
+		$this->assertInstanceOf( WC_Shipping_Zone::class, $result[1] );
+	}
+
 	public function test_shipping_rate_zero_emitted_when_unconditional_free_shipping_exists(): void {
 		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
 

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -27,6 +27,7 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		WC_Shipping_Zones::$test_zones = [];
 		$this->jsonld = new WC_AI_Storefront_JsonLd();
 
 		// Default: syndication enabled, no category restriction. Tests
@@ -80,6 +81,7 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 	protected function tearDown(): void {
 		WC_AI_Storefront::$test_settings = [];
+		WC_Shipping_Zones::$test_zones   = [];
 		Monkey\tearDown();
 		parent::tearDown();
 	}
@@ -855,29 +857,18 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		// will fail the instanceof check and free-shipping detection silently
 		// breaks for all non-RoW zones.
 		//
-		// We can't call WC_Shipping_Zones::get_shipping_zones() in a unit test
-		// (no DB), so we subclass to inject a keyed-by-id array of mock zone
-		// objects — the same shape the real static call returns — and assert
-		// that the production method unwraps them correctly into a flat array
-		// of WC_Shipping_Zone instances with the RoW zone appended at the end.
+		// We inject two WC_Shipping_Zone mocks into the stub's $test_zones
+		// (keyed by id — the exact shape WC_Shipping_Zones::get_shipping_zones()
+		// returns in production) and call the REAL production get_shipping_zones()
+		// method. The test therefore catches any regression in the production
+		// code, not just in a mirrored copy of it.
 		$zone_42 = Mockery::mock( 'WC_Shipping_Zone' );
 		$zone_99 = Mockery::mock( 'WC_Shipping_Zone' );
 
-		// Keyed by zone id — exactly the shape WC_Shipping_Zones::get_shipping_zones() uses.
-		$keyed_zones = array( 42 => $zone_42, 99 => $zone_99 );
+		WC_Shipping_Zones::$test_zones = array( 42 => $zone_42, 99 => $zone_99 );
 
-		$jsonld = new class( $keyed_zones ) extends WC_AI_Storefront_JsonLd {
-			public function __construct( private array $raw ) {}
-
-			protected function get_shipping_zones(): array {
-				// Mirrors the production implementation exactly, but uses the
-				// injected $raw array instead of calling the static WC API.
-				$zones   = array_values( $this->raw );
-				$zones[] = new WC_Shipping_Zone( 0 );
-				return $zones;
-			}
-
-			// Expose the protected method for direct assertion.
+		// Expose the protected method for direct assertion without overriding it.
+		$jsonld = new class extends WC_AI_Storefront_JsonLd {
 			public function call_get_shipping_zones(): array {
 				return $this->get_shipping_zones();
 			}

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -800,6 +800,158 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	// ------------------------------------------------------------------
+	// Shipping rate — free shipping detection
+	// ------------------------------------------------------------------
+
+	/**
+	 * Build a mock WC_Shipping_Zone covering the given country codes.
+	 * Pass an empty array for a Rest-of-World zone (no location restrictions).
+	 *
+	 * @param string[] $country_codes
+	 * @param object[] $methods       Shipping method mocks returned by get_shipping_methods(true).
+	 */
+	private function make_zone( array $country_codes, array $methods ): Mockery\MockInterface {
+		$locations = array_map(
+			static function ( string $code ) {
+				$loc       = new stdClass();
+				$loc->type = 'country';
+				$loc->code = $code;
+				return $loc;
+			},
+			$country_codes
+		);
+
+		$zone = Mockery::mock( 'WC_Shipping_Zone' );
+		$zone->shouldReceive( 'get_zone_locations' )->andReturn( $locations );
+		$zone->shouldReceive( 'get_shipping_methods' )->with( true )->andReturn( $methods );
+		return $zone;
+	}
+
+	/** Build a mock free-shipping method. */
+	private function make_free_method( string $requires = '' ): Mockery\MockInterface {
+		$method           = Mockery::mock( 'WC_Shipping_Free_Shipping' );
+		$method->requires = $requires;
+		return $method;
+	}
+
+	/**
+	 * Thin subclass that replaces get_shipping_zones() with a controlled
+	 * return so tests don't need WC_Shipping_Zones static infrastructure.
+	 */
+	private function make_jsonld_with_zones( array $zones ): WC_AI_Storefront_JsonLd {
+		return new class( $zones ) extends WC_AI_Storefront_JsonLd {
+			public function __construct( private array $stub_zones ) {}
+			protected function get_shipping_zones(): array {
+				return $this->stub_zones;
+			}
+		};
+	}
+
+	public function test_shipping_rate_zero_emitted_when_unconditional_free_shipping_exists(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$zone   = $this->make_zone( [ 'US' ], [ $this->make_free_method( '' ) ] );
+		$jsonld = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$rate = $result['offers'][0]['shippingDetails']['shippingRate'];
+		$this->assertEquals( 'MonetaryAmount', $rate['@type'] );
+		$this->assertSame( 0, $rate['value'] );
+		$this->assertEquals( 'USD', $rate['currency'] );
+	}
+
+	public function test_shipping_rate_omitted_when_only_threshold_free_shipping_exists(): void {
+		// requires: 'min_amount' = free above a spend threshold, not unconditionally free.
+		$zone   = $this->make_zone( [ 'US' ], [ $this->make_free_method( 'min_amount' ) ] );
+		$jsonld = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+		// DefinedRegion must still be present.
+		$this->assertEquals( 'US', $result['offers'][0]['shippingDetails']['shippingDestination']['addressCountry'] );
+	}
+
+	public function test_shipping_rate_omitted_when_no_shipping_zones(): void {
+		$jsonld = $this->make_jsonld_with_zones( [] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+		$this->assertEquals( 'US', $result['offers'][0]['shippingDetails']['shippingDestination']['addressCountry'] );
+	}
+
+	public function test_shipping_rate_omitted_when_no_zone_covers_store_country(): void {
+		// Zone covers CA only; store is US.
+		$zone   = $this->make_zone( [ 'CA' ], [ $this->make_free_method( '' ) ] );
+		$jsonld = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$this->assertArrayNotHasKey( 'shippingRate', $result['offers'][0]['shippingDetails'] );
+	}
+
+	public function test_row_zone_covers_any_country(): void {
+		// Empty locations = Rest of World — matches any country.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'EUR' );
+
+		$zone = Mockery::mock( 'WC_Shipping_Zone' );
+		$zone->shouldReceive( 'get_zone_locations' )->andReturn( [] );
+		$zone->shouldReceive( 'get_shipping_methods' )->with( true )->andReturn( [ $this->make_free_method( '' ) ] );
+
+		$jsonld = $this->make_jsonld_with_zones( [ $zone ] );
+
+		$result = $jsonld->enhance_product_data(
+			[ 'offers' => [ [ '@type' => 'Offer' ] ] ],
+			$this->make_product()
+		);
+
+		$rate = $result['offers'][0]['shippingDetails']['shippingRate'];
+		$this->assertSame( 0, $rate['value'] );
+		$this->assertEquals( 'EUR', $rate['currency'] );
+	}
+
+	public function test_shipping_rate_cache_avoids_redundant_zone_walk(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$zone       = Mockery::mock( 'WC_Shipping_Zone' );
+		$call_count = 0;
+		$zone->shouldReceive( 'get_zone_locations' )->andReturnUsing(
+			static function () use ( &$call_count ) {
+				++$call_count;
+				$loc       = new stdClass();
+				$loc->type = 'country';
+				$loc->code = 'US';
+				return [ $loc ];
+			}
+		);
+		$zone->shouldReceive( 'get_shipping_methods' )->with( true )->andReturn( [ $this->make_free_method( '' ) ] );
+
+		$jsonld  = $this->make_jsonld_with_zones( [ $zone ] );
+		$product = $this->make_product();
+		$input   = [ 'offers' => [ [ '@type' => 'Offer' ] ] ];
+
+		$jsonld->enhance_product_data( $input, $product );
+		$jsonld->enhance_product_data( $input, $product );
+		$jsonld->enhance_product_data( $input, $product );
+
+		$this->assertSame( 1, $call_count, 'Zone walk must be cached after the first call for the same country' );
+	}
+
+	// ------------------------------------------------------------------
 	// Filter extensibility
 	// ------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

- Adds `shippingRate: { @type: MonetaryAmount, value: 0, currency: ... }` to product JSON-LD `OfferShippingDetails` when the store has at least one active, unconditional free-shipping method that covers the store's base country
- Walks WooCommerce shipping zones (including Rest of World zone) to detect `WC_Shipping_Free_Shipping` with `$requires === ''`
- Uses a per-country instance cache to avoid repeated zone walks on archive pages
- `get_shipping_zones()` is a protected instance method acting as a testability seam (anonymous subclass override in tests)
- No `shippingRate` emitted when free shipping requires a minimum order amount, coupon, etc.

## Test plan

- [ ] Unit tests: `shippingRate` emitted for unconditional free shipping; omitted for threshold/coupon-gated; omitted when no zone covers store country; RoW zone covers any country; cache prevents redundant zone walks
- [ ] `composer test` passes locally
- [ ] No regression on existing return-policy or `shippingDestination` tests

Closes #277