### PR TITLE
feat(jsonld): emit ProductGroup + hasVariant for variable products (#328)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,11 +15,12 @@
   - Parent-level `offers` and `potentialAction` are intentionally dropped on conversion — buyers can't purchase the parent of a variable product, and per Schema.org, concrete offers belong on the `hasVariant` Product entries.
   - Core-typed override: when the parent's "Used for variations" flag is unset on `pa_color` / `pa_size` / `pa_material` / `pa_pattern` but variation children still have distinct values stored under `attribute_<slug>` postmeta, the plugin reads that meta directly and emits ProductGroup with the correct `variesBy` URL and per-variant typed property. Limited to the four core typed slugs because they have canonical Schema.org typed-property mappings; unmapped custom attributes still honor the parent flag.
   - When neither path surfaces a varying axis — variations exist but no core typed attribute and no parent-flagged attribute factually differ — the plugin falls back to simple-Product emission. With no `variesBy` to advertise, `hasVariant` would just hand agents N near-identical blocks they can't tell apart — better to emit a working single-SKU shape.
-  - `Offer.checkoutPageURLTemplate` (Schema.org's newer Action vocabulary) emits alongside the existing `BuyAction.target.urlTemplate` — same Shareable Checkout URL on both, so consumers reading from either property resolve a working AI-attribution-tagged link.
+  - `Offer.checkoutPageURLTemplate` (Schema.org `Offer` property — a URL template per [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) that points at the offer's checkout page) emits alongside the existing `BuyAction.target.urlTemplate`. Same Shareable Checkout URL on both, so consumers reading from either property resolve a working AI-attribution-tagged link.
 
-- **JSON-LD: `BuyAction` and `SearchAction` URLs now use the WooCommerce Shareable Checkout URL format.** Closes part of #328.
-  - `BuyAction.target.urlTemplate` now points at `{home}/checkout-link/?products={id}:1&utm_source={agent_id}&utm_medium=referral&utm_id=woo_ucp&ai_session_id={session_id}` instead of the prior product-permalink + `add-to-cart` form.
+- **JSON-LD: `BuyAction.target.urlTemplate` now uses the WooCommerce Shareable Checkout URL format.** Closes part of #328.
+  - Now points at `{home}/checkout-link/?products={id}:1&utm_source={agent_id}&utm_medium=referral&utm_id=woo_ucp&ai_session_id={session_id}` instead of the prior product-permalink + `add-to-cart` form.
   - The `?products=ID:QUANTITY` format goes through WC's `/checkout-link/` rewrite handler, which adds the item to the cart and redirects directly to checkout — no intermediate landing page for the buyer.
+  - The store-level `SearchAction.target.urlTemplate` is unchanged (it still points at the WP search endpoint with the canonical `utm_id=woo_ucp` attribution shape).
 
 ### Fixes
 ### Refactors

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,15 +9,29 @@
   - Variation-defining attributes are skipped from both the typed property and `additionalProperty` on the parent — they describe variants, not the parent product. Per-variant emission is intentionally omitted until #328 (`ProductGroup` + `hasVariant`) lands.
   - Existing typed-property values in the markup (from WC core or other plugins) are not overwritten.
 
+- **JSON-LD: variable products now emit as Schema.org `ProductGroup` with per-variant `hasVariant` entries.** Closes #328.
+  - Variable products with at least one attribute marked "Used for variations" emit `@type: ProductGroup` with `productGroupID` (parent SKU, or post ID fallback), `variesBy` (Schema.org property URLs for axes that actually differ across variations — e.g. `https://schema.org/color`, `https://schema.org/size`), and `hasVariant: [...]` containing one Product entry per variation.
+  - Each `hasVariant` entry carries the variation's own `name`, `sku`, `image`, typed Schema.org property (`color`/`size`/`material`/`pattern`) for its differentiating attribute, an `Offer` (price, currency, availability), and a `BuyAction` whose URL targets the **variation ID** so an AI agent's deep-link resolves to the specific SKU instead of the parent's "choose your color" detour.
+  - Parent-level `offers` and `potentialAction` are intentionally dropped on conversion — buyers can't purchase the parent of a variable product, and per Schema.org, concrete offers belong on the `hasVariant` Product entries.
+  - Core-typed override: when the parent's "Used for variations" flag is unset on `pa_color` / `pa_size` / `pa_material` / `pa_pattern` but variation children still have distinct values stored under `attribute_<slug>` postmeta, the plugin reads that meta directly and emits ProductGroup with the correct `variesBy` URL and per-variant typed property. Limited to the four core typed slugs because they have canonical Schema.org typed-property mappings; unmapped custom attributes still honor the parent flag.
+  - When neither path surfaces a varying axis — variations exist but no core typed attribute and no parent-flagged attribute factually differ — the plugin falls back to simple-Product emission. With no `variesBy` to advertise, `hasVariant` would just hand agents N near-identical blocks they can't tell apart — better to emit a working single-SKU shape.
+  - `Offer.checkoutPageURLTemplate` (Schema.org's newer Action vocabulary) emits alongside the existing `BuyAction.target.urlTemplate` — same Shareable Checkout URL on both, so consumers reading from either property resolve a working AI-attribution-tagged link.
+
+- **JSON-LD: `BuyAction` and `SearchAction` URLs now use the WooCommerce Shareable Checkout URL format.** Closes part of #328.
+  - `BuyAction.target.urlTemplate` now points at `{home}/checkout-link/?products={id}:1&utm_source={agent_id}&utm_medium=referral&utm_id=woo_ucp&ai_session_id={session_id}` instead of the prior product-permalink + `add-to-cart` form.
+  - The `?products=ID:QUANTITY` format goes through WC's `/checkout-link/` rewrite handler, which adds the item to the cart and redirects directly to checkout — no intermediate landing page for the buyer.
+
 ### Fixes
 ### Refactors
 ### Tests
 
 - **`JsonLdTest.php`** — 14 new unit tests covering typed-property emission for all four mapped slugs, UK spelling (`colour`), free-text capitalized slugs, multi-value skip + fallback, variation-defining skip, existing-markup preservation, unmapped-attribute passthrough, invisible-attribute skip, and whitespace-only value handling. Existing `test_visible_attributes_are_emitted_as_additional_properties` updated to use unmapped slugs (`pa_style`, `pa_origin`) since `pa_color`/`pa_size` now route to typed properties.
+- **`JsonLdTest.php`** (PR #328) — 24 new unit tests across `detect_varies_by()` (5), `build_variant_entry()` (7), full ProductGroup conversion (7 — including the misconfigured-variable fallback regression guard), `Offer.checkoutPageURLTemplate` (3), and `allow_product_group_type` (2). The `allow_product_group_type` pair pins the WC core type-allow-list registration that prevents `ProductGroup` blocks from being silently dropped at `WC_Structured_Data::get_structured_data()`.
 
 ### Docs
 
 - **`JSON-LD-SCHEMA.md`** — added a `color`/`material`/`pattern`/`size` typed-property section under "Field reference" with the slug mapping table, emission rules, and a worked example. Updated the `additionalProperty` section to reflect the new exclusion semantics.
+- **`JSON-LD-SCHEMA.md`** — added a `ProductGroup` / `hasVariant` / `variesBy` section documenting the variable-product emission shape, the misconfigured-variable fallback rule, and `Offer.checkoutPageURLTemplate` coexistence with `BuyAction`.
 
 ### Chores
 

--- a/docs/engineering/JSON-LD-SCHEMA.md
+++ b/docs/engineering/JSON-LD-SCHEMA.md
@@ -234,10 +234,10 @@ Variable products with at least one attribute marked **Used for variations** emi
 
 Each entry under `hasVariant` is itself a Product with:
 
-- `@type: "Product"`, `@id` (variation permalink), `name`, `sku`, `image` (variation-specific when set; falls back to parent gallery image).
+- `@type: "Product"`, `@id` and `url` (variation permalink), `name` (WC's variation display name, e.g. `"Hoodie - Blue, Logo: Yes"`), `sku`, `image` (variation-specific when set; falls back to parent gallery image).
 - The typed Schema.org property for the variation's differentiating attribute (`color` / `size` / `material` / `pattern`) — same mapping as the parent's typed-property emission.
-- An `Offer` with `price`, `priceCurrency`, `availability`, and `checkoutPageURLTemplate`.
-- A `BuyAction` whose `target.urlTemplate` points at the **variation ID** so an AI agent's deep-link resolves to that specific SKU instead of the parent's "choose your color" detour.
+- An `offers` array (single-element) whose member carries `price`, `priceCurrency`, `availability`, `shippingDetails`, `hasMerchantReturnPolicy`, and `checkoutPageURLTemplate` (Schema.org `Offer` property — a URL template per [RFC 6570](https://datatracker.ietf.org/doc/html/rfc6570) that points at the variation's checkout page).
+- A `potentialAction: BuyAction` whose `target.urlTemplate` points at the **variation ID** so an AI agent's deep-link resolves to that specific SKU instead of the parent's "choose your color" detour.
 
 **Core-typed override (parent flag missing):**
 
@@ -267,17 +267,21 @@ Worked example (V-Neck T-Shirt with 3 variations across color and size):
   "hasVariant": [
     {
       "@type": "Product",
+      "@id": "https://example.com/product/v-neck-t-shirt/?attribute_pa_color=red&attribute_pa_size=s",
+      "url": "https://example.com/product/v-neck-t-shirt/?attribute_pa_color=red&attribute_pa_size=s",
       "name": "V-Neck T-Shirt - Red, Small",
       "sku": "woo-vneck-tee-red-s",
       "color": "Red",
       "size": "Small",
-      "offers": {
-        "@type": "Offer",
-        "price": "20",
-        "priceCurrency": "USD",
-        "availability": "https://schema.org/InStock",
-        "checkoutPageURLTemplate": "https://example.com/checkout-link/?products=43:1&utm_source={agent_id}&..."
-      },
+      "offers": [
+        {
+          "@type": "Offer",
+          "price": "20",
+          "priceCurrency": "USD",
+          "availability": "https://schema.org/InStock",
+          "checkoutPageURLTemplate": "https://example.com/checkout-link/?products=43:1&utm_source={agent_id}&..."
+        }
+      ],
       "potentialAction": {
         "@type": "BuyAction",
         "target": { "@type": "EntryPoint", "urlTemplate": "...products=43:1..." }

--- a/docs/engineering/JSON-LD-SCHEMA.md
+++ b/docs/engineering/JSON-LD-SCHEMA.md
@@ -199,7 +199,7 @@ Mapped slugs (case-insensitive lookup) → typed Schema.org property:
 
 - **Single-value attribute** with no upstream owner → emit as the typed property (e.g. `"color": "Black"`). The attribute is then *excluded* from `additionalProperty` to avoid double-emit.
 - **Multi-value attribute** (any `,` or `|` in the value) → typed-property emission is **skipped**. Schema.org's `Text` type can't honestly carry a multi-value claim, and a first-piece-only emit would silently drop merchant data. Falls back to `additionalProperty` with the joined string preserved.
-- **Variation-defining attribute** → both typed-property and `additionalProperty` emission are skipped on the parent. Variation-defining attributes describe individual *variants*, not the parent product as a whole — emitting them at the parent level would claim a single intrinsic color/size that the parent doesn't have. Per-variant JSON-LD (`ProductGroup` + `hasVariant`) is tracked in [#328](https://github.com/Automattic/woocommerce-ai-storefront/issues/328); until that lands, variation-specific data isn't currently emitted as Schema.org.
+- **Variation-defining attribute** → both typed-property and `additionalProperty` emission are skipped on the parent. Variation-defining attributes describe individual *variants*, not the parent product as a whole — emitting them at the parent level would claim a single intrinsic color/size that the parent doesn't have. Per-variant typed emission lives on each `hasVariant` Product entry under the `ProductGroup` shape — see [`ProductGroup` / `hasVariant` / `variesBy`](#productgroup--hasvariant--variesby-variable-products) below.
 - **Existing value in `$markup`** (set by WC core or another plugin) → defer on the typed side, don't overwrite. The merchant's attribute *still* emits to `additionalProperty` so its data signal reaches agents even when upstream chose a different typed value. Caller control over the typed claim is preserved.
 
 Worked example:
@@ -218,6 +218,77 @@ Worked example:
 ```
 
 Implementation: [`emit_attributes()`](../../includes/ai-storefront/class-wc-ai-storefront-jsonld.php) — single-pass per attribute, decides typed property vs `additionalProperty` inline. One `get_attribute()` lookup per visible attribute regardless of which path the value takes.
+
+### `ProductGroup` / `hasVariant` / `variesBy` (variable products)
+
+Variable products with at least one attribute marked **Used for variations** emit as Schema.org [`ProductGroup`](https://schema.org/ProductGroup) — a parent abstraction over its variations, where each concrete buyable SKU lives under `hasVariant` as its own Product block.
+
+**Top-level shape change:**
+
+- `@type` flips from `Product` → `ProductGroup`.
+- `productGroupID` is the parent SKU (or, when no SKU is set, the parent post ID as a string).
+- `variesBy` lists Schema.org property URLs (or short Text labels for unmapped attributes) for the axes that **actually** vary across variations — i.e. axes with more than one distinct non-empty value. If every variation shares the same color and only differs by size, only `size` appears in `variesBy`.
+- Parent-level `offers` and `potentialAction` are dropped on conversion. Buyers can't purchase the parent of a variable product, and per Schema.org the concrete offers belong on the `hasVariant` Product entries.
+
+**Per-variant shape (one entry per child variation):**
+
+Each entry under `hasVariant` is itself a Product with:
+
+- `@type: "Product"`, `@id` (variation permalink), `name`, `sku`, `image` (variation-specific when set; falls back to parent gallery image).
+- The typed Schema.org property for the variation's differentiating attribute (`color` / `size` / `material` / `pattern`) — same mapping as the parent's typed-property emission.
+- An `Offer` with `price`, `priceCurrency`, `availability`, and `checkoutPageURLTemplate`.
+- A `BuyAction` whose `target.urlTemplate` points at the **variation ID** so an AI agent's deep-link resolves to that specific SKU instead of the parent's "choose your color" detour.
+
+**Core-typed override (parent flag missing):**
+
+WC's `get_variation_attributes()` is gated by the parent attribute's "Used for variations" flag — if a merchant configures variations with distinct `pa_color` / `pa_size` / `pa_material` / `pa_pattern` values but forgets to flag the parent attribute, that API silently returns empty. Per-variation postmeta (`attribute_<slug>`) is still populated, though. For these four core typed slugs only, the plugin reads variation postmeta directly: if at least two children have distinct non-empty values for a core slug, the axis qualifies as varying and the corresponding Schema.org URL appears in `variesBy`. Each `hasVariant` entry's typed property (`color` / `size` / etc.) is filled from the same postmeta source so the variant data stays coherent with the advertised axis.
+
+Override is intentionally limited to the four core typed slugs: they have canonical Schema.org typed-property mappings and AI agents look for them by name. Unmapped custom attributes (Style, Heel Height, Logo) honor the parent flag — getting them wrong only changes a Text label.
+
+**Misconfigured-variable fallback:**
+
+When a variable product has variation children but no axis qualifies — neither `get_variation_attributes()` nor the core-typed override surfaces ≥2 distinct values — the plugin falls back to simple-Product emission. With no `variesBy` to advertise, a `hasVariant` block of N near-identical entries would just confuse agents. Better to emit a working single-SKU shape and let the merchant fix the variation config in the editor.
+
+**WC core type-allow-list registration:**
+
+`WC_Structured_Data::get_structured_data()` keys the generated markup by `strtolower($value['@type'])` and intersects with the per-page allow-list returned by `get_data_type_for_page()` — which only ships `product`, `breadcrumblist`, `review`, `order`. The plugin hooks `woocommerce_structured_data_type_for_page` on single-product pages to add `productgroup` to that list; without the registration the entire ProductGroup block is silently dropped at output time.
+
+Worked example (V-Neck T-Shirt with 3 variations across color and size):
+
+```jsonc
+{
+  "@type": "ProductGroup",
+  "productGroupID": "woo-vneck-tee",
+  "name": "V-Neck T-Shirt",
+  "variesBy": [
+    "https://schema.org/color",
+    "https://schema.org/size"
+  ],
+  "hasVariant": [
+    {
+      "@type": "Product",
+      "name": "V-Neck T-Shirt - Red, Small",
+      "sku": "woo-vneck-tee-red-s",
+      "color": "Red",
+      "size": "Small",
+      "offers": {
+        "@type": "Offer",
+        "price": "20",
+        "priceCurrency": "USD",
+        "availability": "https://schema.org/InStock",
+        "checkoutPageURLTemplate": "https://example.com/checkout-link/?products=43:1&utm_source={agent_id}&..."
+      },
+      "potentialAction": {
+        "@type": "BuyAction",
+        "target": { "@type": "EntryPoint", "urlTemplate": "...products=43:1..." }
+      }
+    }
+    // ...other variations
+  ]
+}
+```
+
+Implementation: [`maybe_convert_to_product_group()`](../../includes/ai-storefront/class-wc-ai-storefront-jsonld.php) (parent-level rewrite) and [`build_variant_entry()`](../../includes/ai-storefront/class-wc-ai-storefront-jsonld.php) (per-variant block). Type registration: [`allow_product_group_type()`](../../includes/ai-storefront/class-wc-ai-storefront-jsonld.php).
 
 ### `additionalProperty` (attributes)
 
@@ -419,7 +490,7 @@ For reference, fields that a JSON-LD reader might expect but aren't part of this
 
 - **`aggregateRating` / `review`** -- inherited from WC core if present (e.g. via WooCommerce's reviews feature); plugin doesn't add or modify.
 - **`audience`, `eligibleRegion`** -- not modeled. AI agents that need region/audience scoping should infer from `shippingDetails.shippingDestination`.
-- **Variation-level JSON-LD** -- the plugin enhances the parent Product. Variations remain in WC core's `offers` array; per-variation JSON-LD blocks are not emitted.
+- **Per-variation top-level JSON-LD** -- variations don't get their own top-level Product `<script>` block when the buyer lands on a variation permalink. The plugin emits per-variation Product blocks under `hasVariant` on the parent's `ProductGroup` shape (see [`ProductGroup` / `hasVariant` / `variesBy`](#productgroup--hasvariant--variesby-variable-products) above) so AI agents can deep-link to the specific SKU; rendering those same blocks again as standalone top-level markup on each variation URL would duplicate data.
 
 These omissions are deliberate: the plugin's scope is "AI-shopping discovery essentials," not full Schema.org coverage. Extensions can fill these via the `wc_ai_storefront_jsonld_product` filter.
 

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -828,14 +828,25 @@ class WC_AI_Storefront_JsonLd {
 	}
 
 	/**
-	 * Populate a variant entry with sku, image (with parent fallback),
-	 * and per-variant typed Schema.org properties from the variation's
-	 * specific attribute selections.
+	 * Populate a variant entry with `@id`, `url`, `name`, `sku`, `image`
+	 * (with parent fallback), and per-variant typed Schema.org
+	 * properties from the variation's specific attribute selections.
 	 *
-	 * `WC_Product_Variation::get_variation_attributes()` returns the
-	 * variation's specific picks as `['attribute_pa_color' => 'white']`.
-	 * We strip the `attribute_` prefix, look up the slug in
-	 * {@see CORE_ATTRIBUTE_MAP}, and emit the typed property.
+	 * **Typed-property source**: read postmeta directly via
+	 * {@see read_variation_core_attributes()} rather than through
+	 * `WC_Product_Variation::get_variation_attributes()`. The latter
+	 * is gated by the parent's "Used for variations" flag — it
+	 * silently returns empty when that flag is unset on a core typed
+	 * attribute (e.g. `pa_color`), even when each variation child
+	 * carries a real value in its `attribute_<slug>` postmeta. The
+	 * misconfigured-variable `ProductGroup` override in
+	 * {@see detect_varies_by()} depends on those typed values
+	 * reaching the variant entry, so the same direct-postmeta path is
+	 * the source of truth here too.
+	 *
+	 * Scoped to the four core typed slugs in
+	 * {@see CORE_ATTRIBUTE_MAP} — unmapped custom attributes
+	 * (Style, Heel Height, Logo) intentionally honor the parent flag.
 	 *
 	 * @param array      $entry          Variant markup, modified by reference.
 	 * @param WC_Product $variation      The variation.

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -705,19 +705,19 @@ class WC_AI_Storefront_JsonLd {
 			return;
 		}
 
-		// Convert top-level type + add ProductGroup-specific fields.
-		$markup['@type']          = 'ProductGroup';
-		$sku                      = $product->get_sku();
-		$markup['productGroupID'] = '' !== $sku ? $sku : (string) $product->get_id();
-		$markup['variesBy']       = $varies_by;
-
-		// Drop parent-level fields that the variants own. Buyers can't
-		// purchase the parent of a variable product, so a parent-level
-		// `BuyAction` or `offers[]` block would point at an unbuyable
-		// entity. Per Schema.org, `ProductGroup` represents the abstract
-		// group; concrete offers live on the `hasVariant` Product entries.
-		unset( $markup['offers'], $markup['potentialAction'] );
-
+		// Build the variant entries FIRST. Only commit the conversion
+		// (rewrite `@type`, drop parent `offers` + `potentialAction`,
+		// add `productGroupID` / `variesBy` / `hasVariant`) once we
+		// know we have at least one buildable variant.
+		//
+		// Why: `get_children()` can contain stale post IDs (data
+		// corruption, soft-deleted variations, or a transient WP
+		// cache miss). If `wc_get_product()` returns false for every
+		// child, an unconditional convert would emit a `ProductGroup`
+		// with no `hasVariant` AND no `offers`/`potentialAction` —
+		// strictly worse than the simple-Product fallback for AI
+		// agents trying to deep-link or buy. Building first lets the
+		// fallback fire when the variations are unrecoverable.
 		$has_variant = array();
 		foreach ( $children as $child_id ) {
 			$variation = $this->resolve_variation( (int) $child_id );
@@ -726,10 +726,21 @@ class WC_AI_Storefront_JsonLd {
 			}
 			$has_variant[] = $this->build_variant_entry( $variation, $product, $settings, $country );
 		}
-
-		if ( ! empty( $has_variant ) ) {
-			$markup['hasVariant'] = $has_variant;
+		if ( empty( $has_variant ) ) {
+			return;
 		}
+
+		$markup['@type']          = 'ProductGroup';
+		$sku                      = $product->get_sku();
+		$markup['productGroupID'] = '' !== $sku ? $sku : (string) $product->get_id();
+		$markup['variesBy']       = $varies_by;
+		// Buyers can't purchase the parent of a variable product, so a
+		// parent-level `BuyAction` or `offers[]` block would point at
+		// an unbuyable entity. Per Schema.org, `ProductGroup`
+		// represents the abstract group; concrete offers live on the
+		// `hasVariant` Product entries.
+		unset( $markup['offers'], $markup['potentialAction'] );
+		$markup['hasVariant'] = $has_variant;
 	}
 
 	/**
@@ -821,6 +832,25 @@ class WC_AI_Storefront_JsonLd {
 	 * @param WC_Product $parent_product The parent (image fallback only).
 	 */
 	private function add_variant_basics( array &$entry, $variation, $parent_product ): void {
+		// `@id` and `name` are Schema.org Product fundamentals — agents
+		// dereference `@id` to fetch the variant's own page, and `name`
+		// is the human-readable label that surfaces in rich results.
+		// We use the variation permalink as `@id` (so it round-trips to
+		// a real WC URL) and WC's own variation name (e.g. "Hoodie -
+		// Blue, Logo: Yes") which already encodes the differentiating
+		// attribute values per the merchant's variation form.
+		$permalink = $variation->get_permalink();
+		if ( is_string( $permalink ) && '' !== $permalink ) {
+			$entry['@id'] = $permalink;
+			$entry['url'] = $permalink;
+		}
+		if ( method_exists( $variation, 'get_name' ) ) {
+			$name = $variation->get_name();
+			if ( is_string( $name ) && '' !== $name ) {
+				$entry['name'] = $name;
+			}
+		}
+
 		$sku = $variation->get_sku();
 		if ( ! $sku ) {
 			// Mirror WC core's fallback: when no SKU is set, use the

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -90,9 +90,19 @@ class WC_AI_Storefront_JsonLd {
 	 * @return array
 	 */
 	public function allow_product_group_type( $types ) {
-		if ( function_exists( 'is_product' ) && is_product() ) {
-			$types[] = 'productgroup';
+		if ( ! function_exists( 'is_product' ) || ! is_product() ) {
+			return $types;
 		}
+		// Guard against duplicate appends — another plugin (or this
+		// filter running multiple times against the same `$types`
+		// array) may have already added `productgroup`. Duplicates
+		// don't break WC core's allow-list intersection but they're
+		// noise and a future debugger reading the type list would
+		// rightly wonder why.
+		if ( in_array( 'productgroup', $types, true ) ) {
+			return $types;
+		}
+		$types[] = 'productgroup';
 		return $types;
 	}
 

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -64,7 +64,36 @@ class WC_AI_Storefront_JsonLd {
 	 */
 	public function init() {
 		add_filter( 'woocommerce_structured_data_product', [ $this, 'enhance_product_data' ], 20, 2 );
+		add_filter( 'woocommerce_structured_data_type_for_page', [ $this, 'allow_product_group_type' ] );
 		add_action( 'wp_head', [ $this, 'output_store_jsonld' ], 5 );
+	}
+
+	/**
+	 * Register `productgroup` as a renderable structured-data type on
+	 * single-product pages.
+	 *
+	 * WC core's `WC_Structured_Data::get_structured_data()` keys the
+	 * generated markup by `strtolower( $value['@type'] )` and intersects
+	 * the result with the per-page allow-list returned by
+	 * `get_data_type_for_page()`. That list ships only `product`,
+	 * `breadcrumblist`, `review`, `order` — so when our enhancer rewrites
+	 * `@type` from `Product` to `ProductGroup` for variable products
+	 * (PR #328 / `maybe_convert_to_product_group()`), the entire block
+	 * silently drops out of the emitted `<script type="application/ld+json">`.
+	 *
+	 * Adding `productgroup` to the allow-list keeps the block in the
+	 * output without disturbing anything else — `Product` stays allowed
+	 * for simple products, and the new type only matters when our
+	 * filter has actually rewritten `@type`.
+	 *
+	 * @param array $types Allow-listed structured-data types for the page.
+	 * @return array
+	 */
+	public function allow_product_group_type( $types ) {
+		if ( function_exists( 'is_product' ) && is_product() ) {
+			$types[] = 'productgroup';
+		}
+		return $types;
 	}
 
 	/**
@@ -86,6 +115,8 @@ class WC_AI_Storefront_JsonLd {
 
 		$this->add_buy_action( $markup, $product );
 
+		$this->add_checkout_page_url_template( $markup, $product );
+
 		$this->add_inventory_level( $markup, $product );
 
 		$this->add_category_path( $markup, $product );
@@ -102,6 +133,8 @@ class WC_AI_Storefront_JsonLd {
 		$this->add_shipping_details( $markup, $country );
 		$this->add_handling_time( $markup, $settings );
 		$this->add_return_policy( $markup, $product, $settings, $country );
+
+		$this->maybe_convert_to_product_group( $markup, $product, $settings, $country );
 
 		/**
 		 * Filter the enhanced JSON-LD product data.
@@ -128,10 +161,6 @@ class WC_AI_Storefront_JsonLd {
 	 * Adds a BuyAction potentialAction pointing at the store checkout with
 	 * attribution placeholders.
 	 *
-	 * Canonical UTM shape (0.5.0+): utm_medium=referral is Google-canonical;
-	 * utm_id=woo_ucp flags AI-routed traffic via the constant so a future
-	 * rename stays consistent with the attribution matcher.
-	 *
 	 * @param array      $markup  Markup array, modified by reference.
 	 * @param WC_Product $product The product object.
 	 */
@@ -140,22 +169,89 @@ class WC_AI_Storefront_JsonLd {
 			'@type'  => 'BuyAction',
 			'target' => array(
 				'@type'          => 'EntryPoint',
-				'urlTemplate'    => add_query_arg(
-					array(
-						'add-to-cart'   => $product->get_id(),
-						'utm_source'    => '{agent_id}',
-						'utm_medium'    => 'referral',
-						'utm_id'        => WC_AI_Storefront_Attribution::WOO_UCP_ID,
-						'ai_session_id' => '{session_id}',
-					),
-					$product->get_permalink()
-				),
+				'urlTemplate'    => self::build_checkout_url_template( $product->get_id() ),
 				'actionPlatform' => array(
 					'https://schema.org/DesktopWebPlatform',
 					'https://schema.org/MobileWebPlatform',
 				),
 			),
 		);
+	}
+
+	/**
+	 * Build a [WooCommerce Shareable Checkout URL][1] for a product or
+	 * variation, with the canonical UTM-attribution placeholders so an
+	 * AI agent can substitute its identity at recommendation time.
+	 *
+	 * Output shape:
+	 *   `{home}/checkout-link/?products={id}:1&utm_source={agent_id}&utm_medium=referral&utm_id=woo_ucp&ai_session_id={session_id}`
+	 *
+	 * The `?products=ID:QUANTITY` format goes through WC's
+	 * `/checkout-link/` rewrite handler — it adds the item to the cart
+	 * and redirects directly to checkout. For variable products, the
+	 * caller passes the **variation ID** so the right SKU lands in the
+	 * cart pre-selected (no "choose your color" detour). Same construction
+	 * for both simple and variable products; only the ID varies.
+	 *
+	 * Canonical UTM shape (0.5.0+): `utm_medium=referral` is Google-
+	 * canonical; `utm_id=woo_ucp` flags AI-routed traffic via the
+	 * `WOO_UCP_ID` constant so a future rename stays consistent with
+	 * the attribution matcher.
+	 *
+	 * Static so callers without a class instance (e.g. the per-variant
+	 * builder under `hasVariant`) can build URLs uniformly.
+	 *
+	 * [1]: https://woocommerce.com/document/creating-sharable-checkout-urls-in-woocommerce/
+	 *
+	 * @param int $id Product ID for simple products, variation ID for
+	 *                variable products. Quantity is fixed at 1 — the
+	 *                Shareable Checkout URL spec supports multi-product
+	 *                / multi-quantity carts but AI-shopping flows are
+	 *                single-item by convention.
+	 * @return string The full URL with `{agent_id}` and `{session_id}`
+	 *                placeholders ready for the agent to substitute.
+	 */
+	private static function build_checkout_url_template( int $id ): string {
+		return add_query_arg(
+			array(
+				'products'      => $id . ':1',
+				'utm_source'    => '{agent_id}',
+				'utm_medium'    => 'referral',
+				'utm_id'        => WC_AI_Storefront_Attribution::WOO_UCP_ID,
+				'ai_session_id' => '{session_id}',
+			),
+			home_url( '/checkout-link/' )
+		);
+	}
+
+	/**
+	 * Adds `checkoutPageURLTemplate` to `offers[0]` with the same
+	 * Shareable Checkout URL as `BuyAction.urlTemplate`.
+	 *
+	 * Schema.org `Offer.checkoutPageURLTemplate` is the modern dedicated
+	 * e-commerce property — emitted alongside (NOT instead of)
+	 * `Product.potentialAction.BuyAction`. The two cover different
+	 * consumer paths:
+	 *
+	 *   - `BuyAction` is the Action-vocabulary signal recognized by
+	 *     older / cross-domain consumers; supports `actionPlatform`,
+	 *     `result`, etc.
+	 *   - `checkoutPageURLTemplate` lives directly on Offer with
+	 *     native per-offer scope — the right fit for variant-level
+	 *     emission (#328) and modern e-commerce-aware AI agents.
+	 *
+	 * Both emit the same URL value. See
+	 * [SCHEMA-ORG-COVERAGE.md](docs/engineering/SCHEMA-ORG-COVERAGE.md)
+	 * for the keep-both rationale.
+	 *
+	 * @param array      $markup  Markup array, modified by reference.
+	 * @param WC_Product $product The product object.
+	 */
+	private function add_checkout_page_url_template( array &$markup, $product ): void {
+		if ( ! isset( $markup['offers'][0] ) || ! is_array( $markup['offers'][0] ) ) {
+			return;
+		}
+		$markup['offers'][0]['checkoutPageURLTemplate'] = self::build_checkout_url_template( $product->get_id() );
 	}
 
 	/**
@@ -383,6 +479,441 @@ class WC_AI_Storefront_JsonLd {
 		return array_map(
 			'strtolower',
 			array_keys( $product->get_variation_attributes() )
+		);
+	}
+
+	/**
+	 * Builds the `variesBy` array for a `ProductGroup` — Schema.org property
+	 * URLs (or short labels for unmapped attributes) for the dimensions that
+	 * actually vary across this product's variations.
+	 *
+	 * "Actually vary" means the variation set has more than one distinct
+	 * non-empty value for the axis. If all variations share the same color
+	 * and only differ by size, color is uniform and only `size` should appear
+	 * in `variesBy`. This matters because Google's variant rich result keys
+	 * on `variesBy` to know which dimensions a buyer can choose between.
+	 *
+	 * **Core typed override**: If a slug maps to a Schema.org typed property
+	 * via {@see CORE_ATTRIBUTE_MAP} (color / size / material / pattern), we
+	 * also inspect the variation children's own attribute meta directly —
+	 * not just the parent's `get_variation_attributes()`. WC's parent-level
+	 * "Used for variations" flag gates `get_variation_attributes()` but not
+	 * the underlying variation meta; merchants who configure `pa_color`
+	 * with distinct values across variations but forget to flag it as a
+	 * variation axis still get correct ProductGroup emission, because the
+	 * data is right there on each child even if the parent flag is wrong.
+	 * This override is intentionally limited to the four core typed slugs
+	 * — they have canonical Schema.org type mappings and are the axes AI
+	 * agents are most likely to query, so getting them right matters more
+	 * than honoring a likely-misconfigured parent flag.
+	 *
+	 * Slug → Schema.org URL mapping uses {@see CORE_ATTRIBUTE_MAP} (the same
+	 * lookup #331 uses for typed-property emission). Mapped attributes emit
+	 * as full Schema.org URLs (e.g. `https://schema.org/color`); unmapped
+	 * attributes (custom merchant axes like "Style" or "Heel Height") emit
+	 * as plain Text labels — Schema.org `variesBy` accepts both shapes.
+	 *
+	 * @param WC_Product $product The variable product.
+	 * @return string[] List of Schema.org URLs and/or Text labels for axes
+	 *                 that vary. Empty array for non-variable products or
+	 *                 variable products with uniform variation values.
+	 */
+	private static function detect_varies_by( $product ): array {
+		if ( ! method_exists( $product, 'get_variation_attributes' ) ) {
+			return array();
+		}
+
+		$varies_urls   = array();
+		$varies_labels = array();
+
+		// Path 1: parent-flagged variation attributes (canonical WC route).
+		$variation_attrs = $product->get_variation_attributes();
+		foreach ( (array) $variation_attrs as $slug => $values ) {
+			$distinct = array_filter(
+				array_unique( (array) $values ),
+				static fn( $v ) => '' !== (string) $v
+			);
+			if ( count( $distinct ) <= 1 ) {
+				continue;
+			}
+			$slug_lower = strtolower( (string) $slug );
+			if ( isset( self::CORE_ATTRIBUTE_MAP[ $slug_lower ] ) ) {
+				$varies_urls[] = 'https://schema.org/' . self::CORE_ATTRIBUTE_MAP[ $slug_lower ];
+			} else {
+				$varies_labels[] = function_exists( 'wc_attribute_label' )
+					? wc_attribute_label( $slug, $product )
+					: $slug;
+			}
+		}
+
+		// Path 2: core-typed override. For the four canonical Schema.org
+		// slugs (color / size / material / pattern), also peek at the
+		// variation children directly. This catches the misconfigured
+		// case where a merchant set up variations with real per-child
+		// values but didn't flag the parent attribute "Used for
+		// variations". Schema.org rich results care that the typed axis
+		// is advertised correctly; the parent flag is incidental.
+		$override_urls = self::detect_core_typed_axes_from_children( $product );
+		foreach ( $override_urls as $url ) {
+			$varies_urls[] = $url;
+		}
+
+		return array_values( array_unique( array_merge( $varies_urls, $varies_labels ) ) );
+	}
+
+	/**
+	 * Inspect variation children's attribute meta to find core-typed axes
+	 * (color / size / material / pattern) that have ≥2 distinct values
+	 * across children — even if the parent's "Used for variations" flag
+	 * is unset on the matching attribute.
+	 *
+	 * Returns Schema.org property URLs only (no Text labels), because
+	 * the override is scoped to the four core typed slugs by design.
+	 *
+	 * @param WC_Product $product The variable product (parent).
+	 * @return string[] Schema.org URLs for core-typed axes that factually vary.
+	 */
+	private static function detect_core_typed_axes_from_children( $product ): array {
+		$children = $product->get_children();
+		if ( ! is_array( $children ) || count( $children ) < 2 ) {
+			// Need at least 2 children to compare values across.
+			return array();
+		}
+
+		// Bucket: core slug → set of distinct non-empty values seen.
+		$values_by_core_slug = array();
+		foreach ( $children as $child_id ) {
+			$attrs = self::read_variation_core_attributes( (int) $child_id );
+			foreach ( $attrs as $slug_lower => $value_str ) {
+				$values_by_core_slug[ $slug_lower ][ $value_str ] = true;
+			}
+		}
+
+		$urls = array();
+		foreach ( $values_by_core_slug as $slug_lower => $value_set ) {
+			if ( count( $value_set ) >= 2 ) {
+				$urls[] = 'https://schema.org/' . self::CORE_ATTRIBUTE_MAP[ $slug_lower ];
+			}
+		}
+		return $urls;
+	}
+
+	/**
+	 * Read a variation's core-typed attribute values directly from
+	 * postmeta — bypassing the parent's "Used for variations" flag.
+	 *
+	 * `WC_Product_Variation::get_attributes()` (and its
+	 * `get_variation_attributes()` wrapper) only surface attributes
+	 * whose parent has `is_variation: 1`. The per-variation postmeta
+	 * key `attribute_<slug>` is populated whenever the merchant entered
+	 * a value on the variation form, regardless of the parent flag —
+	 * so reading meta directly is the only path to surface the data
+	 * when the merchant configured variations correctly but forgot to
+	 * flag the parent attribute.
+	 *
+	 * Scoped to the four core typed slugs ({@see CORE_ATTRIBUTE_MAP})
+	 * because they have canonical Schema.org typed properties; unmapped
+	 * custom attributes intentionally honor the parent's flag.
+	 *
+	 * @param int $variation_id The variation post ID.
+	 * @return array<string,string> Slug → trimmed value, only for non-empty
+	 *                              core typed slugs.
+	 */
+	private static function read_variation_core_attributes( int $variation_id ): array {
+		if ( $variation_id <= 0 || ! function_exists( 'get_post_meta' ) ) {
+			return array();
+		}
+		$out = array();
+		foreach ( self::CORE_ATTRIBUTE_MAP as $slug_lower => $_schema_property ) {
+			$value     = get_post_meta( $variation_id, 'attribute_' . $slug_lower, true );
+			$value_str = is_string( $value ) ? trim( $value ) : '';
+			if ( '' === $value_str ) {
+				continue;
+			}
+			$out[ $slug_lower ] = $value_str;
+		}
+		return $out;
+	}
+
+	/**
+	 * Convert a variable product's markup to Schema.org `ProductGroup`
+	 * shape with `hasVariant` entries. No-op for simple/grouped/external
+	 * products and for variable products with zero variation children.
+	 *
+	 * Per the locked design (issue #328):
+	 *
+	 *   - Variable + ≥1 variation child + ≥1 attribute marked
+	 *     "Used for variations" → emit `@type: ProductGroup` with
+	 *     `productGroupID`, `variesBy`, and `hasVariant: [...]`. Drop the
+	 *     parent's `offers[]` and `potentialAction` (the variants own
+	 *     them — buyers can't buy the parent of a variable product).
+	 *   - Variable + 0 children → leave as `@type: Product` (today's
+	 *     simple-product shape). Edge case; `BuyAction` URL with the
+	 *     parent ID may not resolve, but mirrors today's pre-#328
+	 *     behavior for misconfigured stores.
+	 *   - Variable + ≥1 child but **no** attribute is flagged "Used for
+	 *     variations" (Product 16 / Hoodie territory in the dev
+	 *     fixtures) → fall back to simple-Product shape. We have no
+	 *     `variesBy` to advertise, so a `hasVariant` block of N
+	 *     near-identical entries would just confuse agents. Honor the
+	 *     merchant-typed-it-wrong reality: emit what works for a single
+	 *     SKU and let the merchant fix the variation flag.
+	 *
+	 * @param array      $markup   Markup array, modified by reference.
+	 * @param WC_Product $product  The product object.
+	 * @param array      $settings Plugin settings (passed to per-variant builder).
+	 * @param string     $country  Store base country (passed to per-variant builder).
+	 */
+	private function maybe_convert_to_product_group( array &$markup, $product, array $settings, string $country ): void {
+		// Capability gate: only WC_Product_Variable (and subclasses) have
+		// variation_attributes. Same gate as `get_variation_attribute_slugs`.
+		if ( ! method_exists( $product, 'get_variation_attributes' ) ) {
+			return;
+		}
+
+		$children = $product->get_children();
+		if ( ! is_array( $children ) || empty( $children ) ) {
+			// No variations to nest under hasVariant — keep simple-Product
+			// shape (locked decision for the zero-children edge case).
+			return;
+		}
+
+		$varies_by = self::detect_varies_by( $product );
+		if ( empty( $varies_by ) ) {
+			// Variations exist but nothing is flagged "Used for variations"
+			// — there are no axes to advertise. Emitting `hasVariant`
+			// without `variesBy` would just hand agents N near-identical
+			// blocks with no way to tell them apart. Fall back to
+			// simple-Product shape; the merchant's WC variation-config
+			// gap belongs in their editor, not in our schema output.
+			return;
+		}
+
+		// Convert top-level type + add ProductGroup-specific fields.
+		$markup['@type']          = 'ProductGroup';
+		$sku                      = $product->get_sku();
+		$markup['productGroupID'] = '' !== $sku ? $sku : (string) $product->get_id();
+		$markup['variesBy']       = $varies_by;
+
+		// Drop parent-level fields that the variants own. Buyers can't
+		// purchase the parent of a variable product, so a parent-level
+		// `BuyAction` or `offers[]` block would point at an unbuyable
+		// entity. Per Schema.org, `ProductGroup` represents the abstract
+		// group; concrete offers live on the `hasVariant` Product entries.
+		unset( $markup['offers'], $markup['potentialAction'] );
+
+		$has_variant = array();
+		foreach ( $children as $child_id ) {
+			$variation = $this->resolve_variation( (int) $child_id );
+			if ( null === $variation ) {
+				continue;
+			}
+			$has_variant[] = $this->build_variant_entry( $variation, $product, $settings, $country );
+		}
+
+		if ( ! empty( $has_variant ) ) {
+			$markup['hasVariant'] = $has_variant;
+		}
+	}
+
+	/**
+	 * Resolve a variation post ID to a WC_Product instance.
+	 *
+	 * Wraps `wc_get_product()` with the null/falsy guard agents need —
+	 * `wc_get_product()` returns `false` for non-product IDs (e.g. data
+	 * corruption where `get_children()` returned a stale ID). Returns
+	 * `null` for callers to short-circuit.
+	 *
+	 * @param int $variation_id The variation post ID.
+	 * @return WC_Product|null The variation product object, or null if
+	 *                         not resolvable.
+	 */
+	private function resolve_variation( int $variation_id ) {
+		if ( $variation_id <= 0 || ! function_exists( 'wc_get_product' ) ) {
+			return null;
+		}
+		$variation = wc_get_product( $variation_id );
+		return ( $variation && is_object( $variation ) ) ? $variation : null;
+	}
+
+	/**
+	 * Build one `hasVariant` Product entry from a `WC_Product_Variation`.
+	 *
+	 * The entry is a standalone Schema.org Product block describing the
+	 * specific variation: SKU, image (with parent fallback), per-variant
+	 * typed properties (color/size/material/pattern from the variation's
+	 * specific attribute selections), an `offers[0]` Offer block with
+	 * price/availability/currency/inventory/shipping/return-policy, the
+	 * variation's `BuyAction`, and `Offer.checkoutPageURLTemplate`.
+	 *
+	 * Both URL fields point at the WC Shareable Checkout URL using the
+	 * **variation ID** so AI-routed traffic lands on checkout with the
+	 * right SKU pre-selected — no "choose your color" detour.
+	 *
+	 * Existing top-level enrichers (`add_inventory_level`, `add_currency`,
+	 * `add_shipping_details`, `add_handling_time`, `add_return_policy`,
+	 * `add_buy_action`, `add_checkout_page_url_template`) all operate on
+	 * `$markup['offers'][0]` — we reuse them by passing the variant's
+	 * own markup as `$markup` and the variation as `$product`. The
+	 * return policy is read from the parent (variants inherit the
+	 * parent's policy + final-sale flag, not their own).
+	 *
+	 * @param WC_Product $variation      The variation (a `WC_Product_Variation` at runtime; typed as `WC_Product` since the variation subclass isn't in PHPStan's stubs and the variation API used here is on the base class).
+	 * @param WC_Product $parent_product The variable parent (for image fallback + return-policy meta).
+	 * @param array      $settings       Plugin settings (for return policy + handling time).
+	 * @param string     $country        Store base country (for shipping).
+	 * @return array Schema.org Product entry suitable for `hasVariant[]`.
+	 */
+	private function build_variant_entry( $variation, $parent_product, array $settings, string $country ): array {
+		$entry = array( '@type' => 'Product' );
+
+		$this->add_variant_basics( $entry, $variation, $parent_product );
+
+		$entry['offers'] = array( $this->build_variant_offer_skeleton( $variation ) );
+
+		// All of these operate on `$entry['offers'][0]`; pass the variation
+		// as `$product` so per-variant data (stock, price) flows through.
+		// Return policy uses the parent — variants inherit, no per-variant
+		// final-sale override (deferred — Pattern B in the meta-box design).
+		$this->add_inventory_level( $entry, $variation );
+		$this->add_currency( $entry );
+		$this->add_shipping_details( $entry, $country );
+		$this->add_handling_time( $entry, $settings );
+		$this->add_return_policy( $entry, $parent_product, $settings, $country );
+
+		// BuyAction + checkoutPageURLTemplate both use the VARIATION ID
+		// (not the parent product ID) so the URL drops the buyer on
+		// checkout with the specific SKU.
+		$this->add_buy_action( $entry, $variation );
+		$this->add_checkout_page_url_template( $entry, $variation );
+
+		return $entry;
+	}
+
+	/**
+	 * Populate a variant entry with sku, image (with parent fallback),
+	 * and per-variant typed Schema.org properties from the variation's
+	 * specific attribute selections.
+	 *
+	 * `WC_Product_Variation::get_variation_attributes()` returns the
+	 * variation's specific picks as `['attribute_pa_color' => 'white']`.
+	 * We strip the `attribute_` prefix, look up the slug in
+	 * {@see CORE_ATTRIBUTE_MAP}, and emit the typed property.
+	 *
+	 * @param array      $entry          Variant markup, modified by reference.
+	 * @param WC_Product $variation      The variation.
+	 * @param WC_Product $parent_product The parent (image fallback only).
+	 */
+	private function add_variant_basics( array &$entry, $variation, $parent_product ): void {
+		$sku = $variation->get_sku();
+		if ( ! $sku ) {
+			// Mirror WC core's fallback: when no SKU is set, use the
+			// post ID. Schema.org requires an `sku` for AI-shopping rich
+			// results to fire.
+			$sku = (string) $variation->get_id();
+		}
+		$entry['sku'] = $sku;
+
+		$image_url = $this->get_variant_image_url( $variation, $parent_product );
+		if ( '' !== $image_url ) {
+			$entry['image'] = $image_url;
+		}
+
+		// Per-variant typed properties (color/size/material/pattern from
+		// the variation's specific attribute selections).
+		//
+		// Read meta directly via `read_variation_core_attributes()`
+		// rather than `get_variation_attributes()` — the latter is
+		// gated by the parent's "Used for variations" flag and silently
+		// returns empty when that flag is unset, even if per-variation
+		// values exist in postmeta. The misconfigured-variable
+		// `ProductGroup` override (see `detect_varies_by()`) depends on
+		// the typed value reaching the variant entry, so the same
+		// fallback path is the source of truth here too.
+		if ( ! method_exists( $variation, 'get_id' ) ) {
+			return;
+		}
+		$variation_attrs = self::read_variation_core_attributes( (int) $variation->get_id() );
+		foreach ( $variation_attrs as $slug => $value ) {
+			$schema_prop = self::CORE_ATTRIBUTE_MAP[ $slug ];
+			if ( array_key_exists( $schema_prop, $entry ) ) {
+				continue;
+			}
+			$entry[ $schema_prop ] = $this->display_name_for_attribute_value( $slug, $value );
+		}
+	}
+
+	/**
+	 * Resolve the image URL for a variant, falling back to the parent.
+	 *
+	 * WC's variation editor lets merchants upload a variation-specific
+	 * image; if none is set, the front-end falls back to the parent
+	 * product's image. Schema.org JSON-LD should mirror this behavior so
+	 * agents see a consistent image regardless of which variations were
+	 * photographed.
+	 *
+	 * @param WC_Product $variation      The variation.
+	 * @param WC_Product $parent_product The variable parent (fallback).
+	 * @return string Absolute image URL, or empty string when neither has one.
+	 */
+	private function get_variant_image_url( $variation, $parent_product ): string {
+		$image_id = $variation->get_image_id();
+		if ( ! $image_id && $parent_product ) {
+			$image_id = $parent_product->get_image_id();
+		}
+		if ( ! $image_id || ! function_exists( 'wp_get_attachment_image_url' ) ) {
+			return '';
+		}
+		$image_url = wp_get_attachment_image_url( $image_id, 'full' );
+		return is_string( $image_url ) ? $image_url : '';
+	}
+
+	/**
+	 * Convert a variation attribute value to its display form.
+	 *
+	 * For taxonomy attributes (`pa_*`), the variation stores the **term
+	 * slug** (e.g. `white`); we resolve it to the display name (`White`)
+	 * via `get_term_by()`. For free-text custom attributes, the value is
+	 * stored as-is and used directly.
+	 *
+	 * @param string $slug  Attribute slug (e.g. `pa_color`).
+	 * @param string $value The raw value (term slug for taxonomy, literal for free-text).
+	 * @return string Display-name form, or the input value as fallback.
+	 */
+	private function display_name_for_attribute_value( string $slug, string $value ): string {
+		if ( ! str_starts_with( $slug, 'pa_' ) || ! function_exists( 'get_term_by' ) ) {
+			return $value;
+		}
+		$term = get_term_by( 'slug', $value, $slug );
+		if ( $term instanceof \WP_Term && '' !== $term->name ) {
+			return $term->name;
+		}
+		return $value;
+	}
+
+	/**
+	 * Build the bare-minimum Offer skeleton for a variant — price,
+	 * priceCurrency, availability. The remaining fields (inventory,
+	 * shipping, return policy, checkoutPageURLTemplate) are layered on
+	 * by the existing enrichers, exactly as they are for the parent
+	 * Product's offer.
+	 *
+	 * @param WC_Product $variation The variation.
+	 * @return array Single Offer block.
+	 */
+	private function build_variant_offer_skeleton( $variation ): array {
+		$price        = function_exists( 'wc_format_decimal' ) && function_exists( 'wc_get_price_decimals' )
+			? wc_format_decimal( $variation->get_price(), wc_get_price_decimals() )
+			: (string) $variation->get_price();
+		$availability = $variation->is_in_stock()
+			? 'https://schema.org/InStock'
+			: 'https://schema.org/OutOfStock';
+
+		return array(
+			'@type'         => 'Offer',
+			'price'         => $price,
+			'priceCurrency' => function_exists( 'get_woocommerce_currency' ) ? get_woocommerce_currency() : 'USD',
+			'availability'  => $availability,
 		);
 	}
 

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -678,6 +678,22 @@ class WC_AI_Storefront_JsonLd {
 			return;
 		}
 
+		// Prime the post + meta caches for all children in a single
+		// query each, before any per-child read. Both `detect_varies_by()`
+		// (via `read_variation_core_attributes()`) and the per-variant
+		// build loop below touch every child; without priming, a 50-
+		// variation product would issue 50+ separate `get_post_meta()`
+		// queries plus 50+ `wc_get_product()` lookups during one page
+		// render. `_prime_post_caches` keeps the WC product factory's
+		// cache hot too — `wc_get_product()` reads from the WP post
+		// cache before falling through to the database.
+		if ( function_exists( '_prime_post_caches' ) ) {
+			_prime_post_caches( $children, false, false );
+		}
+		if ( function_exists( 'update_meta_cache' ) ) {
+			update_meta_cache( 'post', $children );
+		}
+
 		$varies_by = self::detect_varies_by( $product );
 		if ( empty( $varies_by ) ) {
 			// Variations exist but nothing is flagged "Used for variations"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-07T20:45:40+00:00\n"
+"POT-Creation-Date: 2026-05-07T21:04:34+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1281
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1292
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-07T19:43:38+00:00\n"
+"POT-Creation-Date: 2026-05-07T19:53:27+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1225
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1241
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-07T19:53:27+00:00\n"
+"POT-Creation-Date: 2026-05-07T20:19:57+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1241
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1271
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-07T18:17:51+00:00\n"
+"POT-Creation-Date: 2026-05-07T19:43:38+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:694
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1225
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-07T20:19:57+00:00\n"
+"POT-Creation-Date: 2026-05-07T20:45:40+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,7 +82,7 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1271
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1281
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -311,6 +311,27 @@ if ( ! class_exists( 'WC_Product' ) ) {
 			return '19.99';
 		}
 
+		public function get_sku(): string {
+			return '';
+		}
+
+		public function get_image_id(): int {
+			return 0;
+		}
+
+		/**
+		 * Real WC_Product returns variation IDs for variable products,
+		 * grouped product IDs for grouped products, empty array for
+		 * simple/external. Test stub returns empty by default — tests
+		 * that exercise the variable-products path override via
+		 * `make_product([ 'children' => [...] ])`.
+		 *
+		 * @return int[]
+		 */
+		public function get_children(): array {
+			return [];
+		}
+
 		// Stock.
 		public function managing_stock(): bool {
 			return false;

--- a/tests/php/unit/JsonLdNormalizationTest.php
+++ b/tests/php/unit/JsonLdNormalizationTest.php
@@ -52,6 +52,9 @@ class JsonLdNormalizationTest extends \PHPUnit\Framework\TestCase {
 				return $url . $sep . $query . $fragment;
 			}
 		);
+		Functions\when( 'home_url' )->alias(
+			static fn( $path = '' ) => 'https://example.com' . $path
+		);
 		Functions\when( 'wc_get_product_cat_ids' )->justReturn( [] );
 		Functions\when( 'wc_get_base_location' )->justReturn(
 			[ 'country' => 'US' ]
@@ -92,6 +95,8 @@ class JsonLdNormalizationTest extends \PHPUnit\Framework\TestCase {
 		$product->shouldReceive( 'has_dimensions' )->andReturn( false );
 		$product->shouldReceive( 'get_dimensions' )->andReturn( [] );
 		$product->shouldReceive( 'get_attributes' )->andReturn( [] );
+		$product->shouldReceive( 'get_children' )->andReturn( [] );
+		$product->shouldReceive( 'get_sku' )->andReturn( '' );
 		return $product;
 	}
 

--- a/tests/php/unit/JsonLdReturnPolicyTest.php
+++ b/tests/php/unit/JsonLdReturnPolicyTest.php
@@ -45,6 +45,9 @@ class JsonLdReturnPolicyTest extends \PHPUnit\Framework\TestCase {
 				return $url . $sep . $query . $fragment;
 			}
 		);
+		Functions\when( 'home_url' )->alias(
+			static fn( $path = '' ) => 'https://example.com' . $path
+		);
 		Functions\when( 'wc_get_product_cat_ids' )->justReturn( [] );
 		Functions\when( 'wc_get_base_location' )->justReturn(
 			[ 'country' => 'US' ]
@@ -103,6 +106,8 @@ class JsonLdReturnPolicyTest extends \PHPUnit\Framework\TestCase {
 		$product->shouldReceive( 'has_dimensions' )->andReturn( false );
 		$product->shouldReceive( 'get_dimensions' )->andReturn( [] );
 		$product->shouldReceive( 'get_attributes' )->andReturn( [] );
+		$product->shouldReceive( 'get_children' )->andReturn( [] );
+		$product->shouldReceive( 'get_sku' )->andReturn( '' );
 		return $product;
 	}
 

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -95,6 +95,17 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		// the per-test `$this->post_meta_by_id` table populated by
 		// `make_variation()`. The closure captures `$this` so each test
 		// gets the table state at call time, not at setUp time.
+		//
+		// FOOT-GUN: an individual test calling
+		// `Functions\when( 'get_post_meta' )->justReturn( ... )` will
+		// silently REPLACE this aliased version (Brain Monkey keeps the
+		// most recent binding). When that happens, every variation in
+		// the test loses its `attribute_<slug>` reads and ProductGroup
+		// detection falls back to "no varying axis." If you need to
+		// override `get_post_meta` for a specific key in one test, use
+		// a fresh alias that consults `$this->post_meta_by_id` for the
+		// keys this stub already serves and your custom logic for the
+		// rest — don't `justReturn` over the whole function.
 		$test = $this;
 		Functions\when( 'get_post_meta' )->alias(
 			static function ( $post_id, $key = '', $single = false ) use ( $test ) {

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -179,6 +179,8 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 	private function make_product( array $overrides = [] ): Mockery\MockInterface {
 		$product = Mockery::mock( 'WC_Product' );
 		$product->shouldReceive( 'get_id' )->andReturn( $overrides['id'] ?? 42 );
+		$product->shouldReceive( 'get_name' )
+			->andReturn( $overrides['name'] ?? 'Test Product' );
 		$product->shouldReceive( 'get_permalink' )
 			->andReturn( $overrides['permalink'] ?? 'https://example.com/product/test/' );
 		$product->shouldReceive( 'managing_stock' )
@@ -472,6 +474,31 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 'tee-white-l', $entry['sku'] );
 	}
 
+	public function test_variant_entry_emits_id_url_and_name(): void {
+		// `@id` and `name` are Schema.org Product fundamentals — agents
+		// dereference `@id` to fetch the variant's own page and
+		// `name` is what surfaces in rich-result snippets. Regression
+		// guard for PR #338 review feedback (these went missing in the
+		// initial implementation).
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product( [ 'id' => 100 ] );
+		$variation = $this->make_variation( [
+			'id'        => 101,
+			'name'      => 'Hoodie - Blue, Logo: Yes',
+			'permalink' => 'https://example.com/product/hoodie/?attribute_pa_color=blue&attribute_logo=Yes',
+		] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertSame(
+			'https://example.com/product/hoodie/?attribute_pa_color=blue&attribute_logo=Yes',
+			$entry['@id']
+		);
+		$this->assertSame( $entry['@id'], $entry['url'] );
+		$this->assertSame( 'Hoodie - Blue, Logo: Yes', $entry['name'] );
+	}
+
 	public function test_variant_entry_falls_back_to_id_when_no_sku(): void {
 		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
 
@@ -751,6 +778,45 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		// The simple-Product enrichers (BuyAction, currency, etc.) still ran.
 		$this->assertArrayHasKey( 'potentialAction', $result );
 		$this->assertArrayHasKey( 'offers', $result );
+	}
+
+	public function test_unbuyable_variations_fall_back_to_simple_product(): void {
+		// Regression guard for PR #338 review feedback: when
+		// `get_children()` returns IDs but `wc_get_product()` resolves
+		// none of them (data corruption, soft-deleted variations, or a
+		// stale WP cache), we MUST NOT emit a `ProductGroup` with empty
+		// `hasVariant` and the parent's `offers` + `potentialAction`
+		// already dropped. That would produce a strictly-worse shape
+		// than the simple-Product fallback (no offers, no buy action,
+		// no variants — completely unbuyable). Build the variants
+		// FIRST and only commit the conversion when at least one
+		// resolved.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		// Stub `wc_get_product()` to return false for every child ID
+		// — simulating the corrupted-data case.
+		Functions\when( 'wc_get_product' )->justReturn( false );
+
+		$parent = $this->make_product( [
+			'id'                   => 100,
+			'children'             => [ 901, 902, 903 ],
+			'variation_attributes' => array( 'pa_color' => array( 'red', 'blue' ) ),
+		] );
+
+		$markup = array(
+			'@type'           => 'Product',
+			'offers'          => array( array( '@type' => 'Offer', 'price' => '20' ) ),
+			'potentialAction' => array( '@type' => 'BuyAction' ),
+		);
+		$result = $this->jsonld->enhance_product_data( $markup, $parent );
+
+		$this->assertSame( 'Product', $result['@type'] );
+		$this->assertArrayNotHasKey( 'hasVariant', $result );
+		$this->assertArrayNotHasKey( 'productGroupID', $result );
+		$this->assertArrayNotHasKey( 'variesBy', $result );
+		// Critical: the parent-level offers + potentialAction must
+		// survive intact. Pre-fix, both were unconditionally dropped.
+		$this->assertArrayHasKey( 'offers', $result );
+		$this->assertArrayHasKey( 'potentialAction', $result );
 	}
 
 	public function test_simple_product_does_not_convert_to_product_group(): void {

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -49,22 +49,32 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 			'product_selection_mode' => 'all',
 		];
 
-		// add_query_arg is the only WP function we consistently need
-		// across tests — simple passthrough that appends params.
+		// `add_query_arg()` mock mirroring WP's actual behavior. Two
+		// places this differs from PHP's native `http_build_query`:
+		//
+		// 1. WP's `add_query_arg` → `build_query` → `_http_build_query`
+		//    is called with `$urlencode = false`, so values are NOT
+		//    URL-encoded. A pre-0.11 mock built on `http_build_query`
+		//    silently produced `utm_source=%7Bagent_id%7D` while
+		//    production emitted `utm_source={agent_id}` — RFC 6570
+		//    placeholders survive verbatim.
+		// 2. WP strips and re-appends the URI fragment around the
+		//    query string. Without this, a permalink like
+		//    `.../widget/#reviews` would produce
+		//    `.../widget/#reviews?add-to-cart=42` where the whole
+		//    query is in the fragment and never reaches the server.
 		Functions\when( 'add_query_arg' )->alias(
 			static function ( $args, $url ) {
-				// Strip any fragment before appending query params, then
-				// re-append it — matching WordPress core's behavior.
-				// Without this, a permalink like `.../widget/#reviews`
-				// would produce `.../widget/#reviews?add-to-cart=42`
-				// where the entire query string is part of the fragment
-				// and never reaches the server.
 				$fragment = '';
 				if ( str_contains( $url, '#' ) ) {
 					[ $url, $fragment ] = explode( '#', $url, 2 );
 					$fragment = '#' . $fragment;
 				}
-				$query = http_build_query( $args );
+				$pairs = array();
+				foreach ( $args as $k => $v ) {
+					$pairs[] = $k . '=' . $v;
+				}
+				$query = implode( '&', $pairs );
 				$sep   = str_contains( $url, '?' ) ? '&' : '?';
 				return $url . $sep . $query . $fragment;
 			}
@@ -253,15 +263,19 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$url = $result['potentialAction']['target']['urlTemplate'];
 		// Shareable Checkout URL format (0.11.0+): the URL goes through
 		// WC's `/checkout-link/` rewrite handler with `?products=ID:1`.
-		// The `:` is URL-encoded as `%3A` by `http_build_query`.
+		// Values are NOT URL-encoded — WP's `add_query_arg()` uses
+		// `_http_build_query( ..., $urlencode = false )`, which lets
+		// the `:` separator and the RFC 6570 `{...}` placeholders
+		// survive verbatim so consumers can substitute variables
+		// without first decoding the URL.
 		$this->assertStringContainsString( '/checkout-link/', $url );
-		$this->assertStringContainsString( 'products=42%3A1', $url );
-		$this->assertStringContainsString( 'utm_source=%7Bagent_id%7D', $url );
+		$this->assertStringContainsString( 'products=42:1', $url );
+		$this->assertStringContainsString( 'utm_source={agent_id}', $url );
 		// Canonical UTM shape (0.5.0+): medium=referral (Google-canonical),
 		// utm_id=woo_ucp flags "we routed this".
 		$this->assertStringContainsString( 'utm_medium=referral', $url );
 		$this->assertStringContainsString( 'utm_id=woo_ucp', $url );
-		$this->assertStringContainsString( 'ai_session_id=%7Bsession_id%7D', $url );
+		$this->assertStringContainsString( 'ai_session_id={session_id}', $url );
 	}
 
 	public function test_buyaction_url_uses_home_checkout_link_not_product_permalink(): void {
@@ -325,7 +339,8 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 		$url = $result['offers'][0]['checkoutPageURLTemplate'];
 		$this->assertStringStartsWith( 'https://example.com/checkout-link/', $url );
-		$this->assertStringContainsString( 'products=42%3A1', $url );
+		$this->assertStringContainsString( 'products=42:1', $url );
+		$this->assertStringContainsString( 'utm_source={agent_id}', $url );
 		$this->assertStringContainsString( 'utm_id=woo_ucp', $url );
 	}
 
@@ -563,7 +578,7 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$entry = $this->invoke_build_variant_entry( $variation, $parent );
 
 		$url = $entry['potentialAction']['target']['urlTemplate'];
-		$this->assertStringContainsString( 'products=999%3A1', $url );
+		$this->assertStringContainsString( 'products=999:1', $url );
 		$this->assertStringNotContainsString( 'products=100', $url );
 	}
 
@@ -863,6 +878,21 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$result = $this->jsonld->allow_product_group_type( [ 'product', 'breadcrumblist' ] );
 
 		$this->assertNotContains( 'productgroup', $result );
+	}
+
+	public function test_allow_product_group_type_does_not_duplicate_when_already_present(): void {
+		// Another plugin (or this filter running multiple times against
+		// the same `$types` array) may have already added
+		// `productgroup`. Avoid duplicates — they're noise in the
+		// allow-list even though WC core's intersection step doesn't
+		// break on them.
+		Functions\when( 'is_product' )->justReturn( true );
+
+		$result = $this->jsonld->allow_product_group_type( [ 'product', 'productgroup', 'breadcrumblist' ] );
+
+		$this->assertSame( 1, count( array_keys( $result, 'productgroup', true ) ) );
+		$this->assertContains( 'product', $result );
+		$this->assertContains( 'breadcrumblist', $result );
 	}
 
 	public function test_offer_checkout_page_url_template_omitted_when_no_offers(): void {

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -24,9 +24,21 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 
 	private WC_AI_Storefront_JsonLd $jsonld;
 
+	/**
+	 * Per-post postmeta lookup table consulted by the `get_post_meta`
+	 * stub installed in setUp(). Tests populate via `make_variation()`
+	 * (when a variation_attributes override is supplied) so the
+	 * variation's `attribute_<slug>` reads return the test fixture's
+	 * values. Other meta keys still fall through to empty.
+	 *
+	 * @var array<int,array<string,string>>
+	 */
+	private array $post_meta_by_id = [];
+
 	protected function setUp(): void {
 		parent::setUp();
 		Monkey\setUp();
+		$this->post_meta_by_id = [];
 		WC_Shipping_Zones::$test_zones = [];
 		$this->jsonld = new WC_AI_Storefront_JsonLd();
 
@@ -57,6 +69,12 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 				return $url . $sep . $query . $fragment;
 			}
 		);
+		// `home_url()` is the base of the Shareable Checkout URL the
+		// BuyAction emits. Stub a stable value so URL-shape assertions
+		// don't depend on the WP test bootstrap's site URL.
+		Functions\when( 'home_url' )->alias(
+			static fn( $path = '' ) => 'https://example.com' . $path
+		);
 		Functions\when( 'wc_get_product_cat_ids' )->justReturn( [] );
 		Functions\when( 'wc_get_base_location' )->justReturn(
 			[ 'country' => 'US', 'state' => 'CA' ]
@@ -72,7 +90,21 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		// Stub the per-product final-sale meta read to "not flagged"
 		// across all tests in this file. Per-product override coverage
 		// lives in JsonLdReturnPolicyTest's dedicated branch.
-		Functions\when( 'get_post_meta' )->justReturn( '' );
+		//
+		// Variation-attribute postmeta (`attribute_<slug>`) reads consult
+		// the per-test `$this->post_meta_by_id` table populated by
+		// `make_variation()`. The closure captures `$this` so each test
+		// gets the table state at call time, not at setUp time.
+		$test = $this;
+		Functions\when( 'get_post_meta' )->alias(
+			static function ( $post_id, $key = '', $single = false ) use ( $test ) {
+				$post_id = (int) $post_id;
+				if ( isset( $test->post_meta_by_id[ $post_id ][ $key ] ) ) {
+					return $test->post_meta_by_id[ $post_id ][ $key ];
+				}
+				return '';
+			}
+		);
 		// Default `wp_get_post_parent_id()` to 0 — these tests use
 		// non-variation product mocks. Override-scope resolution
 		// happens at the `enhance_product_data` entry point.
@@ -154,6 +186,12 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 			->andReturn( $overrides['attributes'] ?? [] );
 		$product->shouldReceive( 'get_variation_attributes' )
 			->andReturn( $overrides['variation_attributes'] ?? [] );
+		$product->shouldReceive( 'get_image_id' )
+			->andReturn( $overrides['image_id'] ?? 0 );
+		$product->shouldReceive( 'get_children' )
+			->andReturn( $overrides['children'] ?? [] );
+		$product->shouldReceive( 'get_sku' )
+			->andReturn( $overrides['sku'] ?? '' );
 		return $product;
 	}
 
@@ -200,13 +238,35 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( 'BuyAction', $result['potentialAction']['@type'] );
 
 		$url = $result['potentialAction']['target']['urlTemplate'];
-		$this->assertStringContainsString( 'add-to-cart=42', $url );
+		// Shareable Checkout URL format (0.11.0+): the URL goes through
+		// WC's `/checkout-link/` rewrite handler with `?products=ID:1`.
+		// The `:` is URL-encoded as `%3A` by `http_build_query`.
+		$this->assertStringContainsString( '/checkout-link/', $url );
+		$this->assertStringContainsString( 'products=42%3A1', $url );
 		$this->assertStringContainsString( 'utm_source=%7Bagent_id%7D', $url );
 		// Canonical UTM shape (0.5.0+): medium=referral (Google-canonical),
 		// utm_id=woo_ucp flags "we routed this".
 		$this->assertStringContainsString( 'utm_medium=referral', $url );
 		$this->assertStringContainsString( 'utm_id=woo_ucp', $url );
 		$this->assertStringContainsString( 'ai_session_id=%7Bsession_id%7D', $url );
+	}
+
+	public function test_buyaction_url_uses_home_checkout_link_not_product_permalink(): void {
+		// Regression guard: the URL must NOT be derived from the
+		// product permalink (the pre-0.11.0 shape used `add-to-cart=ID`
+		// on the product page). A custom permalink shouldn't appear in
+		// the output.
+		$product = $this->make_product(
+			[ 'permalink' => 'https://example.com/product/widget/#tab-description' ]
+		);
+		$result  = $this->jsonld->enhance_product_data( [], $product );
+
+		$url = $result['potentialAction']['target']['urlTemplate'];
+
+		$this->assertStringStartsWith( 'https://example.com/checkout-link/', $url );
+		$this->assertStringNotContainsString( '/product/widget/', $url );
+		$this->assertStringNotContainsString( '#tab-description', $url );
+		$this->assertStringNotContainsString( 'add-to-cart=', $url );
 	}
 
 	public function test_buyaction_declares_web_platforms(): void {
@@ -218,77 +278,525 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 		$this->assertContains( 'https://schema.org/MobileWebPlatform', $platforms );
 	}
 
-	public function test_buyaction_uritemplate_preserves_fragment_from_permalink(): void {
-		// Some themes append tab deep-links to product permalinks, e.g.
-		// `https://example.com/product/widget/#tab-description`. The real
-		// `add_query_arg()` strips the fragment, appends query params to
-		// the base URL, then re-appends the fragment — producing a
-		// well-formed URL where the query string is readable by the server.
-		//
-		// Regression guard: the mock must behave identically so CI catches
-		// any future production-code change that re-introduces the bug.
-		$product = $this->make_product(
-			[ 'permalink' => 'https://example.com/product/widget/#tab-description' ]
+	// ------------------------------------------------------------------
+	// Offer.checkoutPageURLTemplate (#328) — coexists with BuyAction
+	// ------------------------------------------------------------------
+
+	public function test_offer_emits_checkout_page_url_template_with_same_url_as_buyaction(): void {
+		// Both signals MUST carry the same URL value — different consumers
+		// key on different Schema.org paths but should resolve to the same
+		// destination.
+		$markup  = array(
+			'@type'  => 'Product',
+			'offers' => array( array( '@type' => 'Offer', 'price' => '20.00' ) ),
 		);
-		$result  = $this->jsonld->enhance_product_data( [], $product );
+		$product = $this->make_product();
 
-		$url = $result['potentialAction']['target']['urlTemplate'];
+		$result = $this->jsonld->enhance_product_data( $markup, $product );
 
-		// Query params must appear BEFORE the fragment separator.
-		$fragment_pos    = strpos( $url, '#' );
-		$query_param_pos = strpos( $url, 'add-to-cart=' );
-
-		$this->assertNotFalse( $fragment_pos, 'urlTemplate should still contain the fragment' );
-		$this->assertNotFalse( $query_param_pos, 'urlTemplate should contain add-to-cart param' );
-		$this->assertLessThan(
-			$fragment_pos,
-			$query_param_pos,
-			'Query params must appear before the # fragment separator'
+		$this->assertSame(
+			$result['potentialAction']['target']['urlTemplate'],
+			$result['offers'][0]['checkoutPageURLTemplate'],
+			'BuyAction.urlTemplate and Offer.checkoutPageURLTemplate must carry the same URL value'
 		);
+	}
 
-		// The fragment itself should be intact at the very end.
-		$this->assertStringEndsWith( '#tab-description', $url );
+	public function test_offer_checkout_page_url_template_uses_shareable_checkout_format(): void {
+		$markup  = array(
+			'@type'  => 'Product',
+			'offers' => array( array( '@type' => 'Offer', 'price' => '20.00' ) ),
+		);
+		$product = $this->make_product();
 
-		// Sanity: attribution params must survive too.
+		$result = $this->jsonld->enhance_product_data( $markup, $product );
+
+		$url = $result['offers'][0]['checkoutPageURLTemplate'];
+		$this->assertStringStartsWith( 'https://example.com/checkout-link/', $url );
+		$this->assertStringContainsString( 'products=42%3A1', $url );
 		$this->assertStringContainsString( 'utm_id=woo_ucp', $url );
 	}
 
-	public function test_buyaction_uritemplate_preserves_fragment_when_permalink_has_existing_query(): void {
-		// Combination case: permalink already carries a query string
-		// (e.g. a language plugin adds `?lang=fr`) AND has a fragment.
-		// The mock's `?`-vs-`&` separator check must look at the
-		// fragment-stripped URL so it finds the existing `?` and uses
-		// `&`. Without the fragment strip, a naive check on the full
-		// URL including `#reviews` would still find `?` and use `&`
-		// — but only by accident; the fragment would still land in the
-		// wrong position. This test pins both invariants explicitly.
-		$product = $this->make_product(
-			[ 'permalink' => 'https://example.com/product/widget/?lang=fr#tab-description' ]
+	// ------------------------------------------------------------------
+	// detect_varies_by() — Schema.org URLs for varying variation axes (#328)
+	// ------------------------------------------------------------------
+
+	/**
+	 * Direct test of the static helper via reflection. Covers slug→URL
+	 * mapping, "actually varies" filtering (>1 distinct value), and
+	 * unmapped-axis text-label fallback.
+	 */
+	private function invoke_detect_varies_by( Mockery\MockInterface $product ): array {
+		$method = new \ReflectionMethod( WC_AI_Storefront_JsonLd::class, 'detect_varies_by' );
+		return $method->invoke( null, $product );
+	}
+
+	public function test_detect_varies_by_returns_schema_urls_for_mapped_attributes(): void {
+		$product = $this->make_product( [
+			'variation_attributes' => array(
+				'pa_color' => array( 'navy', 'white', 'gray' ),
+				'pa_size'  => array( 'l', 'm', 's', 'xl' ),
+			),
+		] );
+
+		$result = $this->invoke_detect_varies_by( $product );
+
+		$this->assertContains( 'https://schema.org/color', $result );
+		$this->assertContains( 'https://schema.org/size', $result );
+		$this->assertCount( 2, $result );
+	}
+
+	public function test_detect_varies_by_excludes_uniform_axes(): void {
+		// pa_color has only one distinct value ("navy") — all variations
+		// are navy, only sizes differ. Color shouldn't appear in variesBy.
+		$product = $this->make_product( [
+			'variation_attributes' => array(
+				'pa_color' => array( 'navy' ),
+				'pa_size'  => array( 'l', 'm', 's' ),
+			),
+		] );
+
+		$result = $this->invoke_detect_varies_by( $product );
+
+		$this->assertSame( array( 'https://schema.org/size' ), $result );
+	}
+
+	public function test_detect_varies_by_returns_empty_for_non_variable_product(): void {
+		// Simple product (no `variation_attributes` override → returns []).
+		$product = $this->make_product();
+
+		$result = $this->invoke_detect_varies_by( $product );
+
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_detect_varies_by_returns_empty_for_variable_with_no_varying_axes(): void {
+		// Edge case: variable product where every axis has at most one
+		// value (Product 16 misconfigured-variable territory).
+		$product = $this->make_product( [
+			'variation_attributes' => array(
+				'pa_color' => array( '' ),
+				'pa_size'  => array( '' ),
+			),
+		] );
+
+		$result = $this->invoke_detect_varies_by( $product );
+
+		$this->assertSame( array(), $result );
+	}
+
+	public function test_detect_varies_by_emits_text_label_for_unmapped_axis(): void {
+		// Custom merchant axes (not in CORE_ATTRIBUTE_MAP) emit as plain
+		// Text labels so agents see SOME signal. Schema.org `variesBy`
+		// accepts both URL-shaped Text and plain Text per spec.
+		Functions\when( 'wc_attribute_label' )->alias(
+			static fn( $slug ) => ucfirst( str_replace( 'pa_', '', $slug ) )
 		);
-		$result  = $this->jsonld->enhance_product_data( [], $product );
+		$product = $this->make_product( [
+			'variation_attributes' => array(
+				'pa_style' => array( 'casual', 'formal', 'sport' ),
+			),
+		] );
 
-		$url = $result['potentialAction']['target']['urlTemplate'];
+		$result = $this->invoke_detect_varies_by( $product );
 
-		// Original query param must survive.
-		$this->assertStringContainsString( 'lang=fr', $url );
+		$this->assertSame( array( 'Style' ), $result );
+	}
 
-		// All added params must appear before the fragment.
-		$fragment_pos    = strpos( $url, '#' );
-		$query_param_pos = strpos( $url, 'add-to-cart=' );
+	// ------------------------------------------------------------------
+	// build_variant_entry() — per-variation Product blocks (#328)
+	// ------------------------------------------------------------------
 
-		$this->assertNotFalse( $fragment_pos );
-		$this->assertNotFalse( $query_param_pos );
-		$this->assertLessThan(
-			$fragment_pos,
-			$query_param_pos,
-			'Added query params must appear before the # separator'
+	/**
+	 * Build a `WC_Product_Variation`-shaped mock for the per-variant tests.
+	 *
+	 * Variations expose the same WC_Product API plus `get_variation_attributes()`
+	 * which on a variation returns its specific picks like
+	 * `['attribute_pa_color' => 'white']` (different from the parent's
+	 * version which returns the SET of values across all variations).
+	 */
+	private function make_variation( array $overrides = [] ): Mockery\MockInterface {
+		$variation = $this->make_product( $overrides );
+		$variation->shouldReceive( 'get_price' )->andReturn( $overrides['price'] ?? '20.00' );
+		$variation->shouldReceive( 'is_in_stock' )->andReturn( $overrides['in_stock'] ?? true );
+
+		// `add_variant_basics()` reads typed-property values directly
+		// from variation postmeta (`attribute_<slug>`) — see the doc in
+		// `read_variation_core_attributes()` for why. Translate the
+		// `variation_attributes` test override into the postmeta lookup
+		// table so existing test fixtures keep working without each test
+		// having to know about the indirection.
+		$variation_id = (int) ( $overrides['id'] ?? 42 );
+		foreach ( ( $overrides['variation_attributes'] ?? [] ) as $key => $value ) {
+			$meta_key = str_starts_with( (string) $key, 'attribute_' )
+				? (string) $key
+				: 'attribute_' . (string) $key;
+			$this->post_meta_by_id[ $variation_id ][ $meta_key ] = (string) $value;
+		}
+		return $variation;
+	}
+
+	private function invoke_build_variant_entry(
+		Mockery\MockInterface $variation,
+		Mockery\MockInterface $parent
+	): array {
+		$method = new \ReflectionMethod( WC_AI_Storefront_JsonLd::class, 'build_variant_entry' );
+		return $method->invoke(
+			$this->jsonld,
+			$variation,
+			$parent,
+			[ 'enabled' => 'yes', 'return_policy' => [ 'mode' => 'unconfigured' ] ],
+			'US'
+		);
+	}
+
+	public function test_variant_entry_has_product_type_and_sku(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product( [ 'id' => 100 ] );
+		$variation = $this->make_variation( [ 'id' => 101, 'sku' => 'tee-white-l' ] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertSame( 'Product', $entry['@type'] );
+		$this->assertSame( 'tee-white-l', $entry['sku'] );
+	}
+
+	public function test_variant_entry_falls_back_to_id_when_no_sku(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product( [ 'id' => 100 ] );
+		$variation = $this->make_variation( [ 'id' => 101, 'sku' => '' ] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertSame( '101', $entry['sku'] );
+	}
+
+	public function test_variant_entry_emits_typed_color_from_variation_attribute(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+		// Free-text attribute (no `pa_` prefix): value used directly.
+		$parent    = $this->make_product();
+		$variation = $this->make_variation( [
+			'variation_attributes' => array( 'attribute_color' => 'White' ),
+		] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertSame( 'White', $entry['color'] );
+	}
+
+	public function test_variant_entry_offer_carries_price_currency_availability(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product();
+		$variation = $this->make_variation( [
+			'price'    => '20.00',
+			'in_stock' => true,
+		] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertCount( 1, $entry['offers'] );
+		$this->assertSame( '20.00', $entry['offers'][0]['price'] );
+		$this->assertSame( 'USD', $entry['offers'][0]['priceCurrency'] );
+		$this->assertSame( 'https://schema.org/InStock', $entry['offers'][0]['availability'] );
+	}
+
+	public function test_variant_entry_offer_marks_out_of_stock(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product();
+		$variation = $this->make_variation( [ 'in_stock' => false ] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertSame(
+			'https://schema.org/OutOfStock',
+			$entry['offers'][0]['availability']
+		);
+	}
+
+	public function test_variant_entry_buy_action_uses_variation_id_not_parent(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product( [ 'id' => 100 ] );
+		$variation = $this->make_variation( [ 'id' => 999 ] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$url = $entry['potentialAction']['target']['urlTemplate'];
+		$this->assertStringContainsString( 'products=999%3A1', $url );
+		$this->assertStringNotContainsString( 'products=100', $url );
+	}
+
+	public function test_variant_entry_offer_carries_checkout_page_url_template_with_variation_id(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product( [ 'id' => 100 ] );
+		$variation = $this->make_variation( [ 'id' => 999 ] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		$this->assertSame(
+			$entry['potentialAction']['target']['urlTemplate'],
+			$entry['offers'][0]['checkoutPageURLTemplate'],
+			'Per-variant BuyAction URL and checkoutPageURLTemplate must match'
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// ProductGroup conversion — variable-product end-to-end (#328)
+	// ------------------------------------------------------------------
+	//
+	// `enhance_product_data()` runs all the simple-product enrichers
+	// first (they describe shared characteristics that belong on the
+	// ProductGroup parent), then `maybe_convert_to_product_group()`
+	// reshapes the markup. These tests pin the converted shape:
+	// @type flips, productGroupID/variesBy/hasVariant added, parent's
+	// offers[] and potentialAction dropped (variants own them).
+
+	private function setup_wc_get_product_for_variations( array $variations ): void {
+		// Stub `wc_get_product()` to return one of `$variations` keyed by ID.
+		Functions\when( 'wc_get_product' )->alias(
+			static fn( $id ) => $variations[ (int) $id ] ?? false
+		);
+	}
+
+	public function test_variable_product_emits_as_product_group(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$variation = $this->make_variation( [ 'id' => 101, 'sku' => 'tee-w' ] );
+		$this->setup_wc_get_product_for_variations( [ 101 => $variation ] );
+
+		$parent = $this->make_product( [
+			'id'       => 100,
+			'sku'      => 'tee-parent',
+			'children' => [ 101 ],
+			'variation_attributes' => array(
+				'pa_color' => array( 'navy', 'white' ),
+			),
+		] );
+
+		$markup = array(
+			'@type'  => 'Product',
+			'name'   => 'V-Neck T-Shirt',
+			'offers' => array( array( '@type' => 'Offer', 'price' => '20.00' ) ),
 		);
 
-		// Exactly one `#` — no duplication of the fragment marker.
-		$this->assertSame( 1, substr_count( $url, '#' ) );
+		$result = $this->jsonld->enhance_product_data( $markup, $parent );
 
-		// Fragment intact at the end.
-		$this->assertStringEndsWith( '#tab-description', $url );
+		$this->assertSame( 'ProductGroup', $result['@type'] );
+		$this->assertSame( 'tee-parent', $result['productGroupID'] );
+	}
+
+	public function test_product_group_variesBy_lists_actually_varying_axes_only(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$variation = $this->make_variation( [ 'id' => 101 ] );
+		$this->setup_wc_get_product_for_variations( [ 101 => $variation ] );
+
+		$parent = $this->make_product( [
+			'id'       => 100,
+			'children' => [ 101 ],
+			'variation_attributes' => array(
+				'pa_color' => array( 'navy' ),  // uniform — should NOT appear
+				'pa_size'  => array( 'l', 'm', 's' ),
+			),
+		] );
+
+		$result = $this->jsonld->enhance_product_data( [], $parent );
+
+		$this->assertSame(
+			array( 'https://schema.org/size' ),
+			$result['variesBy']
+		);
+	}
+
+	public function test_product_group_drops_parent_offers_and_potential_action(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$variation = $this->make_variation( [ 'id' => 101 ] );
+		$this->setup_wc_get_product_for_variations( [ 101 => $variation ] );
+
+		$parent = $this->make_product( [
+			'id'                   => 100,
+			'children'             => [ 101 ],
+			'variation_attributes' => array( 'pa_color' => array( 'navy', 'red' ) ),
+		] );
+
+		$markup = array(
+			'@type'  => 'Product',
+			'offers' => array( array( '@type' => 'Offer', 'price' => '20.00' ) ),
+		);
+
+		$result = $this->jsonld->enhance_product_data( $markup, $parent );
+
+		$this->assertArrayNotHasKey( 'offers', $result );
+		$this->assertArrayNotHasKey( 'potentialAction', $result );
+	}
+
+	public function test_product_group_emits_one_has_variant_entry_per_child(): void {
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$v1 = $this->make_variation( [ 'id' => 101, 'sku' => 'tee-w' ] );
+		$v2 = $this->make_variation( [ 'id' => 102, 'sku' => 'tee-n' ] );
+		$v3 = $this->make_variation( [ 'id' => 103, 'sku' => 'tee-g' ] );
+		$this->setup_wc_get_product_for_variations( [ 101 => $v1, 102 => $v2, 103 => $v3 ] );
+
+		$parent = $this->make_product( [
+			'id'                   => 100,
+			'children'             => [ 101, 102, 103 ],
+			'variation_attributes' => array( 'pa_color' => array( 'white', 'navy', 'green' ) ),
+		] );
+
+		$result = $this->jsonld->enhance_product_data( [], $parent );
+
+		$this->assertCount( 3, $result['hasVariant'] );
+		$skus = array_column( $result['hasVariant'], 'sku' );
+		$this->assertSame( array( 'tee-w', 'tee-n', 'tee-g' ), $skus );
+	}
+
+	public function test_product_group_falls_back_to_simple_product_when_no_variations(): void {
+		// Locked decision: variable + 0 children → keep simple Product
+		// shape (don't convert). Edge case for misconfigured stores
+		// where variations were deleted.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent = $this->make_product( [
+			'id'                   => 100,
+			'children'             => [],
+			'variation_attributes' => array( 'pa_color' => array( 'navy' ) ),
+		] );
+
+		$result = $this->jsonld->enhance_product_data( [ '@type' => 'Product' ], $parent );
+
+		$this->assertSame( 'Product', $result['@type'] );
+		$this->assertArrayNotHasKey( 'hasVariant', $result );
+		$this->assertArrayNotHasKey( 'productGroupID', $result );
+	}
+
+	public function test_misconfigured_variable_with_core_typed_axis_still_emits_product_group(): void {
+		// The "core typed override" path: parent attribute `pa_color`
+		// is NOT flagged "Used for variations" (so
+		// `get_variation_attributes()` returns []), but the variation
+		// children themselves have `attribute_pa_color` postmeta with
+		// distinct values. Schema.org has a canonical typed property
+		// for color, AI agents care about it, and the data is right
+		// there on each variation — we override the missing parent
+		// flag and emit ProductGroup with `variesBy: [color]` and
+		// per-variant typed `color` values.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$v1 = $this->make_variation( [ 'id' => 101, 'sku' => 'h-r', 'variation_attributes' => [ 'pa_color' => 'red' ] ] );
+		$v2 = $this->make_variation( [ 'id' => 102, 'sku' => 'h-g', 'variation_attributes' => [ 'pa_color' => 'green' ] ] );
+		$v3 = $this->make_variation( [ 'id' => 103, 'sku' => 'h-b', 'variation_attributes' => [ 'pa_color' => 'blue' ] ] );
+		$this->setup_wc_get_product_for_variations( [ 101 => $v1, 102 => $v2, 103 => $v3 ] );
+
+		// Parent: variable, has children, but `get_variation_attributes()`
+		// returns empty (parent flag missing on `pa_color`).
+		$parent = $this->make_product( [
+			'id'                   => 100,
+			'children'             => [ 101, 102, 103 ],
+			'variation_attributes' => array(),  // parent flag unset
+		] );
+
+		Functions\when( 'get_term_by' )->justReturn( false );  // free-text fallback for term-name lookup
+
+		$result = $this->jsonld->enhance_product_data( [], $parent );
+
+		$this->assertSame( 'ProductGroup', $result['@type'] );
+		$this->assertSame( array( 'https://schema.org/color' ), $result['variesBy'] );
+		$this->assertCount( 3, $result['hasVariant'] );
+		$colors = array_column( $result['hasVariant'], 'color' );
+		$this->assertSame( array( 'red', 'green', 'blue' ), $colors );
+	}
+
+	public function test_misconfigured_variable_falls_back_to_simple_product(): void {
+		// Product 16 / Hoodie territory in the dev fixtures: variable
+		// type with variation children but **no** attribute is flagged
+		// "Used for variations". `detect_varies_by()` returns an empty
+		// array. Emitting `hasVariant` without `variesBy` would hand
+		// agents N near-identical blocks they can't tell apart, so we
+		// fall back to simple-Product shape — keep `offers` and
+		// `potentialAction`, no `hasVariant`, no `productGroupID`.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$v1 = $this->make_variation( [ 'id' => 101, 'variation_attributes' => [] ] );
+		$this->setup_wc_get_product_for_variations( [ 101 => $v1 ] );
+
+		$parent = $this->make_product( [
+			'id'                   => 100,
+			'children'             => [ 101 ],
+			'variation_attributes' => array(),  // no varying axes
+		] );
+
+		$markup = array( '@type' => 'Product', 'offers' => array( array( '@type' => 'Offer' ) ) );
+		$result = $this->jsonld->enhance_product_data( $markup, $parent );
+
+		$this->assertSame( 'Product', $result['@type'] );
+		$this->assertArrayNotHasKey( 'hasVariant', $result );
+		$this->assertArrayNotHasKey( 'productGroupID', $result );
+		$this->assertArrayNotHasKey( 'variesBy', $result );
+		// The simple-Product enrichers (BuyAction, currency, etc.) still ran.
+		$this->assertArrayHasKey( 'potentialAction', $result );
+		$this->assertArrayHasKey( 'offers', $result );
+	}
+
+	public function test_simple_product_does_not_convert_to_product_group(): void {
+		// Regression guard: simple products (no `get_variation_attributes()`
+		// stub on the WC_Product base) must not get the ProductGroup
+		// conversion. The capability gate is method_exists.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$product = $this->make_product( [ 'id' => 50 ] );
+
+		$markup = array( '@type' => 'Product', 'name' => 'Sunglasses' );
+		$result = $this->jsonld->enhance_product_data( $markup, $product );
+
+		$this->assertSame( 'Product', $result['@type'] );
+		$this->assertArrayNotHasKey( 'hasVariant', $result );
+	}
+
+	// ------------------------------------------------------------------
+	// allow_product_group_type — registers `productgroup` on the WC core
+	// per-page allow-list so the rewritten @type survives
+	// `WC_Structured_Data::get_structured_data()`. Without this hook
+	// the entire ProductGroup block is silently dropped on the
+	// front-end (regression observed against TT5 + WC 10.7).
+	// ------------------------------------------------------------------
+
+	public function test_allow_product_group_type_appends_productgroup_on_single_product(): void {
+		Functions\when( 'is_product' )->justReturn( true );
+
+		$result = $this->jsonld->allow_product_group_type( [ 'product', 'breadcrumblist' ] );
+
+		$this->assertContains( 'productgroup', $result );
+		// Existing types must survive untouched — we only append.
+		$this->assertContains( 'product', $result );
+		$this->assertContains( 'breadcrumblist', $result );
+	}
+
+	public function test_allow_product_group_type_does_not_append_off_product_pages(): void {
+		// On non-product pages (cart, archive, generic post) we have no
+		// reason to admit `productgroup`, and admitting it indiscriminately
+		// could surface a stale ProductGroup block from a transient if a
+		// future feature ever caches structured data globally.
+		Functions\when( 'is_product' )->justReturn( false );
+
+		$result = $this->jsonld->allow_product_group_type( [ 'product', 'breadcrumblist' ] );
+
+		$this->assertNotContains( 'productgroup', $result );
+	}
+
+	public function test_offer_checkout_page_url_template_omitted_when_no_offers(): void {
+		// Defensive: products without an offer (rare — typically
+		// non-purchasable) shouldn't get a stranded checkoutPageURLTemplate
+		// on a non-existent Offer.
+		$product = $this->make_product();
+
+		$result = $this->jsonld->enhance_product_data( [], $product );
+
+		$this->assertArrayNotHasKey( 'offers', $result );
 	}
 
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Variable products with at least one varying axis now emit Schema.org `ProductGroup` with `productGroupID`, `variesBy`, and per-variant `hasVariant: [...]` entries — each variant carrying its own SKU, image, typed Schema.org property (color/size/material/pattern), Offer, and a BuyAction whose URL targets the variation ID so AI deep-links land directly on the specific SKU.
- `Offer.checkoutPageURLTemplate` now emits alongside the existing `BuyAction.target.urlTemplate`. Both URLs use the WooCommerce Shareable Checkout URL format (`/checkout-link/?products={id}:1&...`), so consumers reading from either property resolve a working AI-attribution-tagged link.
- Core-typed override for misconfigured variable products: when the parent's "Used for variations" flag is unset on `pa_color`/`pa_size`/`pa_material`/`pa_pattern` but variation children still have distinct values, we read the postmeta directly and emit ProductGroup correctly. Limited to the four canonical Schema.org typed slugs; unmapped custom attributes still honor the parent flag.

Closes #328.

## Notable implementation details

**`woocommerce_structured_data_type_for_page` hook.** WC core's `WC_Structured_Data::get_structured_data()` keys output by `strtolower(@type)` and intersects with a per-page allow-list that ships only `product`, `breadcrumblist`, `review`, `order`. Without registering `productgroup`, the entire ProductGroup block is silently dropped at output time — symptom surfaced during smoke testing on TT5 + WC 10.7. The new `allow_product_group_type()` hook appends `productgroup` on single-product pages.

**Core-typed override path.** `WC_Product_Variable::get_variation_attributes()` and `WC_Product_Variation::get_attributes()` are both gated by the parent attribute's `is_variation` flag — they return empty when the merchant configured per-variation values but didn't flag the parent. The variation's `attribute_<slug>` postmeta is still populated, so for the four core typed slugs we read meta directly via `read_variation_core_attributes()`. Both axis detection (`detect_varies_by()`) and per-variant typed-property emission (`add_variant_basics()`) consume the same helper.

**Misconfigured-variable fallback.** When neither path surfaces a varying axis (variations exist but nothing factually differs), we fall back to simple-Product emission — no `variesBy` to advertise means `hasVariant` would just hand agents N near-identical blocks they can't tell apart.

## Live verification

Smoke-tested against the local dev fixture set:

- **V-Neck T-Shirt** (proper variable, color + size flagged): `ProductGroup`, `variesBy: [color, size]`, 3 variants. ✓
- **Hoodie** (variable, `pa_color` is_variation=0, but children have distinct color values in postmeta): `ProductGroup`, `variesBy: [color]`, 4 variants each carrying typed `color`. ✓
- **Beanie / Pennant** (simple): `Product`, unchanged. ✓

## Test plan

- [x] `npm run build` (unchanged — no JS surface)
- [x] PHPUnit (1228 tests pass; +24 net new for #328)
- [x] PHPCS clean
- [x] PHPStan clean
- [x] Smoke-tested four product types on local dev (`http://localhost:8030/product/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)