### PR TITLE
docs(engineering): refresh post-0.10.0 — OnlineStore + local-dev paths

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,7 @@ When you change a code file, update the corresponding doc(s) in the same PR. The
 | `includes/ai-storefront/class-wc-ai-storefront-attribution.php` | DATA-MODEL.md, UCP-BUY-FLOW.md, USER-GUIDE.md |
 | `includes/ai-storefront/class-wc-ai-storefront-ucp.php` | API-REFERENCE.md, UCP-BUY-FLOW.md, CART-MODELS.md |
 | `includes/ai-storefront/class-wc-ai-storefront-llms-txt.php` | ARCHITECTURE.md, HOOKS.md |
-| `includes/ai-storefront/class-wc-ai-storefront-jsonld.php` | ARCHITECTURE.md, HOOKS.md, USER-GUIDE.md |
+| `includes/ai-storefront/class-wc-ai-storefront-jsonld.php` | ARCHITECTURE.md, HOOKS.md, USER-GUIDE.md, JSON-LD-SCHEMA.md |
 | `includes/ai-storefront/class-wc-ai-storefront-robots.php` | ARCHITECTURE.md, HOOKS.md, USER-GUIDE.md |
 | `includes/ai-storefront/class-wc-ai-storefront-store-api-rate-limiter.php` | ARCHITECTURE.md, USER-GUIDE.md |
 | `includes/ai-storefront/class-wc-ai-storefront-cache-invalidator.php` | DATA-MODEL.md, ARCHITECTURE.md |
@@ -173,6 +173,7 @@ When you change a code file, update the corresponding doc(s) in the same PR. The
 | `package.json` | TESTING.md, RELEASE.md |
 | `phpcs.xml.dist`, `phpstan.neon.dist` | TESTING.md |
 | `.github/workflows/**` | TESTING.md, RELEASE.md |
+| `docker-compose.yml`, `bin/local-dev-bootstrap.sh` | AGENTS.md (Local development section) |
 
 If you add a code file outside this map, add a row to both this table and the workflow YAML so the autonomous docs-followup picks it up.
 

--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -23,11 +23,11 @@ AI agents are a fast-growing product-discovery channel. The plugin lets merchant
 └───────┬──────────────┬──────────────┬────────────────────┬──────────┘
         │              │              │                    │
   ┌─────▼─────┐ ┌─────▼──────┐ ┌─────▼────────┐ ┌──────────▼──────────┐
-  │ /llms.txt │ │ UCP        │ │  JSON-LD on  │ │ UCP REST API        │
-  │ (Markdown)│ │ Manifest   │ │ product pages│ │ /wp-json/wc/ucp/v1/ │
-  │           │ │ (JSON)     │ │              │ │                     │
-  │           │ │/.well-known│ │              │ │                     │
-  │           │ │   /ucp     │ │              │ │                     │
+  │ /llms.txt │ │ UCP        │ │  JSON-LD     │ │ UCP REST API        │
+  │ (Markdown)│ │ Manifest   │ │ Product +    │ │ /wp-json/wc/ucp/v1/ │
+  │           │ │ (JSON)     │ │ OnlineStore  │ │                     │
+  │           │ │/.well-known│ │ (homepage +  │ │                     │
+  │           │ │   /ucp     │ │ product page)│ │                     │
   └────────────┘ └─────────────┘ └──────────────┘ └──────────┬─────────┘
         │              │              │                     │
         └──────────────┼──────────────┴─────────────────────┘
@@ -56,7 +56,7 @@ AI agents are a fast-growing product-discovery channel. The plugin lets merchant
 | File | Endpoint | Purpose |
 |------|----------|---------|
 | `class-wc-ai-storefront-llms-txt.php` | `/llms.txt` | Machine-readable store guide: name, categories, products, attribution instructions. |
-| `class-wc-ai-storefront-jsonld.php` | Product pages | Enhanced Schema.org Product markup: BuyAction, inventory, attributes, return policy. See [`JSON-LD-SCHEMA.md`](JSON-LD-SCHEMA.md) for the full field reference and example output. |
+| `class-wc-ai-storefront-jsonld.php` | Product pages + homepage / shop page | **Per product:** enhanced Schema.org `Product` markup — BuyAction, inventory, attributes, shipping (`OfferShippingDetails` with handlingTime + free-shipping rate), return policy. **Homepage / shop page:** Schema.org `OnlineStore` (an `Organization` subtype, since 0.10.0; previously `Store`/`LocalBusiness`) with auto-sourced identity fields: `logo` (custom-logo theme mod → site-icon fallback), `address` (PostalAddress from `WC()->countries->get_base_*` minus `streetAddress`, suppressed for privacy), `contactPoint.email` (two-stage from `woocommerce_email_reply_to_address` → `woocommerce_email_from_address` with noreply guard, never falls back to `admin_email`). See [`JSON-LD-SCHEMA.md`](JSON-LD-SCHEMA.md) for the full field reference and example output. |
 | `class-wc-ai-storefront-robots.php` | `/robots.txt` | Allow-lists known AI crawlers, allows discovery endpoints, blocks checkout/account. |
 | `class-wc-ai-storefront-ucp.php` | `/.well-known/ucp` | JSON manifest declaring implemented capabilities (catalog, checkout), pointing at the UCP REST adapter, advertising empty `payment_handlers` for the redirect-only posture. |
 

--- a/docs/engineering/HOOKS.md
+++ b/docs/engineering/HOOKS.md
@@ -38,7 +38,7 @@ add_filter( 'wc_ai_storefront_jsonld_product', function( $markup, $product, $set
 
 ### `wc_ai_storefront_jsonld_store`
 
-Filter the store-level JSON-LD emitted on the homepage and shop page.
+Filter the store-level JSON-LD emitted on the homepage and shop page (Schema.org `OnlineStore`, an `Organization` subtype). The filter receives the fully-assembled structure including auto-sourced identity fields (`logo`, `address`, `contactPoint.email`) so plugins can layer extra identity claims without re-implementing the WP/WC reads.
 
 ```php
 apply_filters( 'wc_ai_storefront_jsonld_store', array $store_data, array $settings );
@@ -46,12 +46,58 @@ apply_filters( 'wc_ai_storefront_jsonld_store', array $store_data, array $settin
 
 | Param | Type | Description |
 |-------|------|-------------|
-| `$store_data` | `array` | The Schema.org `OnlineStore` structure (name, url, sameAs, etc.). |
+| `$store_data` | `array` | The Schema.org `OnlineStore` structure (`@type`, `@context`, `name`, `description`, `url`, `currenciesAccepted`, `potentialAction`, `hasOfferCatalog`, plus optionally `logo`, `address`, `contactPoint`). |
 | `$settings` | `array` | A minimal 3-key subset of the plugin's settings: `enabled`, `product_selection_mode`, `return_policy`. Security-sensitive fields are intentionally excluded (same subset as `wc_ai_storefront_jsonld_product`). |
 
 **Returns:** modified `array`.
 
-**When to use:** add organization-level metadata that AI agents read once per crawl — `sameAs` social profiles, `contactPoint`, `address`, regional `inLanguage`, etc.
+**When to use:** add organization-level metadata that AI agents read once per crawl. The plugin **does not** capture `sameAs` (social profiles) or `contactPoint.telephone` itself, because neither has a canonical WP/WC source — ecosystem plugins (Jetpack, Yoast, custom merchant code) own that capture and inject via this filter.
+
+**Common pattern: injecting social profiles.** Plugins that already manage merchant social URLs (Jetpack's "Social Profiles" module, Yoast's "Knowledge Graph" config, etc.) can publish them as `sameAs` in one filter:
+
+```php
+add_filter( 'wc_ai_storefront_jsonld_store', function ( array $store_data, array $settings ): array {
+    // Replace with whatever your plugin / theme exposes:
+    $profiles = array_filter( [
+        get_option( 'my_plugin_twitter_url' ),
+        get_option( 'my_plugin_instagram_url' ),
+        get_option( 'my_plugin_linkedin_url' ),
+    ] );
+
+    if ( ! empty( $profiles ) ) {
+        $store_data['sameAs'] = array_values( $profiles );
+    }
+
+    return $store_data;
+}, 10, 2 );
+```
+
+**Common pattern: injecting a phone number.** Schema.org allows partial `ContactPoint` blocks, so plugins can extend an existing `contactPoint` (added by the plugin from the WC reply-to/from email resolver) with a `telephone` key — or add a fresh `contactPoint` if none exists:
+
+```php
+add_filter( 'wc_ai_storefront_jsonld_store', function ( array $store_data, array $settings ): array {
+    $phone = get_option( 'my_plugin_support_phone' );
+    if ( empty( $phone ) ) {
+        return $store_data;
+    }
+
+    if ( isset( $store_data['contactPoint'] ) ) {
+        // Plugin already emitted contactPoint.email from WC settings;
+        // we add telephone alongside it.
+        $store_data['contactPoint']['telephone'] = $phone;
+    } else {
+        $store_data['contactPoint'] = [
+            '@type'       => 'ContactPoint',
+            'contactType' => 'Customer Service',
+            'telephone'   => $phone,
+        ];
+    }
+
+    return $store_data;
+}, 10, 2 );
+```
+
+**What you should NOT add via this filter.** `streetAddress` is deliberately suppressed by the plugin — for an `OnlineStore` (vs. a `LocalBusiness`) the field has low signal value but real privacy risk (many merchants populate WC Settings with their home address for tax purposes and don't expect it published). Re-injecting `streetAddress` via this filter undoes that privacy guard. If a merchant actually wants their street address published, they should configure that through a plugin that explicitly asks them to opt in.
 
 ### `wc_ai_storefront_ucp_manifest`
 

--- a/docs/engineering/JSON-LD-SCHEMA.md
+++ b/docs/engineering/JSON-LD-SCHEMA.md
@@ -9,7 +9,7 @@ Two distinct JSON-LD blocks:
 | Surface | Block | Location | Source |
 |---------|-------|----------|--------|
 | Product page (single product) | Enhanced `Product` | Inside the `<head>` via `wp_head`, layered on top of WooCommerce core's existing `Product` block | [`includes/ai-storefront/class-wc-ai-storefront-jsonld.php`](../../includes/ai-storefront/class-wc-ai-storefront-jsonld.php) `enhance_product_data()` |
-| Store homepage | `Store` | Inside the `<head>` via `wp_head`, only on the front page when the plugin is enabled | Same file, `output_store_jsonld()` |
+| Store homepage / shop page | `OnlineStore` (an `Organization` subtype, since 0.10.0; previously `Store`) | Inside the `<head>` via `wp_head`, on `is_front_page() || is_shop()` when the plugin is enabled | Same file, `output_store_jsonld()` |
 
 Both blocks emit only when the plugin is enabled (`enabled === 'yes'` in `wc_ai_storefront_settings`). Disabling the plugin removes the markup entirely; the underlying WooCommerce core JSON-LD (basic Product, Offer, AggregateRating) continues to render unchanged.
 
@@ -166,32 +166,84 @@ Schema.org `MerchantReturnPolicy` describing return rules.
   - `returnMethod`: same allow-list defense (`ReturnByMail`, `ReturnInStore`, `ReturnAtKiosk`).
 - **Source**: `add_return_policy()` (line ~356) and `build_return_policy_block()` (line ~559).
 
-## Store homepage: Store schema
+## Store homepage: OnlineStore schema
 
-A separate JSON-LD block emitted only on the front page (when `is_front_page()` is true) and only when the plugin is enabled.
+A separate JSON-LD block emitted on the front page or shop page (`is_front_page() || is_shop()`) when the plugin is enabled.
+
+The `@type` is `OnlineStore` (a Schema.org `Organization` subtype). Prior to 0.10.0 this was `Store` (a `LocalBusiness`/`Place` subtype), which doesn't satisfy AI-readiness audits looking for `Organization`-shaped brand entities. `OnlineStore` is the most accurate type for a Woo storefront and inherits all the descriptive fields (`name`, `url`, `description`) that `Store` carried.
 
 ```jsonc
 {
-  "@context": "https://schema.org/",
-  "@type": "Store",
-  "@id": "https://yourstore.example.com/#store",
+  "@context": "https://schema.org",
+  "@type": "OnlineStore",
   "name": "Your Store",
+  "description": "Your store's tagline / blog description",
   "url": "https://yourstore.example.com/",
-  "image": "https://yourstore.example.com/wp-content/uploads/.../logo.png",
   "currenciesAccepted": "USD",
-  "paymentAccepted": "Credit Card, PayPal",
-  "areaServed": "US",
+  "potentialAction": {
+    "@type": "SearchAction",
+    "target": {
+      "@type": "EntryPoint",
+      "urlTemplate": "https://yourstore.example.com/?s={search_term}&post_type=product&utm_source={agent_id}&utm_medium=referral&utm_id=woo_ucp"
+    },
+    "query-input": "required name=search_term"
+  },
+  "hasOfferCatalog": {
+    "@type": "OfferCatalog",
+    "name": "Products",
+    "itemListElement": [
+      // Top-level categories with product counts; built by get_catalog_summary().
+      // Empty categories (zero exposed products) are omitted.
+    ]
+  },
 
-  // Catalog summary (top categories with product counts)
-  "department": [
-    { "@type": "Store", "name": "Clothing", "numberOfItems": 14 },
-    { "@type": "Store", "name": "Accessories", "numberOfItems": 5 },
-    { "@type": "Store", "name": "Decor", "numberOfItems": 1 }
-  ]
+  // Identity fields (since 0.10.0). Each is omit-when-empty: a merchant
+  // who has no logo, no WC base country, and no usable email gets none of
+  // these keys.
+  "logo": "https://yourstore.example.com/wp-content/uploads/.../brand.png",
+  "address": {
+    "@type": "PostalAddress",
+    "addressCountry": "US",
+    "addressLocality": "Springfield",
+    "addressRegion":   "IL",
+    "postalCode":      "62701"
+    // Note: streetAddress is intentionally NEVER emitted. See "Identity
+    // field sourcing" below.
+  },
+  "contactPoint": {
+    "@type":       "ContactPoint",
+    "contactType": "Customer Service",
+    "email":       "support@yourstore.example.com"
+  }
 }
 ```
 
-The `department` array is built by `get_catalog_summary()` and respects the plugin's product visibility setting -- categories with zero exposed products are omitted.
+### Identity field sourcing
+
+All three identity fields are auto-sourced from existing WP/WC data. There are **no plugin-owned settings** for these — the plugin reads what's already configured at the platform level.
+
+| Field | Source | Omit-when-empty rule |
+|-------|--------|----------------------|
+| `logo` | WP custom-logo theme mod (`get_theme_mod( 'custom_logo' )` → resolved via `wp_get_attachment_image_src`), with `get_site_icon_url()` as fallback. | Omitted when neither is set. Avoids publishing the default WP favicon as a brand mark. |
+| `address.addressCountry` | `WC()->countries->get_base_country()`. | The whole `address` block is omitted when country is empty (the minimum viable address signal). |
+| `address.addressLocality` / `addressRegion` / `postalCode` | `WC()->countries->get_base_city()` / `get_base_state()` / `get_base_postcode()`. | Each sub-key is omitted when WC has no value. |
+| `address.streetAddress` | **NEVER emitted.** Not even when WC has the street address populated (`get_base_address()` / `get_base_address_2()`). | See "Why streetAddress is suppressed" below. |
+| `contactPoint.email` | Two-stage: (1) `woocommerce_email_reply_to_address` when `woocommerce_email_reply_to_enabled === 'yes'`, (2) `woocommerce_email_from_address` as fallback (rejected when local-part is a noreply pattern). | The whole `contactPoint` block is omitted when neither stage produces a usable address. **Never** falls back to `admin_email`. |
+
+### Why streetAddress is suppressed
+
+For an `OnlineStore` (vs. a `LocalBusiness`), street address has low signal value: buyers transact remotely and don't visit. But the privacy/safety risk is real — many small Woo merchants populate WooCommerce > Settings > General with their home address (the field is required at WC setup so tax calculations work) and don't realize that saving it would publish the address in machine-readable form on the homepage's JSON-LD. By emitting only `addressLocality`, `addressRegion`, `postalCode`, and `addressCountry`, we preserve every meaningful identity signal (jurisdiction, shipping origin, fraud-check disambiguation) without leaking a residential address. `build_postal_address()` in the emitter doesn't even read `get_base_address()` or `get_base_address_2()` — even a future filter that wants to re-emit street would have to source it independently.
+
+### Why the email resolver has a noreply guard
+
+WC's "From" address is often set to `noreply@store.com` to avoid bounce-handling on outgoing transactional emails. Publishing that as `contactPoint.email` would route legitimate customer questions into a black hole. The `is_noreply_email()` heuristic matches the four canonical noreply local-parts (`noreply`, `no-reply`, `donotreply`, `do-not-reply`) case-insensitively, including their RFC 5233 plus-addressing variants (`noreply+orders@…`, `do-not-reply+billing@…`) which route to the same underlying mailbox at most providers. Local-part-only matching prevents false positives on legitimate mailboxes hosted on a `noreply.*` subdomain (e.g. `support@noreply.example.com` stays publishable). The guard only applies to the From-address fallback path; the merchant's explicit reply-to address (when enabled in WC settings) is trusted as-is.
+
+### What this plugin does NOT emit
+
+- **`sameAs`** (social profile URLs). WC has no canonical storage for these; ecosystem plugins (Jetpack Social, Yoast Knowledge Graph, etc.) own the merchant capture and can inject via the `wc_ai_storefront_jsonld_store` filter. See [`HOOKS.md`](HOOKS.md) for a worked example.
+- **`contactPoint.telephone`**. Same reason: WC has no phone option, so the plugin can't auto-source. Plugins that capture a merchant phone number can inject via the same filter.
+
+The `hasOfferCatalog.itemListElement` is built by `get_catalog_summary()` and respects the plugin's product visibility setting — categories with zero exposed products are omitted.
 
 ## Public filters
 


### PR DESCRIPTION
Engineering doc pass that should have landed alongside #311 / #312 but was deferred so the 0.10.0 release wasn't blocked on it. Now catching the docs up.

## Files changed

| File | Change |
|---|---|
| `docs/engineering/ARCHITECTURE.md` | Discovery-layer jsonld row + ASCII box diagram updated to reflect homepage `OnlineStore` emission |
| `docs/engineering/HOOKS.md` | `wc_ai_storefront_jsonld_store` filter doc rewritten with two worked examples (`sameAs` injection, `contactPoint.telephone` injection) and a "what NOT to inject" callout for `streetAddress` |
| `docs/engineering/JSON-LD-SCHEMA.md` | "Store homepage" section rewritten as "OnlineStore" with the actual emitted shape, identity-field sourcing table, streetAddress privacy rationale, noreply email-resolver rationale, and what the plugin does NOT emit |
| `AGENTS.md` | Path-impact map: `docker-compose.yml` + `bin/local-dev-bootstrap.sh` now point at AGENTS.md (Local development); `jsonld.php` row gains `JSON-LD-SCHEMA.md` (pre-existing map gap) |

## Why this is in a separate PR

Per the user's call during the 0.10.0 release flow: ship the release first, do the doc pass after. The release notes / CHANGELOG / readme.txt / USER-GUIDE were all already current before 0.10.0 tagged. This PR fills the engineering-doc gap.

## Test plan

- [x] `composer test` — 1177/1177 pass (docs-only PR; smoke test only)
- [ ] Skim review of each doc change for stale claims I may have introduced
- [ ] Verify `JSON-LD-SCHEMA.md` example output matches actual code output via a quick `curl http://localhost:8030/ | grep -A 30 'application/ld+json'` from the local-dev stack

🤖 Generated with [Claude Code](https://claude.com/claude-code)