### PR TITLE
docs: post-B-group catch-up pass for ARCHITECTURE, HOOKS, USER-GUIDE

### DIFF
--- a/docs/engineering/ARCHITECTURE.md
+++ b/docs/engineering/ARCHITECTURE.md
@@ -22,13 +22,13 @@ AI agents are a fast-growing product-discovery channel. The plugin lets merchant
 │     (ChatGPT, Gemini, Perplexity, Claude, Copilot, any bot)         │
 └───────┬──────────────┬──────────────┬────────────────────┬──────────┘
         │              │              │                    │
-  ┌─────▼─────┐ ┌─────▼──────┐ ┌─────▼────────┐ ┌──────────▼──────────┐
-  │ /llms.txt │ │ UCP        │ │  JSON-LD     │ │ UCP REST API        │
-  │ (Markdown)│ │ Manifest   │ │ Product +    │ │ /wp-json/wc/ucp/v1/ │
-  │           │ │ (JSON)     │ │ OnlineStore  │ │                     │
-  │           │ │/.well-known│ │ (homepage +  │ │                     │
-  │           │ │   /ucp     │ │ product page)│ │                     │
-  └────────────┘ └─────────────┘ └──────────────┘ └──────────┬─────────┘
+  ┌─────▼─────┐ ┌─────▼──────┐ ┌─────▼─────────┐ ┌──────────▼──────────┐
+  │ /llms.txt │ │ UCP        │ │  JSON-LD      │ │ UCP REST API        │
+  │ (Markdown)│ │ Manifest   │ │ Product +     │ │ /wp-json/wc/ucp/v1/ │
+  │           │ │ (JSON)     │ │ OnlineBusiness│ │                     │
+  │           │ │/.well-known│ │ (homepage +   │ │                     │
+  │           │ │   /ucp     │ │ product page) │ │                     │
+  └────────────┘ └─────────────┘ └───────────────┘ └──────────┬─────────┘
         │              │              │                     │
         └──────────────┼──────────────┴─────────────────────┘
                        │                         │
@@ -56,7 +56,7 @@ AI agents are a fast-growing product-discovery channel. The plugin lets merchant
 | File | Endpoint | Purpose |
 |------|----------|---------|
 | `class-wc-ai-storefront-llms-txt.php` | `/llms.txt` | Machine-readable store guide: name, categories, products, attribution instructions. |
-| `class-wc-ai-storefront-jsonld.php` | Product pages + homepage / shop page | **Per product:** enhanced Schema.org `Product` markup — BuyAction, inventory, attributes, shipping (`OfferShippingDetails` with handlingTime + free-shipping rate), return policy. **Homepage / shop page:** Schema.org `OnlineStore` (an `Organization` subtype, since 0.10.0; previously `Store`/`LocalBusiness`) with auto-sourced identity fields: `logo` (custom-logo theme mod → site-icon fallback), `address` (PostalAddress from `WC()->countries->get_base_*` minus `streetAddress`, suppressed for privacy), `contactPoint.email` (two-stage from `woocommerce_email_reply_to_address` → `woocommerce_email_from_address` with noreply guard, never falls back to `admin_email`). See [`JSON-LD-SCHEMA.md`](JSON-LD-SCHEMA.md) for the full field reference and example output. |
+| `class-wc-ai-storefront-jsonld.php` | Product pages + homepage / shop page | **Per product:** enhanced Schema.org `Product` markup — typed properties (`color`/`size`/`material`/`pattern`), BuyAction with Shareable Checkout URL, `Offer.checkoutPageURLTemplate`, inventory, attributes, shipping (`OfferShippingDetails` with handlingTime + free-shipping rate), per-Offer return policy, and `isRelatedTo`/`isSimilarTo` from cross-sells/upsells. Variable products convert to Schema.org `ProductGroup` with per-variant `hasVariant` entries (with a postmeta-direct override path for misconfigured variations where the parent's "Used for variations" flag is unset). **Homepage / shop page:** Schema.org `OnlineBusiness` (an `Organization` subtype) with auto-sourced identity fields — `logo` (custom-logo theme mod → site-icon fallback), `address` (PostalAddress from `WC()->countries->get_base_*` minus `streetAddress`, suppressed for privacy), `contactPoint.email` (two-stage from `woocommerce_email_reply_to_address` → `woocommerce_email_from_address` with noreply guard, never falls back to `admin_email`) — plus `knowsAbout` (top product category names from cached catalog summary) and Org-level `hasMerchantReturnPolicy` when the merchant's return policy is configured. See [`JSON-LD-SCHEMA.md`](JSON-LD-SCHEMA.md) for the full field reference and example output. |
 | `class-wc-ai-storefront-robots.php` | `/robots.txt` | Allow-lists known AI crawlers, allows discovery endpoints, blocks checkout/account. |
 | `class-wc-ai-storefront-ucp.php` | `/.well-known/ucp` | JSON manifest declaring implemented capabilities (catalog, checkout), pointing at the UCP REST adapter, advertising empty `payment_handlers` for the redirect-only posture. |
 

--- a/docs/engineering/HOOKS.md
+++ b/docs/engineering/HOOKS.md
@@ -38,7 +38,7 @@ add_filter( 'wc_ai_storefront_jsonld_product', function( $markup, $product, $set
 
 ### `wc_ai_storefront_jsonld_store`
 
-Filter the store-level JSON-LD emitted on the homepage and shop page (Schema.org `OnlineStore`, an `Organization` subtype). The filter receives the fully-assembled structure including auto-sourced identity fields (`logo`, `address`, `contactPoint.email`) so plugins can layer extra identity claims without re-implementing the WP/WC reads.
+Filter the store-level JSON-LD emitted on the homepage and shop page (Schema.org `OnlineBusiness`, an `Organization` subtype). The filter receives the fully-assembled structure including auto-sourced identity fields (`logo`, `address`, `contactPoint.email`), `knowsAbout` (top category names), and Org-level `hasMerchantReturnPolicy` (when configured) — so plugins can layer extra identity claims without re-implementing the WP/WC reads.
 
 ```php
 apply_filters( 'wc_ai_storefront_jsonld_store', array $store_data, array $settings );

--- a/docs/user-guide/USER-GUIDE.md
+++ b/docs/user-guide/USER-GUIDE.md
@@ -124,6 +124,8 @@ Your homepage now publishes your store's brand details (name, logo, address, con
 | Email | Your WooCommerce email | See **Customer service email** below. |
 | Search | Auto-generated | Lets AI agents search your store. |
 | Categories | Auto-generated | A summary of your main product types. |
+| Return policy | Your plugin settings | Edit at **WooCommerce → Settings → AI Storefront → Policies**. See [section 7](#7-set-your-store-policies). Published only when you've set a policy other than "Not configured". |
+| Specialties | Auto-generated | A short list of what your store specializes in, derived from your top product categories. |
 
 **About the address.** Only your city, state, zip, and country are published to AI agents. Your street address is intentionally hidden for privacy and safety — if you use your home address for tax purposes, it stays private.
 
@@ -222,6 +224,8 @@ Stats update hourly, so today's AI traffic appears in the dashboard within an ho
 ## 7. Set your store policies
 
 The **Policies** tab publishes structured signals that AI agents read when deciding what to show shoppers: return terms, shipping timelines, and more. Two cards are currently available.
+
+Your return policy publishes in two places: on each product page (so an AI agent recommending one of your products can mention the policy), AND on your homepage (so an agent that discovers your store before a specific product can learn the store-wide commitment up-front). Per-product overrides — see below — only affect the per-product copy.
 
 ### Return & refund policy
 


### PR DESCRIPTION
## Summary

JSON-LD-SCHEMA.md and SCHEMA-ORG-COVERAGE.md were updated incrementally during the B-group execution (#338, #339, #343, #344, #345). The three other docs in AGENTS.md's path-to-doc map for \`class-wc-ai-storefront-jsonld.php\` — ARCHITECTURE.md, HOOKS.md, USER-GUIDE.md — were deferred per the "one doc pass before release" preference. This is that pass.

## Three factual gaps closed

**ARCHITECTURE.md** — two stale references:
- ASCII data-flow diagram showed \`OnlineStore\` in the JSON-LD column. Updated to \`OnlineBusiness\` with the box widths adjusted to keep the diagram aligned.
- Module table summary for \`class-wc-ai-storefront-jsonld.php\` was a point-in-time snapshot from before the B-group. Rewritten to mention typed-property emission, ProductGroup conversion, \`isRelatedTo\`/\`isSimilarTo\`, OnlineBusiness type, \`knowsAbout\`, and Org-level \`hasMerchantReturnPolicy\`.

**HOOKS.md** — \`wc_ai_storefront_jsonld_store\` filter description said "Schema.org \`OnlineStore\`" → updated to \`OnlineBusiness\`. Also expanded the "auto-sourced fields" list the filter receives to include the new \`knowsAbout\` and Org-level \`hasMerchantReturnPolicy\`, since plugins layering identity claims via this filter benefit from knowing those fields are already present in \`\$store_data\`.

**USER-GUIDE.md** — two adjustments:
- §4a "What the homepage publishes to AI agents" table: added two rows — Return policy (links to §7) and Specialties (\`knowsAbout\` in user-friendly framing).
- §7 "Set your store policies": added a sentence clarifying the policy publishes both per-product AND at the homepage level, with a note that per-product overrides only affect the per-product copy.

## Test plan

Doc-only — no code or test changes.

- [x] Production code unchanged
- [x] PHPUnit unaffected (1255 tests pass, same as main)
- [x] PHPCS / PHPStan untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)