### PR TITLE
chore(local-dev): add project-root docker-compose for one-command setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,10 @@ node_modules/
 .claude/
 .tools/
 release-staging/
+
+# Local docker-compose overrides. Teammates can drop `.env` for port
+# overrides (e.g. `WP_PORT=8088`) or `docker-compose.override.yml` for
+# personal tweaks (xdebug, alternate PHP versions, custom mounts)
+# without committing those to the shared compose file.
+/.env
+/docker-compose.override.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -87,6 +87,30 @@ Two changelogs:
 
 Every PR adds an entry to the `[Unreleased]` block in `CHANGELOG.md`. The PR template's CHANGELOG checkbox should be ticked or explicitly waived.
 
+## Local development
+
+```bash
+docker compose up -d
+```
+
+That's the whole setup. The committed `docker-compose.yml` brings up WordPress + MariaDB + a long-lived wp-cli container, and a one-shot `bootstrap` service runs `wp core install`, activates WC + this plugin, sets pretty permalinks, flushes rewrite rules, and enables plugin syndication.
+
+| URL | Purpose |
+|---|---|
+| http://localhost:8030/ | The store |
+| http://localhost:8030/wp-admin | Admin (user `admin` / password `password`) |
+| http://localhost:8030/llms.txt | Plugin's discovery file |
+| http://localhost:8030/.well-known/ucp | UCP manifest |
+| http://localhost:8030/robots.txt | Robots.txt |
+
+Plugin source bind-mounts from the project root, so file edits in the IDE are reflected instantly inside the container — no rebuild step. PHP files are served directly; JS/CSS still go through `npm run build` (or `npm start` for watch mode).
+
+For wp-cli: `docker exec woocommerce-ai-storefront-cli wp <command>`.
+
+The bootstrap script ([`bin/local-dev-bootstrap.sh`](./bin/local-dev-bootstrap.sh)) is idempotent — `docker compose up` after the first boot is a no-op. To wipe everything and start fresh: `docker compose down -v` (the `-v` removes volumes).
+
+To override the port or add personal tweaks (xdebug, alternate PHP version) without modifying the shared compose file, drop a `.env` (`WP_PORT=8088`) or `docker-compose.override.yml` — both are gitignored.
+
 ## Testing
 
 PHP suite uses PHPUnit + Brain Monkey + Mockery. **No real WordPress install required** — Brain Monkey mocks WP/WC functions. Tests live in `tests/php/unit/`, flat structure, one file per production class. Naming: `<UnitOfBehaviorBeingTested>Test.php`. Test methods: `test_<what>_<conditions>_<outcome>` snake_case.

--- a/bin/local-dev-bootstrap.sh
+++ b/bin/local-dev-bootstrap.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# First-boot setup for the local docker-compose dev stack.
+#
+# Idempotent: short-circuits when WordPress is already installed.
+# Safe to run on every `docker compose up`. Mounted into the
+# `bootstrap` service in docker-compose.yml at /bootstrap/.
+#
+# What it does on a fresh install:
+#   1. Wait for /var/www/html/wp-config.php (the official WordPress
+#      image's entrypoint creates this on first boot — racy with our
+#      bootstrap startup).
+#   2. `wp core install` with admin/password/dev@example.com.
+#   3. Download WooCommerce (the AI Storefront plugin requires it).
+#   4. Activate WooCommerce + this plugin.
+#   5. Set pretty permalinks (`/%postname%/`) — required for the
+#      plugin's custom rewrite rules to apply.
+#   6. Flush rewrite rules so /llms.txt, /.well-known/ucp, /robots.txt
+#      respond.
+#   7. Enable the plugin's `syndication` setting — without this, the
+#      serve_* callbacks return 404 even though the rewrite rules
+#      are registered (gated by design for production opt-in).
+#
+# Login at http://localhost:8030/wp-admin
+#   user: admin
+#   password: password
+
+set -e
+
+WP_PATH=/var/www/html
+WP_URL="${WP_URL:-http://localhost:8030}"
+WP_TITLE="${WP_TITLE:-WC AI Storefront Dev}"
+WP_ADMIN_USER="${WP_ADMIN_USER:-admin}"
+WP_ADMIN_PASS="${WP_ADMIN_PASS:-password}"
+WP_ADMIN_EMAIL="${WP_ADMIN_EMAIL:-dev@example.com}"
+
+cd "$WP_PATH"
+
+# The official `wordpress` image's entrypoint creates wp-config.php on
+# first boot using its DB env vars. Our bootstrap container starts in
+# parallel; wait for the file to appear before invoking wp-cli.
+echo "[bootstrap] Waiting for wp-config.php..."
+i=0
+while [ ! -f wp-config.php ] && [ $i -lt 60 ]; do
+  sleep 1
+  i=$((i + 1))
+done
+if [ ! -f wp-config.php ]; then
+  echo "[bootstrap] ERROR: wp-config.php did not appear within 60s. Aborting."
+  exit 1
+fi
+
+# Idempotency gate. `wp core is-installed` exits 0 when installed,
+# 1 otherwise. If installed, we still want to ensure the plugin
+# settings are flipped on (a merchant who restored a DB without our
+# settings, or a fresh-install bootstrap that landed in a partial
+# state, should converge on the right defaults).
+if wp core is-installed --allow-root 2>/dev/null; then
+  echo "[bootstrap] WordPress already installed; verifying plugin state."
+else
+  echo "[bootstrap] Installing WordPress..."
+  wp core install \
+    --url="$WP_URL" \
+    --title="$WP_TITLE" \
+    --admin_user="$WP_ADMIN_USER" \
+    --admin_password="$WP_ADMIN_PASS" \
+    --admin_email="$WP_ADMIN_EMAIL" \
+    --skip-email \
+    --allow-root
+fi
+
+# Download WooCommerce if it's not already present. The official
+# wordpress image doesn't ship WC; we install it on first boot. wp-cli
+# `plugin install` is idempotent (skips when present) so we don't
+# need to gate this.
+echo "[bootstrap] Ensuring WooCommerce is installed..."
+wp plugin install woocommerce --allow-root 2>&1 | grep -v "already installed" || true
+
+# Activate both plugins. `wp plugin activate` is idempotent — emits
+# "already active" without erroring when the plugin is already
+# active.
+echo "[bootstrap] Activating plugins..."
+wp plugin activate woocommerce woocommerce-ai-storefront --allow-root
+
+# Pretty permalinks. The plugin's `add_rewrite_rule` calls register
+# llms.txt, /.well-known/ucp, and the UCP REST routes — all of these
+# need a non-Plain permalink structure to match.
+echo "[bootstrap] Setting permalink structure..."
+wp option update permalink_structure '/%postname%/' --allow-root
+
+# Enable plugin syndication. The plugin defaults `enabled => 'no'`
+# (production-safe — merchants opt in via the admin UI). For local
+# dev, flip it on so the discovery URLs respond.
+echo "[bootstrap] Enabling plugin syndication..."
+wp option update wc_ai_storefront_settings --format=json '{"enabled":"yes"}' --allow-root
+
+# Flush rewrite rules — must run AFTER plugin activation and AFTER
+# the syndication setting is enabled (the plugin only registers its
+# rewrite rules when those preconditions are met).
+echo "[bootstrap] Flushing rewrite rules..."
+wp rewrite flush --allow-root
+
+echo "[bootstrap] Done."
+echo "[bootstrap] Site:        $WP_URL"
+echo "[bootstrap] Admin login: $WP_URL/wp-admin"
+echo "[bootstrap] User:        $WP_ADMIN_USER"
+echo "[bootstrap] Password:    $WP_ADMIN_PASS"
+echo "[bootstrap] Endpoints:"
+echo "[bootstrap]   $WP_URL/llms.txt"
+echo "[bootstrap]   $WP_URL/.well-known/ucp"
+echo "[bootstrap]   $WP_URL/robots.txt"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,158 @@
+# Local development stack for the WooCommerce AI Storefront plugin.
+#
+# Replaces the prior wp-env workflow with a project-root compose file —
+# matches the house style used by woopay, woocommerce-payments, and
+# woocommerce-gateway-stripe. Why:
+#
+#   - Compose project name auto-derives from this file's directory
+#     (`woocommerce-ai-storefront`), so `container_name:` values render
+#     correctly in Docker Desktop without remembering env vars.
+#   - "Open in VSCode" from Docker Desktop's Containers list routes
+#     correctly to a container in this project.
+#   - No hashed temp directories under ~/.wp-env/, no compose-file
+#     regeneration on every start, no project-name lottery.
+#
+# First-boot setup is automated by the `bootstrap` service: it waits
+# for MySQL to be healthy, then runs `wp core install`, activates
+# WooCommerce + this plugin, sets pretty permalinks, flushes rewrite
+# rules, and enables the plugin's syndication setting (so the
+# /llms.txt, /robots.txt, /.well-known/ucp endpoints respond). The
+# service is idempotent — it short-circuits when WP is already
+# installed — so subsequent `docker compose up` calls don't re-run
+# setup.
+
+services:
+  mysql:
+    container_name: woocommerce-ai-storefront-mysql
+    image: mariadb:lts
+    restart: unless-stopped
+    environment:
+      MYSQL_ROOT_PASSWORD: password
+      MYSQL_DATABASE: wordpress
+      MARIADB_AUTO_UPGRADE: '1'
+    volumes:
+      - mysql:/var/lib/mysql
+    healthcheck:
+      # Match wp-env's healthcheck — `healthcheck.sh --connect
+      # --innodb_initialized` is bundled with the mariadb:lts image
+      # and reports healthy only when the server is accepting
+      # connections AND InnoDB has finished crash-recovery. Without
+      # the InnoDB check, depends_on services start before the DB is
+      # truly query-able and `wp core install` can fail with cryptic
+      # innodb errors on the first boot of a fresh volume.
+      test: ['CMD', 'healthcheck.sh', '--connect', '--innodb_initialized']
+      interval: 5s
+      timeout: 10s
+      retries: 24
+      start_period: 60s
+
+  wordpress:
+    container_name: woocommerce-ai-storefront-wordpress
+    # Pinned to a major.minor (not `latest`) so a future WP release that
+    # changes plugin loader behavior, deprecates a hook, or breaks our
+    # tests doesn't silently land on every `docker compose up`. Bump
+    # this when you intentionally want the new version. WC requires
+    # WP 6.8+ as of 2026; we use the latest 6.8.x at compose-write time.
+    image: wordpress:6.8-apache
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+    ports:
+      - '${WP_PORT:-8030}:80'
+    environment:
+      WORDPRESS_DB_HOST: mysql
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_DB_NAME: wordpress
+      WORDPRESS_DEBUG: '1'
+      # `WORDPRESS_CONFIG_EXTRA` injects literal PHP into wp-config.php
+      # at container boot. Used to flip on debug-log + script-debug
+      # without forcing the merchant to maintain a custom wp-config.php.
+      WORDPRESS_CONFIG_EXTRA: |
+        define('WP_DEBUG_LOG', true);
+        define('WP_DEBUG_DISPLAY', false);
+        define('SCRIPT_DEBUG', true);
+        define('WP_ENVIRONMENT_TYPE', 'local');
+    volumes:
+      # WordPress core files. Persists in the named volume across
+      # container recreations. Plugins/themes installed via the admin
+      # land here and survive `docker compose down` (volume preserved
+      # unless `-v` is passed).
+      - wordpress:/var/www/html
+      # Plugin source — bind-mount from the project root so edits in
+      # the IDE are reflected instantly inside the container, no
+      # rebuild required. Matches wp-env's primary value-add for
+      # plugin development.
+      - .:/var/www/html/wp-content/plugins/woocommerce-ai-storefront
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+
+  cli:
+    # Long-lived wp-cli container so `docker exec
+    # woocommerce-ai-storefront-cli wp <command>` works without
+    # spinning up a one-shot container per call. Shares the WordPress
+    # core volume + the plugin bind-mount so it sees the same
+    # filesystem as the wordpress service.
+    container_name: woocommerce-ai-storefront-cli
+    image: wordpress:cli
+    restart: unless-stopped
+    depends_on:
+      mysql:
+        condition: service_healthy
+      wordpress:
+        condition: service_started
+    user: '33:33'  # www-data, matching the wordpress service
+    environment:
+      WORDPRESS_DB_HOST: mysql
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/woocommerce-ai-storefront
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    # Keep alive so we can `docker exec` into it. wordpress:cli's
+    # default ENTRYPOINT runs wp and exits; override with a sleep
+    # loop instead. `tail -f /dev/null` is the conventional one-liner
+    # for "stay running, do nothing."
+    entrypoint: ['/bin/sh', '-c']
+    command: ['tail -f /dev/null']
+
+  bootstrap:
+    # One-shot service that runs first-boot setup: install WP,
+    # activate plugins, set pretty permalinks, flush rewrite rules,
+    # and turn on plugin syndication. Idempotent — short-circuits
+    # when WP is already installed — so `docker compose up` on a
+    # subsequent boot is a no-op.
+    container_name: woocommerce-ai-storefront-bootstrap
+    image: wordpress:cli
+    depends_on:
+      mysql:
+        condition: service_healthy
+      wordpress:
+        condition: service_started
+    user: '33:33'
+    environment:
+      WORDPRESS_DB_HOST: mysql
+      WORDPRESS_DB_USER: root
+      WORDPRESS_DB_PASSWORD: password
+      WORDPRESS_DB_NAME: wordpress
+    volumes:
+      - wordpress:/var/www/html
+      - .:/var/www/html/wp-content/plugins/woocommerce-ai-storefront
+      - ./bin:/bootstrap:ro
+    extra_hosts:
+      - 'host.docker.internal:host-gateway'
+    entrypoint: ['/bin/sh', '-c']
+    command: ['/bootstrap/local-dev-bootstrap.sh']
+    # restart: 'no' is the default but stated explicitly — bootstrap
+    # is one-shot. If it fails, surface the failure rather than
+    # restart-loop. `docker compose up` exits non-zero, the merchant
+    # sees the bootstrap log, fixes the issue, and re-runs.
+    restart: 'no'
+
+volumes:
+  mysql:
+  wordpress:


### PR DESCRIPTION
## Summary

Replaces the `wp-env`-based local dev workflow with a project-root `docker-compose.yml`, matching the house style of woopay, woocommerce-payments, and woocommerce-gateway-stripe.

**Why this exists:** with wp-env, the auto-generated compose file lives in `~/.wp-env/wp-env-<hash>/`, gets regenerated on every start, and the Compose project name keys off `process.cwd()` of the wp-env invocation. Run `npx wp-env start` from a directory called `docker` (e.g. when working on `woocommerce-payments` first), and you get containers named `docker-wordpress-1` instead of `woocommerce-ai-storefront-wordpress` — confusing in Docker Desktop's UI, breaks "Open in VSCode" routing.

With a project-root compose file, the project name auto-derives from the file's directory basename (`woocommerce-ai-storefront`) — no env vars, no scripts, no thought required. Matches every sibling Woo plugin.

## What's in the stack

```
woocommerce-ai-storefront-wordpress    # wordpress:6.8-apache
woocommerce-ai-storefront-mysql        # mariadb:lts (with InnoDB healthcheck)
woocommerce-ai-storefront-cli          # wordpress:cli, long-lived for docker exec
woocommerce-ai-storefront-bootstrap    # wordpress:cli, one-shot first-boot setup
```

The `bootstrap` service runs `bin/local-dev-bootstrap.sh` on every `docker compose up`:

1. Waits for `wp-config.php` (wordpress image's entrypoint creates it on first boot).
2. `wp core install` (admin/password/dev@example.com) — skipped when already installed.
3. Downloads WooCommerce + activates WC + this plugin.
4. Sets `permalink_structure = '/%postname%/'` (rewrite rules need non-Plain).
5. Enables `wc_ai_storefront_settings.enabled = 'yes'` (otherwise the serve_* callbacks 404).
6. `wp rewrite flush`.

Idempotent — exit 0 on subsequent boots when WP is already installed.

## Files

| File | Change |
|---|---|
| `docker-compose.yml` | New — 4 services with `container_name:` pinned, healthcheck on mysql, plugin source bind-mount |
| `bin/local-dev-bootstrap.sh` | New — first-boot setup, idempotent |
| `AGENTS.md` | New "Local development" section |
| `.gitignore` | Adds `/.env` and `/docker-compose.override.yml` for local-only overrides |

The wp-env config (`.wp-env.json`) is intentionally left in place — anyone still using `npx wp-env start` keeps working. Deprecating wp-env is a separate decision (comms, teammate sync) outside this PR.

## Verification

End-to-end smoke-tested locally on a fresh `docker compose down -v && docker compose up -d`:

```
=== Container project labels ===
woocommerce-ai-storefront-wordpress | project: woocommerce-ai-storefront | state: running
woocommerce-ai-storefront-mysql     | project: woocommerce-ai-storefront | state: running
woocommerce-ai-storefront-cli       | project: woocommerce-ai-storefront | state: running

=== Endpoint check ===
http://localhost:8030/llms.txt        → HTTP 200
http://localhost:8030/.well-known/ucp → HTTP 200
http://localhost:8030/robots.txt      → HTTP 200

=== Admin ===
GET /wp-admin → HTTP 302 (redirect to login, expected)
```

`/llms.txt` body starts: `# WC AI Storefront Dev / ## Store Information / - **Currency**: USD ...`

## Test plan

- [x] `docker compose up -d` from a clean state produces correctly-labeled containers
- [x] All three discovery endpoints respond 200 with correct content
- [x] Admin reachable at http://localhost:8030/wp-admin
- [x] Bootstrap script is idempotent (re-running `docker compose up` exits 0)
- [ ] Verified by a teammate from a fresh clone
- [ ] Confirmed Docker Desktop's "Open in VSCode" action routes correctly to the wordpress container

🤖 Generated with [Claude Code](https://claude.com/claude-code)