### PR TITLE
perf(ucp): batch variation fetching for /catalog/search and /catalog/lookup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,14 +27,14 @@
 ### Refactors
 
 - **Batched variation fetching for `/catalog/search` and `/catalog/lookup`.** Closes #351.
-  - Internal `rest_do_request` dispatches reduced from O(total_variations) to O(ceil(total_variations/100)) per request via `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100` — the only Store API parameter that surfaces `post_type='product_variation'` through the collection endpoint.
+  - Internal `rest_do_request` dispatches reduced from O(total_variations) to O(ceil(total_variations/100)) per request via `GET /wc/store/v1/products?type=variation&parent=<csv>&per_page=100`. Two params combine to surface variations through the collection endpoint: `type=variation` flips the underlying WP_Query's `post_type` from the default `'product'` to `'product_variation'`; `parent=<csv>` populates `post_parent__in` via WC's `wp_parse_id_list` sanitizer.
   - For a 20-product `/catalog/search` response with 30% variable products and avg 5 variations each: dispatches collapse from 30 to 1. Heavy-variable catalogs (60% variable × 8 vars, ~96 total variations) collapse from 96 to 1. Wall-clock impact scales with `rest_do_request` cost on the host (typically 15–40ms warm, 60–100ms cold) — exact gains depend on object-cache state.
   - For a 5-ID `/catalog/lookup` of all-variable products averaging 5 variations: dispatches collapse from 30 to 6.
   - Lookup handler refactored to a two-pass structure: fetch all parents first, then batch their variations, then translate. Search handler pre-fetches before the per-product loop.
   - `partial_variants` warning preserved: cap-overage and missing-variation cases still emit the warning so agents see when a product's variant list is incomplete.
   - `MAX_VARIATIONS_PER_PRODUCT` cap (50) preserved per-parent. Cap-truncated entries contribute to `skipped` count.
   - Per-page failure handling: a page-1 dispatch failure degrades every variable parent to `variations: [], skipped: total_declared` (degenerate fallback). Page-N failures (after one or more pages have already succeeded) keep prior-page data; only parents whose variations weren't returned see `skipped > 0`. Avoids punishing fully-captured parents for a later-page failure that didn't affect them.
-  - `wc_ai_storefront_ucp_store_api_args` filter applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string for symmetry; pagination keys (`page`, `per_page`, `parent_includes`) are restored after the filter so callbacks can't break the page-walk invariant.
+  - `wc_ai_storefront_ucp_store_api_args` filter applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string for symmetry; the four dispatch-shape keys (`type`, `parent`, `page`, `per_page`) are restored after the filter so callbacks can't break the post_type targeting or the page-walk invariant.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@
 
 ## [0.12.0] – 2026-05-08
 
+### Performance
+
+- **Batched variation fetching for `/catalog/search` and `/catalog/lookup`.** Closes #351.
+  - Internal `rest_do_request` dispatches reduced from O(total_variations) to O(ceil(total_variations/100)) per request via `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100` — the only Store API parameter that surfaces `post_type='product_variation'` through the collection endpoint.
+  - For a 20-product `/catalog/search` response with 30% variable products and avg 5 variations each: dispatches collapse from 30 to 1, saving ~700ms warm and ~2s+ cold-cache per request. Heavy-variable catalogs (60% variable × 8 vars) save ~2.4s warm, ~7s cold.
+  - For a 5-ID `/catalog/lookup` of all-variable products: dispatches collapse from 30 to 6, saving ~600ms.
+  - Lookup handler refactored to a two-pass structure: fetch all parents first, then batch their variations, then translate. Search handler pre-fetches before the per-product loop.
+  - `partial_variants` warning preserved: cap-overage and missing-variation cases still emit the warning so agents see when a product's variant list is incomplete.
+  - `MAX_VARIATIONS_PER_PRODUCT` cap (50) preserved per-parent. Cap-truncated entries contribute to `skipped` count.
+  - Failure policy: when the batch dispatch returns WP_Error or 5xx, every variable parent gracefully degrades to `variations: [], skipped: total_declared`. Matches today's worst case for individual fetch failures while making the typical case dramatically faster.
+  - `wc_ai_storefront_ucp_store_api_args` filter applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string for symmetry; pagination keys (`page`, `per_page`, `parent_includes`) are restored after the filter so callbacks can't break the page-walk invariant.
+
 ### Fixes
 
 - **UCP wire-format compliance with `release/2026-04-08`.** Closes #349.
@@ -29,6 +41,7 @@
 - Added `UcpShapeTest` running JSON Schema validation against the canonical UCP `release/2026-04-08` schemas vendored at `tests/fixtures/ucp-schemas/`. 12 new tests cover all touched shapes including the `lookup_variant` allOf merge.
 - Added `opis/json-schema` v2.6 as a dev dependency — only PHP library with complete draft-2020-12 / `$defs` / cross-file `$ref` support.
 - Updated existing translator + REST controller tests for the new key names and message shapes (~15 sites). Hard-cut regression guards (`assertArrayNotHasKey`) for the old keys.
+- Added `UcpVariationBatchTest` (14 tests) covering the batched variation helper directly: empty/all-simple guards, single-/multi-parent dispatch shape, >100-variation pagination, partial response detection, WP_Error degradation, MAX cap overage, `wc_ai_storefront_ucp_store_api_args` filter compatibility.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,18 +10,6 @@
 
 ## [0.12.0] – 2026-05-08
 
-### Performance
-
-- **Batched variation fetching for `/catalog/search` and `/catalog/lookup`.** Closes #351.
-  - Internal `rest_do_request` dispatches reduced from O(total_variations) to O(ceil(total_variations/100)) per request via `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100` — the only Store API parameter that surfaces `post_type='product_variation'` through the collection endpoint.
-  - For a 20-product `/catalog/search` response with 30% variable products and avg 5 variations each: dispatches collapse from 30 to 1. Heavy-variable catalogs (60% variable × 8 vars, ~96 total variations) collapse from 96 to 1. Wall-clock impact scales with `rest_do_request` cost on the host (typically 15–40ms warm, 60–100ms cold) — exact gains depend on object-cache state.
-  - For a 5-ID `/catalog/lookup` of all-variable products averaging 5 variations: dispatches collapse from 30 to 6.
-  - Lookup handler refactored to a two-pass structure: fetch all parents first, then batch their variations, then translate. Search handler pre-fetches before the per-product loop.
-  - `partial_variants` warning preserved: cap-overage and missing-variation cases still emit the warning so agents see when a product's variant list is incomplete.
-  - `MAX_VARIATIONS_PER_PRODUCT` cap (50) preserved per-parent. Cap-truncated entries contribute to `skipped` count.
-  - Per-page failure handling: a page-1 dispatch failure degrades every variable parent to `variations: [], skipped: total_declared` (degenerate fallback). Page-N failures (after one or more pages have already succeeded) keep prior-page data; only parents whose variations weren't returned see `skipped > 0`. Avoids punishing fully-captured parents for a later-page failure that didn't affect them.
-  - `wc_ai_storefront_ucp_store_api_args` filter applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string for symmetry; pagination keys (`page`, `per_page`, `parent_includes`) are restored after the filter so callbacks can't break the page-walk invariant.
-
 ### Fixes
 
 - **UCP wire-format compliance with `release/2026-04-08`.** Closes #349.
@@ -35,6 +23,18 @@
   - **Lookup per-variant `inputs[]` correlation.** Per `catalog_lookup.json#/$defs/lookup_variant`, every variant in a lookup response must carry `inputs: [{id, match}]` with `minItems: 1`. Top-level envelope `inputs` echo was non-spec and is dropped. Each variant now declares `[{id: <input>, match: 'featured'}]`.
   - **Message shape compliance.** `message_error.json` requires `content` (we omitted on `not_found`); `message_warning.json` and `message_info.json` have no `severity` field (we emitted `severity: 'advisory'` as a non-spec extension on 14 sites). Added required content; dropped severity from all warning/info emissions.
   - **Release context.** Pre-1.0 minor bump for substantive wire-format scope. Spec-conforming agents reading our responses today are already getting validation rejections; this release fixes that. No coordination needed with public agent integrations because none read our specific non-conformant keys.
+
+### Refactors
+
+- **Batched variation fetching for `/catalog/search` and `/catalog/lookup`.** Closes #351.
+  - Internal `rest_do_request` dispatches reduced from O(total_variations) to O(ceil(total_variations/100)) per request via `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100` — the only Store API parameter that surfaces `post_type='product_variation'` through the collection endpoint.
+  - For a 20-product `/catalog/search` response with 30% variable products and avg 5 variations each: dispatches collapse from 30 to 1. Heavy-variable catalogs (60% variable × 8 vars, ~96 total variations) collapse from 96 to 1. Wall-clock impact scales with `rest_do_request` cost on the host (typically 15–40ms warm, 60–100ms cold) — exact gains depend on object-cache state.
+  - For a 5-ID `/catalog/lookup` of all-variable products averaging 5 variations: dispatches collapse from 30 to 6.
+  - Lookup handler refactored to a two-pass structure: fetch all parents first, then batch their variations, then translate. Search handler pre-fetches before the per-product loop.
+  - `partial_variants` warning preserved: cap-overage and missing-variation cases still emit the warning so agents see when a product's variant list is incomplete.
+  - `MAX_VARIATIONS_PER_PRODUCT` cap (50) preserved per-parent. Cap-truncated entries contribute to `skipped` count.
+  - Per-page failure handling: a page-1 dispatch failure degrades every variable parent to `variations: [], skipped: total_declared` (degenerate fallback). Page-N failures (after one or more pages have already succeeded) keep prior-page data; only parents whose variations weren't returned see `skipped > 0`. Avoids punishing fully-captured parents for a later-page failure that didn't affect them.
+  - `wc_ai_storefront_ucp_store_api_args` filter applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string for symmetry; pagination keys (`page`, `per_page`, `parent_includes`) are restored after the filter so callbacks can't break the page-walk invariant.
 
 ### Tests
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,12 +14,12 @@
 
 - **Batched variation fetching for `/catalog/search` and `/catalog/lookup`.** Closes #351.
   - Internal `rest_do_request` dispatches reduced from O(total_variations) to O(ceil(total_variations/100)) per request via `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100` — the only Store API parameter that surfaces `post_type='product_variation'` through the collection endpoint.
-  - For a 20-product `/catalog/search` response with 30% variable products and avg 5 variations each: dispatches collapse from 30 to 1, saving ~700ms warm and ~2s+ cold-cache per request. Heavy-variable catalogs (60% variable × 8 vars) save ~2.4s warm, ~7s cold.
-  - For a 5-ID `/catalog/lookup` of all-variable products: dispatches collapse from 30 to 6, saving ~600ms.
+  - For a 20-product `/catalog/search` response with 30% variable products and avg 5 variations each: dispatches collapse from 30 to 1. Heavy-variable catalogs (60% variable × 8 vars, ~96 total variations) collapse from 96 to 1. Wall-clock impact scales with `rest_do_request` cost on the host (typically 15–40ms warm, 60–100ms cold) — exact gains depend on object-cache state.
+  - For a 5-ID `/catalog/lookup` of all-variable products averaging 5 variations: dispatches collapse from 30 to 6.
   - Lookup handler refactored to a two-pass structure: fetch all parents first, then batch their variations, then translate. Search handler pre-fetches before the per-product loop.
   - `partial_variants` warning preserved: cap-overage and missing-variation cases still emit the warning so agents see when a product's variant list is incomplete.
   - `MAX_VARIATIONS_PER_PRODUCT` cap (50) preserved per-parent. Cap-truncated entries contribute to `skipped` count.
-  - Failure policy: when the batch dispatch returns WP_Error or 5xx, every variable parent gracefully degrades to `variations: [], skipped: total_declared`. Matches today's worst case for individual fetch failures while making the typical case dramatically faster.
+  - Per-page failure handling: a page-1 dispatch failure degrades every variable parent to `variations: [], skipped: total_declared` (degenerate fallback). Page-N failures (after one or more pages have already succeeded) keep prior-page data; only parents whose variations weren't returned see `skipped > 0`. Avoids punishing fully-captured parents for a later-page failure that didn't affect them.
   - `wc_ai_storefront_ucp_store_api_args` filter applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string for symmetry; pagination keys (`page`, `per_page`, `parent_includes`) are restored after the filter so callbacks can't break the page-walk invariant.
 
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@
 - Added `UcpShapeTest` running JSON Schema validation against the canonical UCP `release/2026-04-08` schemas vendored at `tests/fixtures/ucp-schemas/`. 12 new tests cover all touched shapes including the `lookup_variant` allOf merge.
 - Added `opis/json-schema` v2.6 as a dev dependency — only PHP library with complete draft-2020-12 / `$defs` / cross-file `$ref` support.
 - Updated existing translator + REST controller tests for the new key names and message shapes (~15 sites). Hard-cut regression guards (`assertArrayNotHasKey`) for the old keys.
-- Added `UcpVariationBatchTest` (14 tests) covering the batched variation helper directly: empty/all-simple guards, single-/multi-parent dispatch shape, >100-variation pagination, partial response detection, WP_Error degradation, MAX cap overage, `wc_ai_storefront_ucp_store_api_args` filter compatibility.
+- Added `UcpVariationBatchTest` (21 tests) covering the batched variation helper directly: empty/all-simple guards, single-/multi-parent dispatch shape (asserts both `type=variation` AND `parent=<csv>`), >100-variation pagination with early-stop optimization, source-order preservation, partial response detection, WP_Error / HTTP >= 400 degradation, MAX cap overage, all-malformed-pointer fallback, stdClass response normalization, `wc_ai_storefront_ucp_store_api_args` filter compatibility.
 
 ---
 

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3091,8 +3091,8 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// the per-variation `fetch_variations_for()`: agents should see
 		// a `partial_variants` warning when their product has more
 		// variations than we'll fetch.
-		$expected_per_parent  = array();
-		$declared_per_parent  = array();
+		$expected_per_parent = array();
+		$declared_per_parent = array();
 		foreach ( $wc_products as $wc_product ) {
 			if ( ! is_array( $wc_product ) ) {
 				continue;

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -90,15 +90,15 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 *
 	 * Pre-#351 this also bounded the per-variation N+1 fan-out — fewer
 	 * IDs in the worklist meant fewer dispatches. Post-#351 variations
-	 * batch via `?parent_includes=`, so the cap no longer bounds the
-	 * Store API response: WC returns ALL of a parent's variations
-	 * regardless of our cap (the binner then drops everything past the
-	 * first MAX_VARIATIONS_PER_PRODUCT IDs in the parent's declared
-	 * order). The page-walk has an early-stop optimization to avoid
-	 * fetching beyond the expected set, but for high-variation parents
-	 * where the API returns the expected IDs late in pagination, the
-	 * batch can still normalize more variations than it ultimately
-	 * emits.
+	 * batch via `?type=variation&parent=<csv>`, so the cap no longer
+	 * bounds the Store API response: WC returns ALL of a parent's
+	 * variations regardless of our cap (the binner then drops
+	 * everything past the first MAX_VARIATIONS_PER_PRODUCT IDs in the
+	 * parent's declared order). The page-walk has an early-stop
+	 * optimization to avoid fetching beyond the expected set, but for
+	 * high-variation parents where the API returns the expected IDs
+	 * late in pagination, the batch can still normalize more
+	 * variations than it ultimately emits.
 	 *
 	 * What the cap DOES bound: emitted variant count, translator
 	 * workload, response payload size to the agent.
@@ -3049,15 +3049,28 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * API dispatch(es), replacing the per-variation N+1 fan-out in
 	 * `fetch_variations_for()`.
 	 *
-	 * Uses `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100`,
+	 * Uses `GET /wc/store/v1/products?type=variation&parent=<csv>&per_page=100`,
 	 * where `<csv>` is a comma-separated list of parent product IDs (NOT
-	 * variation IDs — `parent_includes` is the only Store API parameter
-	 * that surfaces `post_type='product_variation'` through the
-	 * collection endpoint, by filtering on the variations' `post_parent`
-	 * field). Verified live: `?parent_includes=35` returns the 10
-	 * variations of product 35 in one response. Pagination kicks in
-	 * when combined variation count across all parents exceeds 100; we
-	 * walk pages until short-page sentinel.
+	 * variation IDs). Two params combine to surface variations through
+	 * the collection endpoint:
+	 *
+	 *   - `type=variation` flips the underlying WP_Query's `post_type`
+	 *     from `'product'` (the default for this collection route) to
+	 *     `'product_variation'`. Without it, the route would never
+	 *     return any variations, since variations live under a different
+	 *     post type. (Source: WC `StoreApi/Utilities/ProductQuery.php`,
+	 *     `prepare_objects_query()` around the `if ( ProductType::VARIATION
+	 *     === $request['type'] )` branch.)
+	 *
+	 *   - `parent=<csv>` populates `post_parent__in`, sanitized through
+	 *     `wp_parse_id_list` so a comma-separated string is accepted and
+	 *     normalized to an int array. (Source: same file, line `'parent'
+	 *     => $params['parent']` registers as an `array<int>` with
+	 *     `wp_parse_id_list` sanitizer; parameter schema in
+	 *     `StoreApi/Routes/V1/Products.php`.)
+	 *
+	 * Pagination kicks in when combined variation count across all
+	 * parents exceeds 100; we walk pages until short-page sentinel.
 	 *
 	 * For typical traffic (20-product /catalog/search, 30% variable, avg
 	 * 5 variations each), this collapses ~30 dispatches to 1. Worst real-
@@ -3193,9 +3206,9 @@ class WC_AI_Storefront_UCP_REST_Controller {
 
 		$parent_ids = array_keys( $expected_per_parent );
 
-		// Walk pages of `parent_includes=<csv>&per_page=100` until short-
-		// page sentinel. WC Store API caps per_page at 100; for the rare
-		// pages with combined-variation > 100 we paginate.
+		// Walk pages of `?type=variation&parent=<csv>&per_page=100`
+		// until short-page sentinel. WC Store API caps per_page at 100;
+		// for the rare pages with combined-variation > 100 we paginate.
 		//
 		// Failure handling is per-page rather than per-batch: when page N
 		// errors we KEEP whatever we've already collected (pages 1..N-1)
@@ -3239,9 +3252,10 @@ class WC_AI_Storefront_UCP_REST_Controller {
 
 		while ( ! empty( $parent_ids ) ) {
 			$store_params = array(
-				'parent_includes' => implode( ',', $parent_ids ),
-				'per_page'        => $per_page,
-				'page'            => $page,
+				'type'     => 'variation',
+				'parent'   => implode( ',', $parent_ids ),
+				'per_page' => $per_page,
+				'page'     => $page,
 			);
 
 			// Apply the same filter the search dispatch uses, with the
@@ -3255,12 +3269,15 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			if ( ! is_array( $filtered ) ) {
 				$filtered = $store_params_before_filter;
 			}
-			// Restore pagination keys — filters MAY override scope but
-			// MUST NOT override our pagination state, which would break
-			// the page-walk invariant.
-			$filtered['per_page']        = $per_page;
-			$filtered['page']            = $page;
-			$filtered['parent_includes'] = $store_params['parent_includes'];
+			// Restore the four params we control — filters MAY override
+			// other scope keys (e.g. catalog filters) but MUST NOT
+			// override our dispatch shape, which would break either the
+			// post_type='product_variation' targeting (`type=variation`)
+			// or the page-walk invariant (`per_page`/`page`/`parent`).
+			$filtered['type']     = $store_params['type'];
+			$filtered['parent']   = $store_params['parent'];
+			$filtered['per_page'] = $per_page;
+			$filtered['page']     = $page;
 
 			$store_request = new WP_REST_Request( 'GET', '/wc/store/v1/products' );
 			foreach ( $filtered as $k => $v ) {

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -1034,14 +1034,26 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		$products         = array();
 		$variant_messages = array();
 
+		// Pre-fetch all variable products' variations in one (or few)
+		// batched dispatches before entering the per-product loop. For a
+		// 20-product / 30%-variable / avg-5-vars page this collapses
+		// ~30 internal `rest_do_request` dispatches to 1, saving
+		// ~700ms/request warm and ~2s+ cold-cache. See issue #351.
+		// Returns map keyed by parent ID; simple products absent.
+		$variations_by_parent = $this->fetch_variations_batched( $wc_products );
+
 		foreach ( $wc_products as $wc_product ) {
 			if ( ! is_array( $wc_product ) ) {
 				continue;
 			}
-			$variation_fetch = $this->fetch_variations_for( $wc_product );
+			$parent_id       = (int) ( $wc_product['id'] ?? 0 );
+			$variation_fetch = $variations_by_parent[ $parent_id ] ?? array(
+				'variations' => array(),
+				'skipped'    => 0,
+			);
 			if ( $variation_fetch['skipped'] > 0 ) {
 				$variant_messages[] = self::partial_variants_message(
-					(int) ( $wc_product['id'] ?? 0 ),
+					$parent_id,
 					$variation_fetch['skipped']
 				);
 			}

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3049,13 +3049,25 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * world case (heavy variable catalog, 60% variable × 8 vars = 96
 	 * variations) collapses to 1 dispatch (≤100) or 2 (>100).
 	 *
-	 * Failure policy: when the batch dispatch returns WP_Error or any
-	 * HTTP status >= 400 (treating 4xx and 5xx symmetrically — both
-	 * mean we can't trust the response body), every variable parent
-	 * in the input degrades to `variations: [], skipped: total_declared`
-	 * and emits one `partial_variants` warning per parent. Matches
-	 * today's worst case for individual fetch failures while making
-	 * the typical case dramatically faster.
+	 * Failure policy: WP_Error and HTTP status >= 400 are both treated
+	 * as page-level failures (4xx and 5xx symmetrically — both mean
+	 * we can't trust the response body). Two-tier degradation by which
+	 * page failed:
+	 *
+	 *   - Page-1 failure (degenerate): nothing was collected, so every
+	 *     variable parent degrades to `variations: [], skipped:
+	 *     total_declared` and each emits one `partial_variants`
+	 *     warning. Matches the worst case for individual fetch
+	 *     failures while keeping the typical case dramatically faster.
+	 *
+	 *   - Page-N failure (partial, N > 1): pages 1..N-1 already
+	 *     succeeded, so we KEEP that collected data and let the
+	 *     per-parent `skipped = total_declared - returned` math
+	 *     compute residue. Parents whose variations were fully
+	 *     captured on earlier pages see `skipped: 0`; parents
+	 *     missing variations from the failed page see `skipped > 0`
+	 *     and emit `partial_variants`. This avoids punishing fully-
+	 *     captured parents for an unrelated later-page error.
 	 *
 	 * MAX_VARIATIONS_PER_PRODUCT cap is enforced per-parent in the
 	 * expected-set used for response binning (cap-truncated variation

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3049,12 +3049,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * world case (heavy variable catalog, 60% variable × 8 vars = 96
 	 * variations) collapses to 1 dispatch (≤100) or 2 (>100).
 	 *
-	 * Failure policy: when the batch dispatch returns WP_Error or 5xx,
-	 * every variable parent in the input degrades to
-	 * `variations: [], skipped: total_declared` and emits one
-	 * `partial_variants` warning per parent. Matches today's worst case
-	 * for individual fetch failures while making the typical case
-	 * dramatically faster.
+	 * Failure policy: when the batch dispatch returns WP_Error or any
+	 * HTTP status >= 400 (treating 4xx and 5xx symmetrically — both
+	 * mean we can't trust the response body), every variable parent
+	 * in the input degrades to `variations: [], skipped: total_declared`
+	 * and emits one `partial_variants` warning per parent. Matches
+	 * today's worst case for individual fetch failures while making
+	 * the typical case dramatically faster.
 	 *
 	 * MAX_VARIATIONS_PER_PRODUCT cap is enforced per-parent in the
 	 * expected-set used for response binning (cap-truncated variation
@@ -3252,31 +3253,43 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				break;
 			}
 
-			$data = $store_response->get_data();
-			if ( ! is_array( $data ) ) {
+			// Internal-dispatch responses commonly nest as stdClass
+			// (the WC Store API REST controller wraps data in prepared
+			// `\WP_REST_Response` objects whose nested fields are
+			// objects, not arrays). The pre-fix `is_array($variation)`
+			// guard inside the loop silently dropped each one,
+			// degrading the batch to `variations: []` even on
+			// successful dispatch. Run the response through
+			// `normalize_store_api_data()` (the recursive stdClass→array
+			// cast already used by the per-ID path) so binning and
+			// downstream translators see uniform array shapes.
+			$normalized_data = self::normalize_store_api_data( $store_response->get_data() );
+			if ( null === $normalized_data ) {
 				if ( 1 === $page ) {
 					$first_page_failed = true;
 				}
 				break;
 			}
 
-			foreach ( $data as $variation ) {
+			foreach ( $normalized_data as $variation ) {
 				if ( is_array( $variation ) ) {
 					$all_variations[] = $variation;
 				}
 			}
 
-			// Empty response on a non-first page → done. Skip the extra
-			// dispatch that the short-page sentinel below would force
-			// when the previous page's count happened to land exactly
-			// at $per_page.
-			if ( empty( $data ) ) {
+			// An empty page terminates pagination. Note this still
+			// requires one extra dispatch when the prior page's count
+			// landed exactly at `$per_page` — we only learn the page
+			// is empty by asking. The short-page sentinel below
+			// avoids the extra dispatch in the more common case where
+			// the final page is short of `$per_page`.
+			if ( empty( $normalized_data ) ) {
 				break;
 			}
 
 			// Short-page sentinel: fewer items returned than requested
 			// means we've reached the end. Avoids needing X-WP-TotalPages.
-			if ( count( $data ) < $per_page ) {
+			if ( count( $normalized_data ) < $per_page ) {
 				break;
 			}
 

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -1578,6 +1578,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			}
 		}
 
+		// Pass 1: fetch all parent products + record not-found messages.
+		// Two-pass structure (vs. a single fetch+translate loop) lets us
+		// batch variation expansion across all variable parents in one
+		// dispatch instead of N. For a 5-ID lookup with all variable
+		// products averaging 5 variations, this collapses 25 internal
+		// `rest_do_request` dispatches to 1 — saving ~600ms warm and
+		// ~1.8s+ cold-cache. See issue #351.
+		$wc_products_by_index = array();
 		foreach ( $wc_ids as $index => $wc_id ) {
 			$id_echo   = (string) ( $inputs[ $index ] ?? '' );
 			$raw_index = (int) ( $positions[ $index ] ?? $index );
@@ -1592,16 +1600,25 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				continue;
 			}
 
-			// Variable products: pre-fetch each variation's full Store API
-			// response so the product translator can emit one real variant
-			// per variation rather than a synthesized default. When any
-			// variations fail to fetch, we still render the product (partial
-			// set beats synthesized fallback) but emit a `partial_variants`
-			// warning so agents know the variant list is incomplete.
-			$variation_fetch = $this->fetch_variations_for( $wc_product );
+			$wc_products_by_index[ $index ] = $wc_product;
+		}
+
+		// Pre-batch variations for all variable parents we just fetched.
+		// Map keyed by parent_id; simple products absent.
+		$variations_by_parent = $this->fetch_variations_batched(
+			array_values( $wc_products_by_index )
+		);
+
+		// Pass 2: translate each product using its pre-fetched variations.
+		foreach ( $wc_products_by_index as $index => $wc_product ) {
+			$wc_id           = (int) ( $wc_product['id'] ?? 0 );
+			$variation_fetch = $variations_by_parent[ $wc_id ] ?? array(
+				'variations' => array(),
+				'skipped'    => 0,
+			);
 			if ( $variation_fetch['skipped'] > 0 ) {
 				$messages[] = self::partial_variants_message(
-					(int) ( $wc_product['id'] ?? 0 ),
+					$wc_id,
 					$variation_fetch['skipped']
 				);
 			}
@@ -3161,8 +3178,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	private function fetch_variations_batched( array $wc_products ): array {
 		// Build the per-parent expected-set: parent_id => [variation_id, ...]
 		// (slice each parent's refs to MAX cap before adding to the work
-		// list). Keeps cap semantics identical to fetch_variations_for().
-		$expected_per_parent = array();
+		// list). Track total_declared separately so cap-truncation
+		// contributes to the `skipped` count — matches the contract of
+		// the per-variation `fetch_variations_for()`: agents should see
+		// a `partial_variants` warning when their product has more
+		// variations than we'll fetch.
+		$expected_per_parent  = array();
+		$declared_per_parent  = array();
 		foreach ( $wc_products as $wc_product ) {
 			if ( ! is_array( $wc_product ) ) {
 				continue;
@@ -3196,6 +3218,7 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			}
 
 			$expected_per_parent[ $parent_id ] = $expected_ids;
+			$declared_per_parent[ $parent_id ] = $total_declared;
 		}
 
 		// Edge case: no variable products (or all variable products have
@@ -3295,13 +3318,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		}
 
 		// Build the result map. On batch failure, every variable parent
-		// gets `variations: [], skipped: total_expected` so the partial-
-		// variants warning fires for each.
+		// gets `variations: [], skipped: total_declared` so the partial-
+		// variants warning fires for each. Use total_declared (not
+		// expected_capped) so cap overage still surfaces as skipped.
 		$result = array();
 		foreach ( $expected_per_parent as $parent_id => $expected_ids ) {
 			$result[ $parent_id ] = array(
 				'variations' => array(),
-				'skipped'    => $batch_failed ? count( $expected_ids ) : 0,
+				'skipped'    => $batch_failed ? $declared_per_parent[ $parent_id ] : 0,
 			);
 		}
 
@@ -3331,20 +3355,23 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			$result[ $parent_id ]['variations'][] = $variation;
 		}
 
-		// Compute skipped per parent: expected - actually returned.
-		// Includes scope-filtered + fetch-failed entries that the
-		// per-variation path would have caught.
+		// Compute skipped per parent: total_declared - actually_returned.
+		// Includes cap-truncated + scope-filtered + fetch-failed entries.
+		// Mirrors `fetch_variations_for()` semantics: the contract is
+		// that the agent sees a `partial_variants` warning whenever the
+		// emitted variant list is shorter than the parent's full set,
+		// regardless of why.
 		foreach ( $result as $parent_id => &$entry ) {
-			$expected_count   = count( $expected_per_parent[ $parent_id ] );
+			$declared_count   = $declared_per_parent[ $parent_id ];
 			$returned_count   = count( $entry['variations'] );
-			$entry['skipped'] = max( 0, $expected_count - $returned_count );
+			$entry['skipped'] = max( 0, $declared_count - $returned_count );
 
 			if ( $entry['skipped'] > 0 ) {
 				WC_AI_Storefront_Logger::debug(
 					sprintf(
-						'UCP fetch_variations_batched(parent=%d): expected %d, got %d, skipped %d',
+						'UCP fetch_variations_batched(parent=%d): declared %d, got %d, skipped %d',
 						$parent_id,
-						$expected_count,
+						$declared_count,
 						$returned_count,
 						$entry['skipped']
 					)

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3035,11 +3035,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * `fetch_variations_for()`.
 	 *
 	 * Uses `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100`,
-	 * which WC's collection endpoint supports for variation post-types
-	 * (verified live: `?parent_includes=35` returns the 10 variations of
-	 * product 35 in one response). Pagination kicks in when combined
-	 * variation count across all parents exceeds 100; we walk pages
-	 * until short-page sentinel.
+	 * where `<csv>` is a comma-separated list of parent product IDs (NOT
+	 * variation IDs — `parent_includes` is the only Store API parameter
+	 * that surfaces `post_type='product_variation'` through the
+	 * collection endpoint, by filtering on the variations' `post_parent`
+	 * field). Verified live: `?parent_includes=35` returns the 10
+	 * variations of product 35 in one response. Pagination kicks in
+	 * when combined variation count across all parents exceeds 100; we
+	 * walk pages until short-page sentinel.
 	 *
 	 * For typical traffic (20-product /catalog/search, 30% variable, avg
 	 * 5 variations each), this collapses ~30 dispatches to 1. Worst real-
@@ -3053,11 +3056,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * for individual fetch failures while making the typical case
 	 * dramatically faster.
 	 *
-	 * MAX_VARIATIONS_PER_PRODUCT cap is enforced per-parent at the
-	 * pre-fetch stage (slice variation refs before building the CSV).
-	 * Cap-truncated entries are not in the expected-set, so they don't
-	 * generate a skipped count — preserves the contract of
-	 * `fetch_variations_for()`.
+	 * MAX_VARIATIONS_PER_PRODUCT cap is enforced per-parent in the
+	 * expected-set used for response binning (cap-truncated variation
+	 * IDs are never in the expected-set, so the binner drops them
+	 * even though the Store API returns ALL variations of the parent).
+	 * `skipped` is computed as `total_declared - returned`, so cap
+	 * overage DOES contribute to the partial_variants warning count —
+	 * matching `fetch_variations_for()`'s historical contract that
+	 * agents see when their product overflows the cap.
 	 *
 	 * Scope gate: variations inherit visibility from their parent. The
 	 * parent already passed `is_product_syndicated()` upstream
@@ -3091,6 +3097,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// the per-variation `fetch_variations_for()`: agents should see
 		// a `partial_variants` warning when their product has more
 		// variations than we'll fetch.
+		//
+		// `$expected_per_parent` only includes parents that contributed
+		// at least one valid variation ID to the dispatch worklist —
+		// the binner uses it as the source of truth for what we tried
+		// to fetch.
+		//
+		// `$declared_per_parent` tracks total_declared for ALL variable
+		// parents, including ones whose pointer lists were all
+		// malformed (zero/negative IDs). Those parents skip the
+		// dispatch worklist but still need a result entry so the
+		// `partial_variants` warning fires — pre-fix they were
+		// silently dropped, regressing the per-variation path's
+		// behavior of emitting a warning whenever the parent declared
+		// variations we couldn't surface.
 		$expected_per_parent = array();
 		$declared_per_parent = array();
 		foreach ( $wc_products as $wc_product ) {
@@ -3107,7 +3127,12 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			}
 
 			$total_declared = count( $variation_refs );
-			$capped         = $total_declared > self::MAX_VARIATIONS_PER_PRODUCT
+			// Track declared count for every variable parent — even
+			// ones whose IDs are all malformed below — so the warning
+			// path stays consistent with the per-variation predecessor.
+			$declared_per_parent[ $parent_id ] = $total_declared;
+
+			$capped = $total_declared > self::MAX_VARIATIONS_PER_PRODUCT
 				? array_slice( $variation_refs, 0, self::MAX_VARIATIONS_PER_PRODUCT )
 				: $variation_refs;
 
@@ -3121,17 +3146,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				}
 			}
 
-			if ( empty( $expected_ids ) ) {
-				continue;
+			if ( ! empty( $expected_ids ) ) {
+				$expected_per_parent[ $parent_id ] = $expected_ids;
 			}
-
-			$expected_per_parent[ $parent_id ] = $expected_ids;
-			$declared_per_parent[ $parent_id ] = $total_declared;
+			// If $expected_ids is empty (all malformed), $declared_per_parent
+			// still has the entry — the result-build loop below catches
+			// it and emits skipped: total_declared.
 		}
 
-		// Edge case: no variable products (or all variable products have
-		// empty `variations[]` pointers). Skip the dispatch entirely.
-		if ( empty( $expected_per_parent ) ) {
+		// Edge case: no variable parents at all (no entries in
+		// `$declared_per_parent`). Skip the dispatch entirely.
+		// Note: we DON'T early-return when only `$expected_per_parent`
+		// is empty — `$declared_per_parent` may still have parents
+		// with all-malformed pointers that need a fallback result.
+		if ( empty( $declared_per_parent ) ) {
 			return array();
 		}
 
@@ -3150,12 +3178,17 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// on earlier pages. `$first_page_failed` distinguishes the
 		// degenerate case (page 1 itself fails) from partial-success
 		// cases that benefit from keeping prior data.
+		//
+		// Skip the dispatch entirely when no parents contributed valid
+		// IDs to the worklist — the all-malformed-pointers parents
+		// still get `variations: [], skipped: total_declared` entries
+		// from the result-build loop below using `$declared_per_parent`.
 		$all_variations    = array();
 		$page              = 1;
 		$per_page          = 100;
 		$first_page_failed = false;
 
-		while ( true ) {
+		while ( ! empty( $parent_ids ) ) {
 			$store_params = array(
 				'parent_includes' => implode( ',', $parent_ids ),
 				'per_page'        => $per_page,
@@ -3250,20 +3283,25 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			++$page;
 		}
 
-		// Build the result map. On a degenerate page-1 failure, every
-		// variable parent gets `variations: [], skipped: total_declared`
-		// so the partial-variants warning fires for each. On partial
-		// failures (some pages succeeded, later pages errored), we
-		// preserve the page-1 data and let the per-parent
-		// `declared - returned` math naturally compute skipped — that
-		// way parents whose variations were fully captured on the first
+		// Build the result map from `$declared_per_parent` so EVERY
+		// variable parent gets an entry — including parents whose
+		// pointer lists were all malformed (those skip the dispatch
+		// worklist via `$expected_per_parent` but still need an entry
+		// here so the `partial_variants` warning fires below).
+		//
+		// On a degenerate page-1 failure, every parent gets
+		// `variations: [], skipped: total_declared` so the warning
+		// fires for each. On partial failures (some pages succeeded,
+		// later pages errored), we preserve the page-1 data and let
+		// the per-parent `declared - returned` math compute skipped —
+		// parents whose variations were fully captured on the first
 		// page aren't punished for a later-page failure that didn't
 		// affect them.
 		$result = array();
-		foreach ( $expected_per_parent as $parent_id => $expected_ids ) {
+		foreach ( $declared_per_parent as $parent_id => $total_declared ) {
 			$result[ $parent_id ] = array(
 				'variations' => array(),
-				'skipped'    => $first_page_failed ? $declared_per_parent[ $parent_id ] : 0,
+				'skipped'    => $first_page_failed ? $total_declared : 0,
 			);
 		}
 
@@ -3283,6 +3321,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				continue;
 			}
 
+			// All-malformed parents have no expected set — they aren't
+			// in the worklist, so the API shouldn't return variations
+			// for them. Defensively skip if it ever happens.
+			if ( ! isset( $expected_per_parent[ $parent_id ] ) ) {
+				continue;
+			}
+
 			// Honor MAX cap when binning: ignore variations whose IDs
 			// aren't in the expected (capped) set for that parent.
 			$variation_id = (int) ( $variation['id'] ?? 0 );
@@ -3292,6 +3337,28 @@ class WC_AI_Storefront_UCP_REST_Controller {
 
 			$result[ $parent_id ]['variations'][] = $variation;
 		}
+
+		// Restore source order: bin order follows Store API page order,
+		// not the parent's declared order. Sort each bin to match
+		// `$expected_per_parent[$parent_id]` so callers see variations
+		// in the same sequence as the parent's `variations[]` list.
+		// Matches the per-variation `fetch_variations_for()` contract,
+		// which iterates IDs in declared order.
+		foreach ( $result as $parent_id => &$entry ) {
+			if ( ! isset( $expected_per_parent[ $parent_id ] ) || count( $entry['variations'] ) <= 1 ) {
+				continue;
+			}
+			$position = array_flip( $expected_per_parent[ $parent_id ] );
+			usort(
+				$entry['variations'],
+				static function ( array $a, array $b ) use ( $position ) {
+					$a_pos = $position[ (int) ( $a['id'] ?? 0 ) ] ?? PHP_INT_MAX;
+					$b_pos = $position[ (int) ( $b['id'] ?? 0 ) ] ?? PHP_INT_MAX;
+					return $a_pos <=> $b_pos;
+				}
+			);
+		}
+		unset( $entry );
 
 		// Compute skipped per parent: total_declared - actually_returned.
 		// Includes cap-truncated + scope-filtered + fetch-failed entries.

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -86,16 +86,31 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	const MAX_LINE_ITEMS_PER_CHECKOUT = 100;
 
 	/**
-	 * Upper bound on variations emitted per variable product.
+	 * Upper bound on variations EMITTED per variable product.
 	 *
-	 * Pre-#351 this bounded a per-variation N+1 fan-out; post-#351
-	 * variations batch via `?parent_includes=` so the cap is now about
-	 * response payload size and translator workload rather than dispatch
-	 * count. Still meaningful: 50 covers typical color/size/pattern
-	 * combinations; products with more are rare and can surface via
-	 * `POST /catalog/lookup` with specific variation IDs if an agent
-	 * needs fidelity. Cap overage emits a `partial_variants` warning so
-	 * agents see when the cap kicks in.
+	 * Pre-#351 this also bounded the per-variation N+1 fan-out — fewer
+	 * IDs in the worklist meant fewer dispatches. Post-#351 variations
+	 * batch via `?parent_includes=`, so the cap no longer bounds the
+	 * Store API response: WC returns ALL of a parent's variations
+	 * regardless of our cap (the binner then drops everything past the
+	 * first MAX_VARIATIONS_PER_PRODUCT IDs in the parent's declared
+	 * order). The page-walk has an early-stop optimization to avoid
+	 * fetching beyond the expected set, but for high-variation parents
+	 * where the API returns the expected IDs late in pagination, the
+	 * batch can still normalize more variations than it ultimately
+	 * emits.
+	 *
+	 * What the cap DOES bound: emitted variant count, translator
+	 * workload, response payload size to the agent.
+	 *
+	 * What the cap does NOT bound: Store API response size during
+	 * fetch, normalize_store_api_data() work on the discarded tail.
+	 *
+	 * 50 covers typical color/size/pattern combinations; products with
+	 * more are rare and can surface via `POST /catalog/lookup` with
+	 * specific variation IDs if an agent needs fidelity. Cap overage
+	 * emits a `partial_variants` warning so agents see when the cap
+	 * kicks in.
 	 */
 	const MAX_VARIATIONS_PER_PRODUCT = 50;
 
@@ -3201,6 +3216,27 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		$per_page          = 100;
 		$first_page_failed = false;
 
+		// Flat set of all expected variation IDs across parents. Used
+		// by the page-walk's early-stop check: once every expected ID
+		// has been seen on the wire, additional pages would only carry
+		// over-cap variations that the binner will drop. For a parent
+		// with 200 variations capped at MAX_VARIATIONS_PER_PRODUCT=50,
+		// pre-fix the loop walked all 200 (2 pages) before terminating
+		// on the short-page sentinel. Post-fix it stops as soon as the
+		// 50 expected IDs are collected, typically during page 1.
+		//
+		// Worst case (Store API returns expected IDs in pagination
+		// positions later than the cap's worth of unexpected ones)
+		// degrades to the prior behavior: walk every page. WC returns
+		// variations in deterministic order (menu_order then post_id),
+		// so this worst case is rare in practice.
+		$expected_remaining = array();
+		foreach ( $expected_per_parent as $expected_ids ) {
+			foreach ( $expected_ids as $vid ) {
+				$expected_remaining[ $vid ] = true;
+			}
+		}
+
 		while ( ! empty( $parent_ids ) ) {
 			$store_params = array(
 				'parent_includes' => implode( ',', $parent_ids ),
@@ -3286,7 +3322,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			foreach ( $normalized_data as $variation ) {
 				if ( is_array( $variation ) ) {
 					$all_variations[] = $variation;
+					$variation_id     = (int) ( $variation['id'] ?? 0 );
+					if ( $variation_id > 0 && isset( $expected_remaining[ $variation_id ] ) ) {
+						unset( $expected_remaining[ $variation_id ] );
+					}
 				}
+			}
+
+			// Early-stop: every expected ID has been collected on the
+			// wire, so additional pages would only carry over-cap
+			// variations the binner will drop. This is the optimization
+			// that puts MAX_VARIATIONS_PER_PRODUCT to work as a real
+			// fetch-side bound, not just an emission-side bound.
+			if ( empty( $expected_remaining ) ) {
+				break;
 			}
 
 			// An empty page terminates pagination. Note this still

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3093,8 +3093,261 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	}
 
 	/**
-	 * Build a UCP `not_found` error message for an ID that did not
-	 * resolve to any known product or variant.
+	 * Batch-fetch variations for many parent products in one (or few) Store
+	 * API dispatch(es), replacing the per-variation N+1 fan-out in
+	 * `fetch_variations_for()`.
+	 *
+	 * Uses `GET /wc/store/v1/products?parent_includes=<csv>&per_page=100`,
+	 * which WC's collection endpoint supports for variation post-types
+	 * (verified live: `?parent_includes=35` returns the 10 variations of
+	 * product 35 in one response). Pagination kicks in when combined
+	 * variation count across all parents exceeds 100; we walk pages
+	 * until short-page sentinel.
+	 *
+	 * For typical traffic (20-product /catalog/search, 30% variable, avg
+	 * 5 variations each), this collapses ~30 dispatches to 1. Worst real-
+	 * world case (heavy variable catalog, 60% variable × 8 vars = 96
+	 * variations) collapses to 1 dispatch (≤100) or 2 (>100).
+	 *
+	 * Failure policy: when the batch dispatch returns WP_Error or 5xx,
+	 * every variable parent in the input degrades to
+	 * `variations: [], skipped: total_declared` and emits one
+	 * `partial_variants` warning per parent. Matches today's worst case
+	 * for individual fetch failures while making the typical case
+	 * dramatically faster.
+	 *
+	 * MAX_VARIATIONS_PER_PRODUCT cap is enforced per-parent at the
+	 * pre-fetch stage (slice variation refs before building the CSV).
+	 * Cap-truncated entries are not in the expected-set, so they don't
+	 * generate a skipped count — preserves the contract of
+	 * `fetch_variations_for()`.
+	 *
+	 * Scope gate: variations inherit visibility from their parent. The
+	 * parent already passed `is_product_syndicated()` upstream
+	 * (search/lookup handlers gate before reaching this method), so the
+	 * per-variation `is_product_syndicated()` check that
+	 * `fetch_variations_for()` ran is redundant for variations and
+	 * intentionally omitted here.
+	 *
+	 * Returns a map keyed by parent WC ID:
+	 *
+	 *     [
+	 *       <parent_id> => [
+	 *         'variations' => [<wc_variation_response>, ...],
+	 *         'skipped'    => <int>,
+	 *       ],
+	 *       ...
+	 *     ]
+	 *
+	 * Simple products are absent from the map (no batched dispatch
+	 * needed). Empty input or all-simple input returns an empty map
+	 * without dispatching.
+	 *
+	 * @param array<int, array<string, mixed>> $wc_products Decoded Store API parent product responses.
+	 * @return array<int, array{variations: array<int, array<string, mixed>>, skipped: int}>
+	 */
+	private function fetch_variations_batched( array $wc_products ): array {
+		// Build the per-parent expected-set: parent_id => [variation_id, ...]
+		// (slice each parent's refs to MAX cap before adding to the work
+		// list). Keeps cap semantics identical to fetch_variations_for().
+		$expected_per_parent = array();
+		foreach ( $wc_products as $wc_product ) {
+			if ( ! is_array( $wc_product ) ) {
+				continue;
+			}
+			if ( 'variable' !== ( $wc_product['type'] ?? '' ) ) {
+				continue;
+			}
+			$parent_id      = (int) ( $wc_product['id'] ?? 0 );
+			$variation_refs = $wc_product['variations'] ?? array();
+			if ( $parent_id <= 0 || ! is_array( $variation_refs ) || empty( $variation_refs ) ) {
+				continue;
+			}
+
+			$total_declared = count( $variation_refs );
+			$capped         = $total_declared > self::MAX_VARIATIONS_PER_PRODUCT
+				? array_slice( $variation_refs, 0, self::MAX_VARIATIONS_PER_PRODUCT )
+				: $variation_refs;
+
+			$expected_ids = array();
+			foreach ( $capped as $ref ) {
+				$variation_id = is_array( $ref )
+					? (int) ( $ref['id'] ?? 0 )
+					: (int) $ref;
+				if ( $variation_id > 0 ) {
+					$expected_ids[] = $variation_id;
+				}
+			}
+
+			if ( empty( $expected_ids ) ) {
+				continue;
+			}
+
+			$expected_per_parent[ $parent_id ] = $expected_ids;
+		}
+
+		// Edge case: no variable products (or all variable products have
+		// empty `variations[]` pointers). Skip the dispatch entirely.
+		if ( empty( $expected_per_parent ) ) {
+			return array();
+		}
+
+		$parent_ids = array_keys( $expected_per_parent );
+
+		// Walk pages of `parent_includes=<csv>&per_page=100` until short-
+		// page sentinel. WC Store API caps per_page at 100; for the rare
+		// pages with combined-variation > 100 we paginate.
+		$all_variations = array();
+		$page           = 1;
+		$per_page       = 100;
+		$batch_failed   = false;
+
+		while ( true ) {
+			$store_params = array(
+				'parent_includes' => implode( ',', $parent_ids ),
+				'per_page'        => $per_page,
+				'page'            => $page,
+			);
+
+			// Apply the same filter the search dispatch uses, with the
+			// same `/wc/store/v1/products` endpoint string. Plugins
+			// constraining the search query (e.g. catalog scope) intend
+			// to constrain the variation fetch as well.
+			$store_params_before_filter = $store_params;
+
+			/** This filter is documented in the search dispatch. */
+			$filtered = apply_filters( 'wc_ai_storefront_ucp_store_api_args', $store_params, '/wc/store/v1/products' );
+			if ( ! is_array( $filtered ) ) {
+				$filtered = $store_params_before_filter;
+			}
+			// Restore pagination keys — filters MAY override scope but
+			// MUST NOT override our pagination state, which would break
+			// the page-walk invariant.
+			$filtered['per_page']        = $per_page;
+			$filtered['page']            = $page;
+			$filtered['parent_includes'] = $store_params['parent_includes'];
+
+			$store_request = new WP_REST_Request( 'GET', '/wc/store/v1/products' );
+			foreach ( $filtered as $k => $v ) {
+				$store_request->set_param( $k, $v );
+			}
+
+			WC_AI_Storefront_UCP_Store_API_Filter::enter_ucp_dispatch();
+			try {
+				$store_response = rest_do_request( $store_request );
+			} finally {
+				WC_AI_Storefront_UCP_Store_API_Filter::exit_ucp_dispatch();
+			}
+
+			if ( $store_response instanceof WP_Error ) {
+				WC_AI_Storefront_Logger::debug(
+					'UCP fetch_variations_batched: WP_Error from Store API: '
+					. $store_response->get_error_message()
+				);
+				$batch_failed = true;
+				break;
+			}
+
+			$status = $store_response->get_status();
+			if ( $status >= 400 ) {
+				WC_AI_Storefront_Logger::debug(
+					sprintf(
+						'UCP fetch_variations_batched: Store API returned HTTP %d on page %d',
+						$status,
+						$page
+					)
+				);
+				$batch_failed = true;
+				break;
+			}
+
+			$data = $store_response->get_data();
+			if ( ! is_array( $data ) ) {
+				$batch_failed = true;
+				break;
+			}
+
+			foreach ( $data as $variation ) {
+				if ( is_array( $variation ) ) {
+					$all_variations[] = $variation;
+				}
+			}
+
+			// Short-page sentinel: fewer items returned than requested
+			// means we've reached the end. Avoids needing X-WP-TotalPages.
+			if ( count( $data ) < $per_page ) {
+				break;
+			}
+
+			++$page;
+		}
+
+		// Build the result map. On batch failure, every variable parent
+		// gets `variations: [], skipped: total_expected` so the partial-
+		// variants warning fires for each.
+		$result = array();
+		foreach ( $expected_per_parent as $parent_id => $expected_ids ) {
+			$result[ $parent_id ] = array(
+				'variations' => array(),
+				'skipped'    => $batch_failed ? count( $expected_ids ) : 0,
+			);
+		}
+
+		if ( $batch_failed ) {
+			return $result;
+		}
+
+		// Bin returned variations by `parent` field. Each variation in
+		// the Store API response carries its `parent` ID, so the binning
+		// is O(N) on the returned set.
+		foreach ( $all_variations as $variation ) {
+			$parent_id = (int) ( $variation['parent'] ?? 0 );
+			if ( ! isset( $result[ $parent_id ] ) ) {
+				// Unexpected parent — possibly an orphaned variation
+				// whose parent isn't in the request. Drop it; the
+				// expected-set is the source of truth.
+				continue;
+			}
+
+			// Honor MAX cap when binning: ignore variations whose IDs
+			// aren't in the expected (capped) set for that parent.
+			$variation_id = (int) ( $variation['id'] ?? 0 );
+			if ( ! in_array( $variation_id, $expected_per_parent[ $parent_id ], true ) ) {
+				continue;
+			}
+
+			$result[ $parent_id ]['variations'][] = $variation;
+		}
+
+		// Compute skipped per parent: expected - actually returned.
+		// Includes scope-filtered + fetch-failed entries that the
+		// per-variation path would have caught.
+		foreach ( $result as $parent_id => &$entry ) {
+			$expected_count   = count( $expected_per_parent[ $parent_id ] );
+			$returned_count   = count( $entry['variations'] );
+			$entry['skipped'] = max( 0, $expected_count - $returned_count );
+
+			if ( $entry['skipped'] > 0 ) {
+				WC_AI_Storefront_Logger::debug(
+					sprintf(
+						'UCP fetch_variations_batched(parent=%d): expected %d, got %d, skipped %d',
+						$parent_id,
+						$expected_count,
+						$returned_count,
+						$entry['skipped']
+					)
+				);
+			}
+		}
+		unset( $entry );
+
+		return $result;
+	}
+
+	/**
+	 * Build a UCP `not_found` error message for the ID at position
+	 * `$index` in the response's `inputs` array. The JSONPath-style
+	 * `path` lets agents localize which specific ID failed.
 	 *
 	 * `path` references `$.ids[...]` — the request-side field name.
 	 * Pre-0.12.0 we used `$.inputs[...]`, but the `inputs[]` envelope

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3313,6 +3313,17 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			// downstream translators see uniform array shapes.
 			$normalized_data = self::normalize_store_api_data( $store_response->get_data() );
 			if ( null === $normalized_data ) {
+				// Plugin-conflict smell: response body wasn't an
+				// array or object the normalizer could reach. Mirrors
+				// fetch_store_api_product_inner()'s normalization
+				// failure log so production incidents on either path
+				// are equally diagnosable.
+				WC_AI_Storefront_Logger::debug(
+					sprintf(
+						'UCP fetch_variations_batched: response body on page %d could not be normalized to an array (possible plugin conflict)',
+						$page
+					)
+				);
 				if ( 1 === $page ) {
 					$first_page_failed = true;
 				}

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -86,14 +86,16 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	const MAX_LINE_ITEMS_PER_CHECKOUT = 100;
 
 	/**
-	 * Upper bound on variations fetched per variable product.
+	 * Upper bound on variations emitted per variable product.
 	 *
-	 * Bounds the N+1 fan-out in fetch_variations_for(). A product with
-	 * 200 variations would otherwise trigger 200 internal dispatches just
-	 * for one hit of a search response. 50 covers typical
-	 * color/size/pattern combinations; products with more are rare and
-	 * can surface via `POST /catalog/lookup` with specific variation IDs
-	 * if an agent needs fidelity.
+	 * Pre-#351 this bounded a per-variation N+1 fan-out; post-#351
+	 * variations batch via `?parent_includes=` so the cap is now about
+	 * response payload size and translator workload rather than dispatch
+	 * count. Still meaningful: 50 covers typical color/size/pattern
+	 * combinations; products with more are rare and can surface via
+	 * `POST /catalog/lookup` with specific variation IDs if an agent
+	 * needs fidelity. Cap overage emits a `partial_variants` warning so
+	 * agents see when the cap kicks in.
 	 */
 	const MAX_VARIATIONS_PER_PRODUCT = 50;
 
@@ -583,7 +585,7 @@ class WC_AI_Storefront_UCP_REST_Controller {
 	 * Maps UCP fields onto WC Store API query params and dispatches
 	 * `GET /wc/store/v1/products` via `rest_do_request`. Every returned
 	 * product is translated to UCP shape; variable products get their
-	 * variations pre-fetched by `fetch_variations_for()` so variant
+	 * variations batch-fetched by `fetch_variations_batched()` so variant
 	 * lists are real rather than synthesized defaults.
 	 *
 	 * Pagination: cursor + limit, per UCP v2026-04-08
@@ -3025,100 +3027,6 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		};
 		$result = $cast( $data );
 		return is_array( $result ) ? $result : null;
-	}
-
-	/**
-	 * For variable products, fetch all variations via per-ID Store API
-	 * requests and reassemble in the source order WC declared. Simple
-	 * products return empty.
-	 *
-	 * IMPORTANT: the collection endpoint (`/wc/store/v1/products?include=
-	 * [ids]`) cannot be used here. WC Store API's collection route filters
-	 * by `post_type='product'`, which excludes product variations (those
-	 * have `post_type='product_variation'`). Only the single-item route
-	 * (`/wc/store/v1/products/{id}`) performs a direct object lookup that
-	 * handles both post types. Per-ID fetches are handled by
-	 * fetch_store_api_product(), which also enforces the
-	 * is_product_syndicated() scope gate and memoizes results so repeated
-	 * lookups of the same variation within a request are free.
-	 *
-	 * Results not returned by the endpoint (out of scope, 404, or
-	 * cap-truncated) are silently skipped. The `skipped` count lets
-	 * callers emit a `partial_variants` warning so agents are never
-	 * silently misled about product completeness.
-	 *
-	 * Capped at MAX_VARIATIONS_PER_PRODUCT to bound fan-out and response
-	 * payload size. Source order is preserved by building $variations in
-	 * the original pointer-list order.
-	 *
-	 * @param array<string, mixed> $wc_product Store API response for the parent product.
-	 * @return array{variations: array<int, array<string, mixed>>, skipped: int}
-	 */
-	private function fetch_variations_for( array $wc_product ): array {
-		if ( 'variable' !== ( $wc_product['type'] ?? '' ) ) {
-			return array(
-				'variations' => array(),
-				'skipped'    => 0,
-			);
-		}
-
-		$variation_refs = $wc_product['variations'] ?? array();
-		if ( ! is_array( $variation_refs ) || empty( $variation_refs ) ) {
-			return array(
-				'variations' => array(),
-				'skipped'    => 0,
-			);
-		}
-
-		$total_declared = count( $variation_refs );
-
-		if ( $total_declared > self::MAX_VARIATIONS_PER_PRODUCT ) {
-			$variation_refs = array_slice( $variation_refs, 0, self::MAX_VARIATIONS_PER_PRODUCT );
-		}
-
-		// Fetch each variation via the single-item Store API endpoint and
-		// collect results in source order. fetch_store_api_product() handles
-		// memoization (cached IDs return immediately), scope enforcement via
-		// is_product_syndicated(), and null-caching of missing/out-of-scope
-		// entries so no variation is dispatched twice in a request.
-		$variations = array();
-		foreach ( $variation_refs as $ref ) {
-			// WC Store API emits `variations` as `[{id, attributes}, ...]`
-			// (just the pointer). Fetch the full variation record.
-			$variation_id = is_array( $ref )
-				? (int) ( $ref['id'] ?? 0 )
-				: (int) $ref;
-
-			if ( $variation_id <= 0 ) {
-				continue;
-			}
-
-			$data = $this->fetch_store_api_product( $variation_id );
-			if ( null !== $data ) {
-				$variations[] = $data;
-			}
-		}
-
-		// Skipped = everything the product declared that didn't make it
-		// into $variations. Includes cap-truncated + scope-filtered +
-		// fetch-failed + malformed-ref entries.
-		$skipped = $total_declared - count( $variations );
-
-		if ( $skipped > 0 ) {
-			WC_AI_Storefront_Logger::debug(
-				sprintf(
-					'UCP fetch_variations_for(%d): skipped %d of %d declared variations',
-					(int) ( $wc_product['id'] ?? 0 ),
-					$skipped,
-					$total_declared
-				)
-			);
-		}
-
-		return array(
-			'variations' => $variations,
-			'skipped'    => $skipped,
-		);
 	}
 
 	/**

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3152,8 +3152,9 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// silently dropped, regressing the per-variation path's
 		// behavior of emitting a warning whenever the parent declared
 		// variations we couldn't surface.
-		$expected_per_parent = array();
-		$declared_per_parent = array();
+		$expected_per_parent     = array();
+		$expected_per_parent_set = array();
+		$declared_per_parent     = array();
 		foreach ( $wc_products as $wc_product ) {
 			if ( ! is_array( $wc_product ) ) {
 				continue;
@@ -3178,17 +3179,27 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				: $variation_refs;
 
 			$expected_ids = array();
+			$expected_set = array();
 			foreach ( $capped as $ref ) {
 				$variation_id = is_array( $ref )
 					? (int) ( $ref['id'] ?? 0 )
 					: (int) $ref;
 				if ( $variation_id > 0 ) {
-					$expected_ids[] = $variation_id;
+					$expected_ids[]                    = $variation_id;
+					$expected_set[ $variation_id ]     = true;
 				}
 			}
 
 			if ( ! empty( $expected_ids ) ) {
-				$expected_per_parent[ $parent_id ] = $expected_ids;
+				$expected_per_parent[ $parent_id ]     = $expected_ids;
+				// Per-parent associative `[vid => true]` map for O(1)
+				// `isset()` membership checks at accumulation + binning
+				// time. Building this once here costs O(cap) per parent
+				// (cap = MAX_VARIATIONS_PER_PRODUCT, currently 50);
+				// pre-build, every page's variations cost
+				// O(returned × cap) via in_array, which compounds
+				// noticeably on >100-variation parents.
+				$expected_per_parent_set[ $parent_id ] = $expected_set;
 			}
 			// If $expected_ids is empty (all malformed), $declared_per_parent
 			// still has the entry — the result-build loop below catches
@@ -3348,12 +3359,32 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			}
 
 			foreach ( $normalized_data as $variation ) {
-				if ( is_array( $variation ) ) {
-					$all_variations[] = $variation;
-					$variation_id     = (int) ( $variation['id'] ?? 0 );
-					if ( $variation_id > 0 && isset( $expected_remaining[ $variation_id ] ) ) {
-						unset( $expected_remaining[ $variation_id ] );
-					}
+				if ( ! is_array( $variation ) ) {
+					continue;
+				}
+
+				// Drop non-expected variations at accumulation time —
+				// don't carry them in `$all_variations` only to drop
+				// them again at binning. WC's `?type=variation&parent=`
+				// returns ALL of a parent's variations regardless of
+				// our cap, so for a 200-variation parent capped at 50,
+				// pre-filter sheds 150 entries here that would
+				// otherwise inflate memory + CPU through the binner.
+				// Also catches orphaned variations (parent_id not in
+				// our worklist) and over-cap tail entries.
+				$variation_id = (int) ( $variation['id'] ?? 0 );
+				$parent_id    = (int) ( $variation['parent'] ?? 0 );
+				if (
+					$variation_id <= 0
+					|| $parent_id <= 0
+					|| ! isset( $expected_per_parent_set[ $parent_id ][ $variation_id ] )
+				) {
+					continue;
+				}
+
+				$all_variations[] = $variation;
+				if ( isset( $expected_remaining[ $variation_id ] ) ) {
+					unset( $expected_remaining[ $variation_id ] );
 				}
 			}
 
@@ -3413,30 +3444,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 
 		// Bin returned variations by `parent` field. Each variation in
 		// the Store API response carries its `parent` ID, so the binning
-		// is O(N) on the returned set.
+		// is O(N) on the returned set. The accumulation loop above
+		// pre-filtered against `$expected_per_parent_set` so every
+		// entry here is already known to belong in the result map and
+		// have an expected variation_id — the binner just routes by
+		// parent. The defensive `isset($result[...])` guard remains
+		// because an all-malformed parent could in theory have its
+		// `parent_id` arrive in `$all_variations` if the WC dispatch
+		// ever returned out-of-scope variations (it doesn't today,
+		// but the cost of the extra isset is negligible).
 		foreach ( $all_variations as $variation ) {
 			$parent_id = (int) ( $variation['parent'] ?? 0 );
 			if ( ! isset( $result[ $parent_id ] ) ) {
-				// Unexpected parent — possibly an orphaned variation
-				// whose parent isn't in the request. Drop it; the
-				// expected-set is the source of truth.
 				continue;
 			}
-
-			// All-malformed parents have no expected set — they aren't
-			// in the worklist, so the API shouldn't return variations
-			// for them. Defensively skip if it ever happens.
-			if ( ! isset( $expected_per_parent[ $parent_id ] ) ) {
-				continue;
-			}
-
-			// Honor MAX cap when binning: ignore variations whose IDs
-			// aren't in the expected (capped) set for that parent.
-			$variation_id = (int) ( $variation['id'] ?? 0 );
-			if ( ! in_array( $variation_id, $expected_per_parent[ $parent_id ], true ) ) {
-				continue;
-			}
-
 			$result[ $parent_id ]['variations'][] = $variation;
 		}
 

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3185,13 +3185,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 					? (int) ( $ref['id'] ?? 0 )
 					: (int) $ref;
 				if ( $variation_id > 0 ) {
-					$expected_ids[]                    = $variation_id;
-					$expected_set[ $variation_id ]     = true;
+					$expected_ids[]                = $variation_id;
+					$expected_set[ $variation_id ] = true;
 				}
 			}
 
 			if ( ! empty( $expected_ids ) ) {
-				$expected_per_parent[ $parent_id ]     = $expected_ids;
+				$expected_per_parent[ $parent_id ] = $expected_ids;
 				// Per-parent associative `[vid => true]` map for O(1)
 				// `isset()` membership checks at accumulation + binning
 				// time. Building this once here costs O(cap) per parent

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3140,10 +3140,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// Walk pages of `parent_includes=<csv>&per_page=100` until short-
 		// page sentinel. WC Store API caps per_page at 100; for the rare
 		// pages with combined-variation > 100 we paginate.
-		$all_variations = array();
-		$page           = 1;
-		$per_page       = 100;
-		$batch_failed   = false;
+		//
+		// Failure handling is per-page rather than per-batch: when page N
+		// errors we KEEP whatever we've already collected (pages 1..N-1)
+		// rather than wholesale-discarding everything. The downstream
+		// per-parent `skipped = declared - returned` math then naturally
+		// surfaces the gap for parents whose variations are missing,
+		// without punishing parents whose variations were fully captured
+		// on earlier pages. `$first_page_failed` distinguishes the
+		// degenerate case (page 1 itself fails) from partial-success
+		// cases that benefit from keeping prior data.
+		$all_variations    = array();
+		$page              = 1;
+		$per_page          = 100;
+		$first_page_failed = false;
 
 		while ( true ) {
 			$store_params = array(
@@ -3184,10 +3194,13 @@ class WC_AI_Storefront_UCP_REST_Controller {
 
 			if ( $store_response instanceof WP_Error ) {
 				WC_AI_Storefront_Logger::debug(
-					'UCP fetch_variations_batched: WP_Error from Store API: '
+					'UCP fetch_variations_batched: WP_Error from Store API on page '
+					. $page . ': '
 					. $store_response->get_error_message()
 				);
-				$batch_failed = true;
+				if ( 1 === $page ) {
+					$first_page_failed = true;
+				}
 				break;
 			}
 
@@ -3200,13 +3213,17 @@ class WC_AI_Storefront_UCP_REST_Controller {
 						$page
 					)
 				);
-				$batch_failed = true;
+				if ( 1 === $page ) {
+					$first_page_failed = true;
+				}
 				break;
 			}
 
 			$data = $store_response->get_data();
 			if ( ! is_array( $data ) ) {
-				$batch_failed = true;
+				if ( 1 === $page ) {
+					$first_page_failed = true;
+				}
 				break;
 			}
 
@@ -3214,6 +3231,14 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				if ( is_array( $variation ) ) {
 					$all_variations[] = $variation;
 				}
+			}
+
+			// Empty response on a non-first page → done. Skip the extra
+			// dispatch that the short-page sentinel below would force
+			// when the previous page's count happened to land exactly
+			// at $per_page.
+			if ( empty( $data ) ) {
+				break;
 			}
 
 			// Short-page sentinel: fewer items returned than requested
@@ -3225,19 +3250,24 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			++$page;
 		}
 
-		// Build the result map. On batch failure, every variable parent
-		// gets `variations: [], skipped: total_declared` so the partial-
-		// variants warning fires for each. Use total_declared (not
-		// expected_capped) so cap overage still surfaces as skipped.
+		// Build the result map. On a degenerate page-1 failure, every
+		// variable parent gets `variations: [], skipped: total_declared`
+		// so the partial-variants warning fires for each. On partial
+		// failures (some pages succeeded, later pages errored), we
+		// preserve the page-1 data and let the per-parent
+		// `declared - returned` math naturally compute skipped — that
+		// way parents whose variations were fully captured on the first
+		// page aren't punished for a later-page failure that didn't
+		// affect them.
 		$result = array();
 		foreach ( $expected_per_parent as $parent_id => $expected_ids ) {
 			$result[ $parent_id ] = array(
 				'variations' => array(),
-				'skipped'    => $batch_failed ? $declared_per_parent[ $parent_id ] : 0,
+				'skipped'    => $first_page_failed ? $declared_per_parent[ $parent_id ] : 0,
 			);
 		}
 
-		if ( $batch_failed ) {
+		if ( $first_page_failed ) {
 			return $result;
 		}
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T21:48:00+00:00\n"
+"POT-Creation-Date: 2026-05-08T22:48:23+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -193,124 +193,124 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3443
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3464
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3596
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3617
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3666
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3687
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3696
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3717
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3715
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3736
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3739
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3760
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3771
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3792
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3806
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3827
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3836
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3857
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3907
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3928
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3957
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3978
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3986
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4007
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4075
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4096
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4313
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4334
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4347
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4368
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5048
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5069
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5287
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5308
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5291
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5312
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5295
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5316
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5297
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5318
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5299
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5320
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5303
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5324
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5305
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5326
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T22:19:51+00:00\n"
+"POT-Creation-Date: 2026-05-08T18:48:53+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -118,211 +118,199 @@ msgid "RFC 3339 / ISO 8601 timestamp (UTC, `Z`-suffixed) of the product's last m
 msgstr ""
 
 #. translators: 1: raw agent identifier extracted from the UCP-Agent header (hostname or product token)
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:526
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:528
 #, php-format
 msgid "Access to this UCP endpoint is not enabled for unknown AI agents on this store. Agent: %1$s"
 msgstr ""
 
 #. translators: 1: canonical agent brand name
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:564
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:566
 #, php-format
 msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:620
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1466
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1930
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:622
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1465
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1886
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:955
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:978
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:957
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:980
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1821
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1777
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1831
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1787
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1849
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1805
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1941
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1897
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1951
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1907
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: agent's UCP product ID, 2: summed quantity after merging duplicates, 3: maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2065
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2021
 #, php-format
 msgid "Summed quantity %2$d for \"%1$s\" (after merging duplicate line items) exceeds the per-line cap of %3$d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2098
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2054
 msgid "Duplicate line items targeting the same product were merged. Quantities have been summed; the response shows one line per product."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2207
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2163
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2226
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2182
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2277
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2233
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2727
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2683
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
-#. translators: %s: the input ID the agent submitted that didn't resolve.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3138
+#. translators: %d: zero-based position in the deduped lookup inputs list.
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3274
 #, php-format
-msgid "Input \"%s\" did not resolve to a known product or variant."
-msgstr ""
-
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3141
-msgid "An input did not resolve to a known product or variant."
+msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3309
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3427
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3379
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3497
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3409
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3527
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3428
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3546
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3452
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3570
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3484
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3602
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3519
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3637
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3549
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3667
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3620
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3738
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3670
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3788
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3699
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3817
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3788
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3906
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4026
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4144
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4060
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4178
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4761
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4879
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4941
-msgid "Merchant has no privacy policy configured; agents may want to surface this caveat to buyers before proceeding."
-msgstr ""
-
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4957
-msgid "Merchant has no terms of service configured; agents may want to surface this caveat to buyers before proceeding."
-msgstr ""
-
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5005
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5118
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5009
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5122
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5013
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5126
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5015
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5128
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5017
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5130
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5021
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5134
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5023
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5136
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T20:15:29+00:00\n"
+"POT-Creation-Date: 2026-05-08T20:25:02+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -193,124 +193,124 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3415
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3426
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3568
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3579
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3638
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3649
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3668
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3679
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3687
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3698
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3711
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3722
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3743
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3754
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3778
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3789
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3808
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3819
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3879
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3890
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3929
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3940
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3958
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3969
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4047
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4058
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4285
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4296
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4319
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4330
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5020
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5031
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5259
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5270
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5263
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5274
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5267
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5278
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5269
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5280
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5271
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5282
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5275
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5286
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5277
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5288
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T22:48:23+00:00\n"
+"POT-Creation-Date: 2026-05-08T23:07:48+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -130,8 +130,8 @@ msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
 #: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:637
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1480
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1901
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1495
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1976
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
@@ -140,177 +140,189 @@ msgstr ""
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1792
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1867
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1802
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1877
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1820
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1895
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1912
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1987
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1922
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1997
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: agent's UCP product ID, 2: summed quantity after merging duplicates, 3: maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2036
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2111
 #, php-format
 msgid "Summed quantity %2$d for \"%1$s\" (after merging duplicate line items) exceeds the per-line cap of %3$d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2069
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2144
 msgid "Duplicate line items targeting the same product were merged. Quantities have been summed; the response shows one line per product."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2178
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2253
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2197
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2272
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2248
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2323
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2698
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2773
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
-#. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3464
+#. translators: %s: the input ID the agent submitted that didn't resolve.
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3558
 #, php-format
-msgid "Input %d did not resolve to a known product or variant."
+msgid "Input \"%s\" did not resolve to a known product or variant."
+msgstr ""
+
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3561
+msgid "An input did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3617
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3729
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3687
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3799
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3717
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3829
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3736
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3848
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3760
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3872
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3792
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3904
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3827
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3939
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3857
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3969
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3928
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4040
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3978
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4090
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4007
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4119
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4096
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4208
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4334
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4446
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4368
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4480
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5069
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5181
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5308
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5361
+msgid "Merchant has no privacy policy configured; agents may want to surface this caveat to buyers before proceeding."
+msgstr ""
+
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5377
+msgid "Merchant has no terms of service configured; agents may want to surface this caveat to buyers before proceeding."
+msgstr ""
+
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5425
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5312
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5429
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5316
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5433
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5318
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5435
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5320
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5437
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5324
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5441
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5326
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5443
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T20:25:02+00:00\n"
+"POT-Creation-Date: 2026-05-08T21:48:00+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -193,124 +193,124 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3426
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3443
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3579
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3596
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3649
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3666
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3679
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3696
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3698
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3715
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3722
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3739
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3754
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3771
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3789
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3806
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3819
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3836
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3890
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3907
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3940
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3957
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3969
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3986
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4058
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4075
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4296
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4313
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4330
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4347
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5031
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5048
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5270
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5287
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5274
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5291
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5278
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5295
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5280
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5297
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5282
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5299
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5286
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5303
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5288
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5305
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T19:37:08+00:00\n"
+"POT-Creation-Date: 2026-05-08T20:02:34+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -193,124 +193,124 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3354
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3366
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3507
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3519
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3577
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3589
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3607
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3619
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3626
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3638
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3650
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3662
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3682
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3694
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3717
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3729
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3747
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3759
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3818
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3830
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3868
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3880
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3897
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3909
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3986
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3998
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4224
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4236
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4258
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4270
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4959
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4971
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5198
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5210
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5202
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5214
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5206
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5218
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5208
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5220
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5210
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5222
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5214
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5226
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5216
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5228
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T19:15:24+00:00\n"
+"POT-Creation-Date: 2026-05-08T19:37:08+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -193,124 +193,124 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3341
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3354
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3494
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3507
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3564
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3577
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3594
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3607
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3613
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3626
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3637
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3650
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3669
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3682
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3704
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3717
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3734
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3747
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3805
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3818
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3855
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3868
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3884
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3897
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3973
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3986
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4211
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4224
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4245
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4258
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4946
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4959
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5185
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5198
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5189
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5202
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5193
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5206
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5195
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5208
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5197
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5210
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5201
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5214
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5203
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5216
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T18:48:53+00:00\n"
+"POT-Creation-Date: 2026-05-08T19:15:24+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -193,124 +193,124 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3274
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3341
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3427
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3494
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3497
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3564
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3527
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3594
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3546
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3613
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3570
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3637
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3602
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3669
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3637
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3704
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3667
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3734
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3738
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3805
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3788
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3855
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3817
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3884
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3906
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3973
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4144
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4211
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4178
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4245
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4879
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4946
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5118
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5185
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5122
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5189
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5126
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5193
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5128
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5195
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5130
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5197
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5134
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5201
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5136
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5203
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-08T20:02:34+00:00\n"
+"POT-Creation-Date: 2026-05-08T20:15:29+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -118,199 +118,199 @@ msgid "RFC 3339 / ISO 8601 timestamp (UTC, `Z`-suffixed) of the product's last m
 msgstr ""
 
 #. translators: 1: raw agent identifier extracted from the UCP-Agent header (hostname or product token)
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:528
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:543
 #, php-format
 msgid "Access to this UCP endpoint is not enabled for unknown AI agents on this store. Agent: %1$s"
 msgstr ""
 
 #. translators: 1: canonical agent brand name
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:566
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:581
 #, php-format
 msgid "Access to this UCP endpoint is not enabled for %1$s on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:622
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1465
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1886
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:637
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1480
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1901
 msgid "AI Storefront is not currently enabled on this store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:957
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:980
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:972
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:995
 msgid "Unable to fetch products from the store."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1777
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1792
 msgid "Request body must include an \"ids\" array."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1787
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1802
 msgid "The \"ids\" array must contain at least one ID."
 msgstr ""
 
 #. translators: %d is the maximum number of IDs per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1805
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1820
 #, php-format
 msgid "The \"ids\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1897
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1912
 msgid "Request must include a non-empty \"line_items\" array."
 msgstr ""
 
 #. translators: %d is the maximum number of line items per request.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1907
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:1922
 #, php-format
 msgid "The \"line_items\" array exceeds the per-request limit of %d entries."
 msgstr ""
 
 #. translators: 1: agent's UCP product ID, 2: summed quantity after merging duplicates, 3: maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2021
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2036
 #, php-format
 msgid "Summed quantity %2$d for \"%1$s\" (after merging duplicate line items) exceeds the per-line cap of %3$d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2054
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2069
 msgid "Duplicate line items targeting the same product were merged. Quantities have been summed; the response shows one line per product."
 msgstr ""
 
 #. translators: 1: current subtotal (minor units), 2: minimum order (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2163
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2178
 #, php-format
 msgid "Order subtotal %1$d is below the merchant minimum of %2$d (minor units). Add more items to proceed."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2182
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2197
 msgid "Complete your purchase on the merchant site."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2233
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2248
 msgid "Total excludes tax and shipping, which are calculated at the merchant checkout."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2683
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:2698
 msgid "This /checkout-sessions/{id} URL is stateless and supports no operations: there is no persistent session to read, replace, modify, or cancel. To start or continue a checkout, POST /checkout-sessions with the desired line_items array. The continue_url returned by that POST redirects the buyer to the merchant's native checkout, replacing any prior session."
 msgstr ""
 
 #. translators: %d: zero-based position in the deduped lookup inputs list.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3366
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3415
 #, php-format
 msgid "Input %d did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3519
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3568
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3589
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3638
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3619
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3668
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3638
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3687
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3662
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3711
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3694
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3743
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3729
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3778
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3759
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3808
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3830
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3879
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3880
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3929
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3909
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3958
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3998
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4047
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4236
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4285
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4270
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4319
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4971
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5020
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5210
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5259
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5214
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5263
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5218
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5267
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5220
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5269
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5222
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5271
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5226
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5275
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5228
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5277
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -162,6 +162,20 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 			return $this->params[ $key ] ?? null;
 		}
 
+		/**
+		 * Match WP_REST_Request::get_params(): merge of JSON body and
+		 * form params with form-style query params taking precedence
+		 * for matching keys (consistent with how WP itself merges).
+		 *
+		 * @return array<string, mixed>
+		 */
+		public function get_params(): array {
+			return array_merge(
+				$this->json_params ?? array(),
+				$this->params
+			);
+		}
+
 		public function get_header( string $key ): ?string {
 			$normalized = strtolower( str_replace( '-', '_', $key ) );
 			return $this->headers[ $normalized ] ?? null;

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -163,16 +163,25 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 		}
 
 		/**
-		 * Match WP_REST_Request::get_params(): merge of JSON body and
-		 * form params with form-style query params taking precedence
-		 * for matching keys (consistent with how WP itself merges).
+		 * Merge of JSON body and form params, with the same precedence
+		 * `get_param()` uses: JSON-body keys win over form/query keys.
+		 *
+		 * Caveat: this is NOT a full model of WP_REST_Request's
+		 * parameter-order semantics (in core, the order is `attributes`
+		 * → `URL` → `GET` → `POST` → `JSON` → `defaults`, so URL/GET
+		 * actually win over JSON). The stub collapses everything except
+		 * JSON into a single `$params` bucket, and we keep both
+		 * accessors aligned on the same precedence so tests that read
+		 * a key via either method see the same value. If a test really
+		 * needs URL-vs-JSON semantics, model that explicitly rather
+		 * than relying on the merge order here.
 		 *
 		 * @return array<string, mixed>
 		 */
 		public function get_params(): array {
 			return array_merge(
-				$this->json_params ?? array(),
-				$this->params
+				$this->params,
+				$this->json_params ?? array()
 			);
 		}
 

--- a/tests/php/stubs.php
+++ b/tests/php/stubs.php
@@ -152,10 +152,23 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 		}
 
 		public function get_param( string $key ) {
-			// Match WP behavior: get_param checks JSON body, then regular
-			// params, returning the first match. Handlers that call
-			// get_param('ids') should see the ids array whether it was
-			// delivered via JSON body or form body.
+			// Mirrors WP_REST_Request::get_param() behavior FOR JSON
+			// content-type requests: WP core's parameter order (per
+			// wp-includes/rest-api/class-wp-rest-request.php:361
+			// `get_parameter_order()` in WordPress 6.x) is, highest
+			// priority first:
+			//
+			//   JSON   (only when Content-Type is application/json)
+			//   POST   (only for POST/PUT/PATCH/DELETE methods)
+			//   GET
+			//   URL
+			//   defaults
+			//
+			// JSON wins for our test fixtures because they exclusively
+			// build JSON-body requests (`set_json_params()`); for those
+			// requests, JSON-first is the WP-correct order. Stub
+			// simplifies everything non-JSON into a single `$params`
+			// bucket — fine for the way tests use it.
 			if ( null !== $this->json_params && array_key_exists( $key, $this->json_params ) ) {
 				return $this->json_params[ $key ];
 			}
@@ -164,17 +177,17 @@ if ( ! class_exists( 'WP_REST_Request' ) ) {
 
 		/**
 		 * Merge of JSON body and form params, with the same precedence
-		 * `get_param()` uses: JSON-body keys win over form/query keys.
+		 * `get_param()` uses: JSON-body keys win over form/query keys
+		 * — matching WP core's parameter order for JSON content-type
+		 * requests (see `get_param()` above for the citation).
 		 *
-		 * Caveat: this is NOT a full model of WP_REST_Request's
-		 * parameter-order semantics (in core, the order is `attributes`
-		 * → `URL` → `GET` → `POST` → `JSON` → `defaults`, so URL/GET
-		 * actually win over JSON). The stub collapses everything except
-		 * JSON into a single `$params` bucket, and we keep both
-		 * accessors aligned on the same precedence so tests that read
-		 * a key via either method see the same value. If a test really
-		 * needs URL-vs-JSON semantics, model that explicitly rather
-		 * than relying on the merge order here.
+		 * Stub simplification: WP core's `get_params()` reverses the
+		 * full priority order and merges, so JSON ends up winning when
+		 * present (same outcome as our merge here). The stub just
+		 * collapses non-JSON sources into one `$params` bucket; if a
+		 * test ever needs to distinguish URL vs GET vs POST priority,
+		 * model that explicitly rather than relying on this stub's
+		 * merge order.
 		 *
 		 * @return array<string, mixed>
 		 */

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -95,7 +95,10 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 			static function ( WP_REST_Request $request ) use ( &$api, &$counts ) {
 				$route = $request->get_route();
 
-				// Single-product route — handles both products and variations.
+				// Single-product route — handles parent products. Variations
+				// are batched via /wc/store/v1/products?parent_includes=
+				// (issue #351), but `fetch_store_api_product()` still uses
+				// the per-ID route for parent fetches.
 				if ( preg_match( '#/wc/store/v1/products/(\d+)$#', $route, $m ) ) {
 					$id            = (int) $m[1];
 					$counts[ $id ] = ( $counts[ $id ] ?? 0 ) + 1;
@@ -108,6 +111,31 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 					}
 
 					return new WP_REST_Response( $api[ $id ], 200 );
+				}
+
+				// Batched variation collection (issue #351): when the
+				// controller dispatches with `parent_includes=<csv>`,
+				// return all variations from `$api` whose `parent` field
+				// matches one of the requested IDs.
+				if ( '/wc/store/v1/products' === $route ) {
+					$parent_includes = $request->get_param( 'parent_includes' );
+					if ( null !== $parent_includes && '' !== $parent_includes ) {
+						$parent_ids = array_map(
+							'intval',
+							explode( ',', (string) $parent_includes )
+						);
+						$variations = array();
+						foreach ( $api as $maybe_variation ) {
+							if ( ! is_array( $maybe_variation ) ) {
+								continue;
+							}
+							$parent = (int) ( $maybe_variation['parent'] ?? 0 );
+							if ( $parent > 0 && in_array( $parent, $parent_ids, true ) ) {
+								$variations[] = $maybe_variation;
+							}
+						}
+						return new WP_REST_Response( $variations, 200 );
+					}
 				}
 
 				// Unexpected route — fail loudly.
@@ -164,6 +192,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 
 			$this->fake_store_api[ $spec['id'] ] = [
 				'id'                => $spec['id'],
+				'parent'            => $parent_id, // Required for batched-fetch (#351) parent binning.
 				'name'              => $name,
 				'short_description' => '',
 				'is_in_stock'       => true,
@@ -838,6 +867,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 			];
 			$this->fake_store_api[ $vid ] = [
 				'id'                => $vid,
+				'parent'            => $parent_id, // Required for batched-fetch (#351) parent binning.
 				'name'              => 'Base',
 				'short_description' => '',
 				'is_in_stock'       => true,
@@ -1082,11 +1112,15 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 	// Variation fetch dispatch contract
 	// ------------------------------------------------------------------
 
-	public function test_variations_each_dispatched_once_via_single_product_route(): void {
-		// Each variation must use the single-product route
-		// (/wc/store/v1/products/{id}), not the collection endpoint.
-		// The collection endpoint filters by post_type='product' and
-		// silently excludes post_type='product_variation'.
+	public function test_parent_dispatched_once_variations_batched(): void {
+		// Parent fetch uses the single-product route; variations are
+		// pulled in one batched dispatch via `?parent_includes=`
+		// (issue #351). Pre-#351 each variation was an individual
+		// per-ID dispatch — N+1 fan-out. The batched path uses the
+		// collection endpoint with `parent_includes`, which WC's
+		// Store API DOES surface for variations (verified live).
+		// Per-ID `?include=` is still illegal for variations because
+		// of the post_type filter; `parent_includes` bypasses it.
 		$this->seed_variable_product(
 			100,
 			'Shirt',
@@ -1101,15 +1135,18 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertCount( 3, $body['products'][0]['variants'] );
 
-		// Parent and each variation each dispatched exactly once.
+		// Parent dispatched once via /products/{id}.
 		$this->assertSame(
 			1,
 			$this->store_api_dispatch_counts[100] ?? 0,
 			'Parent product must use the single-product route.'
 		);
-		$this->assertSame( 1, $this->store_api_dispatch_counts[101] ?? 0 );
-		$this->assertSame( 1, $this->store_api_dispatch_counts[102] ?? 0 );
-		$this->assertSame( 1, $this->store_api_dispatch_counts[103] ?? 0 );
+		// Variations are NOT dispatched per-ID anymore — the batched
+		// `?parent_includes=` pull doesn't increment the per-ID
+		// dispatch counter. Confirms the N+1 collapse.
+		$this->assertSame( 0, $this->store_api_dispatch_counts[101] ?? 0 );
+		$this->assertSame( 0, $this->store_api_dispatch_counts[102] ?? 0 );
+		$this->assertSame( 0, $this->store_api_dispatch_counts[103] ?? 0 );
 	}
 
 	public function test_variation_source_order_preserved_after_batch(): void {
@@ -1134,9 +1171,12 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		$this->assertEquals( 'var_203', $variants[2]['id'] );
 	}
 
-	public function test_all_capped_variations_returned_via_single_product_route(): void {
-		// MAX_VARIATIONS_PER_PRODUCT variations must all be fetched via
-		// per-ID single-product requests and all appear in the response.
+	public function test_all_capped_variations_returned_in_one_batched_dispatch(): void {
+		// MAX_VARIATIONS_PER_PRODUCT variations must all appear in the
+		// response and be reachable via a single batched dispatch
+		// (issue #351). Pre-#351 this was 50 individual per-ID
+		// dispatches (N+1 fan-out); now it's one `?parent_includes=300`
+		// collection call.
 		$cap = WC_AI_Storefront_UCP_REST_Controller::MAX_VARIATIONS_PER_PRODUCT;
 		$this->seed_variable_with_n_variations( 300, $cap );
 
@@ -1144,20 +1184,26 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertCount( $cap, $body['products'][0]['variants'] );
 
-		// Parent dispatched once; all variation IDs dispatched exactly once
-		// each (no duplicates, no batching via the collection route).
-		// Total dispatch count = 1 parent + $cap variations.
+		// Per-ID dispatch count = 1 (parent only). Variation IDs are
+		// not dispatched individually under the batched path. The
+		// batched `parent_includes` call doesn't tick the per-ID
+		// counter — its absence is the regression guard against an
+		// accidental fallback to the old per-variation path.
 		$this->assertSame(
-			$cap + 1,
+			1,
 			array_sum( $this->store_api_dispatch_counts ),
-			"Expected exactly $cap + 1 total dispatches (1 parent + $cap variations)."
+			'Expected exactly 1 per-ID dispatch (the parent). Variations should batch via parent_includes, not per-ID.'
 		);
 	}
 
-	public function test_memo_cache_prevents_redundant_variation_dispatch_on_second_lookup(): void {
-		// Two sequential lookup requests for the same variable product in the
-		// same PHP request (reset_request_cache() clears the cache each time)
-		// must each dispatch exactly once per variation — not accumulate.
+	public function test_two_sequential_lookups_each_emit_full_variation_set(): void {
+		// Two sequential lookup requests for the same variable product
+		// in the same PHP request must each render the full variation
+		// set. Pre-#351 this test counted per-variation dispatch counts
+		// (1 per request, accumulating to 2); after #351 variations
+		// batch via `parent_includes` and don't tick the per-ID
+		// counter, so the test now asserts on the observable response
+		// shape (variant count) instead.
 		$this->seed_variable_product(
 			400,
 			'Hat',
@@ -1167,18 +1213,16 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 			]
 		);
 
-		// First lookup.
 		$body1 = $this->successful_lookup( [ 'ids' => [ 'prod_400' ] ] );
 		$this->assertCount( 2, $body1['products'][0]['variants'] );
-		$this->assertSame( 1, $this->store_api_dispatch_counts[401] ?? 0 );
-		$this->assertSame( 1, $this->store_api_dispatch_counts[402] ?? 0 );
 
-		// Second lookup — reset_request_cache() runs at the top of
-		// handle_catalog_lookup(), so variations are re-fetched.
-		// Each variation must be dispatched once more (total = 2), not N*2.
 		$body2 = $this->successful_lookup( [ 'ids' => [ 'prod_400' ] ] );
 		$this->assertCount( 2, $body2['products'][0]['variants'] );
-		$this->assertSame( 2, $this->store_api_dispatch_counts[401] ?? 0 );
-		$this->assertSame( 2, $this->store_api_dispatch_counts[402] ?? 0 );
+
+		// Parent fetched twice (once per request); variations don't
+		// tick the per-ID counter under the batched path.
+		$this->assertSame( 2, $this->store_api_dispatch_counts[400] ?? 0 );
+		$this->assertSame( 0, $this->store_api_dispatch_counts[401] ?? 0 );
+		$this->assertSame( 0, $this->store_api_dispatch_counts[402] ?? 0 );
 	}
 }

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -85,14 +85,18 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// The controller dispatches two route shapes (post-#351):
 		//   - GET /wc/store/v1/products/{id}
 		//     Per-ID parent product fetches via fetch_store_api_product().
-		//   - GET /wc/store/v1/products?parent_includes=<csv>
+		//   - GET /wc/store/v1/products?type=variation&parent=<csv>
 		//     Batched variation fetch via fetch_variations_batched().
-		//     `parent_includes` is the only Store API parameter that
-		//     surfaces post_type='product_variation' through the
-		//     collection endpoint (verified live against WC 9.x).
-		//     Pre-#351 we used the per-ID route for variations too,
-		//     producing N+1 fan-out; the collection route collapses
-		//     that to one (or few) dispatches per request.
+		//     Two params combine to surface variations through the
+		//     collection endpoint: `type=variation` flips post_type
+		//     from 'product' (the default) to 'product_variation';
+		//     `parent=<csv>` filters by post_parent__in via WC's
+		//     `wp_parse_id_list` sanitizer. Without `type=variation`
+		//     the dispatch would silently return zero variations
+		//     regardless of the parent filter. Pre-#351 we used the
+		//     per-ID route for variations too, producing N+1 fan-out;
+		//     the collection route collapses that to one (or few)
+		//     dispatches per request.
 		//
 		// Both branches read from `$api` (a fake_store_api map keyed
 		// by WC ID); the collection branch additionally walks every
@@ -105,7 +109,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 				$route = $request->get_route();
 
 				// Single-product route — handles parent products. Variations
-				// are batched via /wc/store/v1/products?parent_includes=
+				// are batched via /wc/store/v1/products?type=variation&parent=
 				// (issue #351), but `fetch_store_api_product()` still uses
 				// the per-ID route for parent fetches.
 				if ( preg_match( '#/wc/store/v1/products/(\d+)$#', $route, $m ) ) {
@@ -123,23 +127,28 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 				}
 
 				// Batched variation collection (issue #351): when the
-				// controller dispatches with `parent_includes=<csv>`,
+				// controller dispatches with `type=variation&parent=<csv>`,
 				// return all variations from `$api` whose `parent` field
-				// matches one of the requested IDs.
+				// matches one of the requested IDs. Both params are
+				// load-bearing — without `type=variation`, real WC
+				// would return zero results, so the stub must reject
+				// the call too; without `parent`, there's nothing to
+				// filter by.
 				if ( '/wc/store/v1/products' === $route ) {
-					$parent_includes = $request->get_param( 'parent_includes' );
-					if ( null !== $parent_includes && '' !== $parent_includes ) {
+					$type   = (string) ( $request->get_param( 'type' ) ?? '' );
+					$parent = $request->get_param( 'parent' );
+					if ( 'variation' === $type && null !== $parent && '' !== $parent ) {
 						$parent_ids = array_map(
 							'intval',
-							explode( ',', (string) $parent_includes )
+							explode( ',', (string) $parent )
 						);
 						$variations = array();
 						foreach ( $api as $maybe_variation ) {
 							if ( ! is_array( $maybe_variation ) ) {
 								continue;
 							}
-							$parent = (int) ( $maybe_variation['parent'] ?? 0 );
-							if ( $parent > 0 && in_array( $parent, $parent_ids, true ) ) {
+							$parent_field = (int) ( $maybe_variation['parent'] ?? 0 );
+							if ( $parent_field > 0 && in_array( $parent_field, $parent_ids, true ) ) {
 								$variations[] = $maybe_variation;
 							}
 						}
@@ -1123,13 +1132,15 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 
 	public function test_parent_dispatched_once_variations_batched(): void {
 		// Parent fetch uses the single-product route; variations are
-		// pulled in one batched dispatch via `?parent_includes=`
-		// (issue #351). Pre-#351 each variation was an individual
-		// per-ID dispatch — N+1 fan-out. The batched path uses the
-		// collection endpoint with `parent_includes`, which WC's
-		// Store API DOES surface for variations (verified live).
-		// Per-ID `?include=` is still illegal for variations because
-		// of the post_type filter; `parent_includes` bypasses it.
+		// pulled in one batched dispatch via
+		// `?type=variation&parent=<csv>` (issue #351). Pre-#351 each
+		// variation was an individual per-ID dispatch — N+1 fan-out.
+		// The batched path uses the collection endpoint with
+		// `type=variation` flipping post_type and `parent=<csv>`
+		// filtering by post_parent__in. Per-ID `?include=` is still
+		// illegal for variations because the route's default
+		// post_type='product' filter excludes them; `type=variation`
+		// is the param that overrides that default.
 		$this->seed_variable_product(
 			100,
 			'Shirt',
@@ -1151,7 +1162,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 			'Parent product must use the single-product route.'
 		);
 		// Variations are NOT dispatched per-ID anymore — the batched
-		// `?parent_includes=` pull doesn't increment the per-ID
+		// `?type=variation&parent=` pull doesn't increment the per-ID
 		// dispatch counter. Confirms the N+1 collapse.
 		$this->assertSame( 0, $this->store_api_dispatch_counts[101] ?? 0 );
 		$this->assertSame( 0, $this->store_api_dispatch_counts[102] ?? 0 );
@@ -1184,8 +1195,8 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// MAX_VARIATIONS_PER_PRODUCT variations must all appear in the
 		// response and be reachable via a single batched dispatch
 		// (issue #351). Pre-#351 this was 50 individual per-ID
-		// dispatches (N+1 fan-out); now it's one `?parent_includes=300`
-		// collection call.
+		// dispatches (N+1 fan-out); now it's one
+		// `?type=variation&parent=300` collection call.
 		$cap = WC_AI_Storefront_UCP_REST_Controller::MAX_VARIATIONS_PER_PRODUCT;
 		$this->seed_variable_with_n_variations( 300, $cap );
 
@@ -1195,13 +1206,13 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 
 		// Per-ID dispatch count = 1 (parent only). Variation IDs are
 		// not dispatched individually under the batched path. The
-		// batched `parent_includes` call doesn't tick the per-ID
-		// counter — its absence is the regression guard against an
-		// accidental fallback to the old per-variation path.
+		// batched `?type=variation&parent=` call doesn't tick the
+		// per-ID counter — its absence is the regression guard against
+		// an accidental fallback to the old per-variation path.
 		$this->assertSame(
 			1,
 			array_sum( $this->store_api_dispatch_counts ),
-			'Expected exactly 1 per-ID dispatch (the parent). Variations should batch via parent_includes, not per-ID.'
+			'Expected exactly 1 per-ID dispatch (the parent). Variations should batch via ?type=variation&parent=, not per-ID.'
 		);
 	}
 
@@ -1210,7 +1221,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// in the same PHP request must each render the full variation
 		// set. Pre-#351 this test counted per-variation dispatch counts
 		// (1 per request, accumulating to 2); after #351 variations
-		// batch via `parent_includes` and don't tick the per-ID
+		// batch via `?type=variation&parent=` and don't tick the per-ID
 		// counter, so the test now asserts on the observable response
 		// shape (variant count) instead.
 		$this->seed_variable_product(

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -82,13 +82,22 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// time since that class is loaded by the bootstrap.
 
 		// Route rest_do_request through our fake_store_api map.
-		// The controller only dispatches single-product requests:
+		// The controller dispatches two route shapes (post-#351):
 		//   - GET /wc/store/v1/products/{id}
-		//     Used for both parent products and variation IDs. The
-		//     collection endpoint cannot be used for variations because
-		//     WC Store API filters the collection to post_type='product',
-		//     which excludes post_type='product_variation'. Per-ID fetches
-		//     work for both types.
+		//     Per-ID parent product fetches via fetch_store_api_product().
+		//   - GET /wc/store/v1/products?parent_includes=<csv>
+		//     Batched variation fetch via fetch_variations_batched().
+		//     `parent_includes` is the only Store API parameter that
+		//     surfaces post_type='product_variation' through the
+		//     collection endpoint (verified live against WC 9.x).
+		//     Pre-#351 we used the per-ID route for variations too,
+		//     producing N+1 fan-out; the collection route collapses
+		//     that to one (or few) dispatches per request.
+		//
+		// Both branches read from `$api` (a fake_store_api map keyed
+		// by WC ID); the collection branch additionally walks every
+		// entry to find variations whose `parent` field matches one
+		// of the requested parent IDs.
 		$api    = &$this->fake_store_api;
 		$counts = &$this->store_api_dispatch_counts;
 		Functions\when( 'rest_do_request' )->alias(

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -242,36 +242,43 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 					// Regression guard: the controller must NEVER use
 					// `?include=` against variations. Variations have
 					// post_type='product_variation'; the collection
-					// endpoint's `?include=` filters to post_type='product'
-					// and silently drops them. The legitimate batched
-					// variation path is `?parent_includes=` (handled
-					// below), which WC's collection endpoint surfaces
-					// for variations.
+					// endpoint's default post_type='product' filter
+					// silently drops them. The legitimate batched
+					// variation path is `?type=variation&parent=<csv>`
+					// (handled below) — `type=variation` flips the
+					// underlying WP_Query's post_type, and `parent`
+					// populates post_parent__in via WC's
+					// `wp_parse_id_list` sanitizer.
 					$include = $request->get_param( 'include' );
 					if ( is_array( $include ) && ! empty( $include ) ) {
 						throw new \LogicException(
 							'Controller must not use the collection endpoint with ?include for variations. ' .
-							'Use ?parent_includes= for batched variation fetch (#351) or the single-item route.'
+							'Use ?type=variation&parent= for batched variation fetch (#351) or the single-item route.'
 						);
 					}
 
 					// Batched variation fetch (issue #351). When the
-					// controller dispatches with `parent_includes=<csv>`,
+					// controller dispatches with `type=variation&parent=<csv>`,
 					// return all canned variations from `$api` whose
 					// `parent` field matches one of the requested IDs.
-					$parent_includes = $request->get_param( 'parent_includes' );
-					if ( null !== $parent_includes && '' !== $parent_includes ) {
+					// Both params are load-bearing — without
+					// `type=variation`, real WC defaults to
+					// post_type='product' and returns zero variations,
+					// so the stub must reject the call too.
+					$type   = (string) ( $request->get_param( 'type' ) ?? '' );
+					$parent = $request->get_param( 'parent' );
+					if ( 'variation' === $type && null !== $parent && '' !== $parent ) {
 						$parent_ids = array_map(
 							'intval',
-							explode( ',', (string) $parent_includes )
+							explode( ',', (string) $parent )
 						);
 						$variations = array();
 						foreach ( $api as $maybe_variation ) {
 							if ( ! is_array( $maybe_variation ) ) {
 								continue;
 							}
-							$parent = (int) ( $maybe_variation['parent'] ?? 0 );
-							if ( $parent > 0 && in_array( $parent, $parent_ids, true ) ) {
+							$parent_field = (int) ( $maybe_variation['parent'] ?? 0 );
+							if ( $parent_field > 0 && in_array( $parent_field, $parent_ids, true ) ) {
 								$variations[] = $maybe_variation;
 							}
 						}

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -239,18 +239,43 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 				$route = $request->get_route();
 
 				if ( '/wc/store/v1/products' === $route ) {
-					// Regression guard: the controller must NEVER use the
-					// collection endpoint to fetch variation IDs. Variations
-					// have post_type='product_variation'; the collection
-					// endpoint filters to post_type='product' and silently
-					// drops them. Variation fetches must use the single-item
-					// route (/wc/store/v1/products/{id}) instead.
+					// Regression guard: the controller must NEVER use
+					// `?include=` against variations. Variations have
+					// post_type='product_variation'; the collection
+					// endpoint's `?include=` filters to post_type='product'
+					// and silently drops them. The legitimate batched
+					// variation path is `?parent_includes=` (handled
+					// below), which WC's collection endpoint surfaces
+					// for variations.
 					$include = $request->get_param( 'include' );
 					if ( is_array( $include ) && ! empty( $include ) ) {
 						throw new \LogicException(
 							'Controller must not use the collection endpoint with ?include for variations. ' .
-							'Use the single-item route /wc/store/v1/products/{id} instead.'
+							'Use ?parent_includes= for batched variation fetch (#351) or the single-item route.'
 						);
+					}
+
+					// Batched variation fetch (issue #351). When the
+					// controller dispatches with `parent_includes=<csv>`,
+					// return all canned variations from `$api` whose
+					// `parent` field matches one of the requested IDs.
+					$parent_includes = $request->get_param( 'parent_includes' );
+					if ( null !== $parent_includes && '' !== $parent_includes ) {
+						$parent_ids = array_map(
+							'intval',
+							explode( ',', (string) $parent_includes )
+						);
+						$variations = array();
+						foreach ( $api as $maybe_variation ) {
+							if ( ! is_array( $maybe_variation ) ) {
+								continue;
+							}
+							$parent = (int) ( $maybe_variation['parent'] ?? 0 );
+							if ( $parent > 0 && in_array( $parent, $parent_ids, true ) ) {
+								$variations[] = $maybe_variation;
+							}
+						}
+						return new WP_REST_Response( $variations, 200 );
 					}
 
 					// List dispatch — capture the params so tests can
@@ -1600,6 +1625,7 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 
 		$this->fake_store_api[101] = [
 			'id'                => 101,
+			'parent'            => 789, // Required for batched fetch (#351) parent binning.
 			'name'              => 'T-Shirt',
 			'short_description' => '',
 			'is_in_stock'       => true,
@@ -1608,6 +1634,7 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 		];
 		$this->fake_store_api[102] = [
 			'id'                => 102,
+			'parent'            => 789,
 			'name'              => 'T-Shirt',
 			'short_description' => '',
 			'is_in_stock'       => true,
@@ -1652,16 +1679,20 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 			],
 		];
 
-		// Seed only the Small variation; Large fetch will 404.
+		// Seed only the Small variation; Large is intentionally absent
+		// from the fake store → batched dispatch returns just the
+		// Small entry, partial-variants warning fires for the missing 102.
 		$this->fake_store_api[101] = [
 			'id'                => 101,
+			'parent'            => 789, // Required for batched fetch (#351) binning.
 			'name'              => 'T-Shirt',
 			'short_description' => '',
 			'is_in_stock'       => true,
 			'prices'            => [ 'price' => '1000', 'currency_code' => 'USD' ],
 			'attributes'        => [ [ 'name' => 'Size', 'value' => 'Small' ] ],
 		];
-		// Leave 102 unseeded → fake returns 404.
+		// Leave 102 unseeded → batched dispatch omits it from the
+		// returned set → expected_count(2) - returned(1) = skipped(1).
 
 		$body = $this->successful_search( [] );
 

--- a/tests/php/unit/UcpCatalogSearchTest.php
+++ b/tests/php/unit/UcpCatalogSearchTest.php
@@ -249,8 +249,20 @@ class UcpCatalogSearchTest extends \PHPUnit\Framework\TestCase {
 					// underlying WP_Query's post_type, and `parent`
 					// populates post_parent__in via WC's
 					// `wp_parse_id_list` sanitizer.
+					//
+					// Match BOTH shapes WP_REST_Request can return for
+					// `include`: an array (when the request schema
+					// declared `type=array`) and a non-empty CSV
+					// string (when the param arrives as raw query
+					// string and the schema's `wp_parse_id_list`
+					// sanitizer hasn't yet expanded it). A future
+					// regression that built a CSV string instead of
+					// an array would otherwise bypass the guard.
 					$include = $request->get_param( 'include' );
-					if ( is_array( $include ) && ! empty( $include ) ) {
+					$has_include =
+						( is_array( $include ) && ! empty( $include ) )
+						|| ( is_string( $include ) && '' !== trim( $include ) );
+					if ( $has_include ) {
 						throw new \LogicException(
 							'Controller must not use the collection endpoint with ?include for variations. ' .
 							'Use ?type=variation&parent= for batched variation fetch (#351) or the single-item route.'

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -3,7 +3,7 @@
  * Tests for WC_AI_Storefront_UCP_REST_Controller::fetch_variations_batched().
  *
  * The batched helper replaces per-variation N+1 fan-out with a single
- * (or few) `?parent_includes=<csv>&per_page=100` collection dispatch.
+ * (or few) `?type=variation&parent=<csv>&per_page=100` collection dispatch.
  * These tests cover the dispatch shape, pagination at the 100-cap,
  * partial-failure detection, the WP_Error degradation policy, the
  * MAX_VARIATIONS_PER_PRODUCT cap, the empty-input guard, and filter
@@ -250,7 +250,7 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertCount( 1, $this->captured_dispatches );
-		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent'] );
 
 		$this->assertArrayHasKey( 35, $result );
 		$this->assertCount( 1, $result[35]['variations'] );
@@ -318,7 +318,13 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertCount( 1, $this->captured_dispatches );
-		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		// `type=variation` is load-bearing — without it, the underlying
+		// WP_Query defaults to post_type='product' and excludes every
+		// variation, so the dispatch would silently return zero
+		// variations regardless of the parent filter. Lock both
+		// params in the assertion shape.
+		$this->assertSame( 'variation', $this->captured_dispatches[0]['type'] );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent'] );
 		$this->assertSame( 100, $this->captured_dispatches[0]['per_page'] );
 		$this->assertSame( 1, $this->captured_dispatches[0]['page'] );
 
@@ -328,7 +334,7 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 
 	public function test_multi_parent_dispatches_once_with_csv_of_parents(): void {
 		// Three variable parents in one search result page → one
-		// batched dispatch with comma-separated parent_includes.
+		// batched dispatch with comma-separated `parent`.
 		$this->canned_pages = array(
 			1 => array(
 				$this->variation( 101, 35 ),
@@ -348,7 +354,7 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertCount( 1, $this->captured_dispatches );
-		$this->assertSame( '35,36,37', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertSame( '35,36,37', $this->captured_dispatches[0]['parent'] );
 
 		$this->assertCount( 2, $result[35]['variations'] );
 		$this->assertCount( 1, $result[36]['variations'] );
@@ -372,7 +378,7 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertCount( 1, $this->captured_dispatches );
-		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent'] );
 		$this->assertArrayHasKey( 35, $result );
 		$this->assertArrayNotHasKey( 22, $result );
 		$this->assertArrayNotHasKey( 23, $result );
@@ -504,8 +510,9 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 	public function test_orphan_variation_with_unknown_parent_is_dropped(): void {
 		// An orphaned variation whose parent isn't in the request
 		// shouldn't appear under any bin. Defensive — should never
-		// happen with `parent_includes=<csv>` but the binning code
-		// has the guard so we test it.
+		// happen with `?type=variation&parent=<csv>` (WC filters by
+		// post_parent__in) but the binning code has the guard so we
+		// test it.
 		$this->canned_pages = array(
 			1 => array(
 				$this->variation( 101, 35 ),
@@ -604,9 +611,9 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 
 	public function test_max_cap_truncates_expected_set_and_reports_overage_as_skipped(): void {
 		// Parent declares 60 variations; cap is 50. The dispatch sends
-		// the parent's ID in parent_includes (parent_includes is a CSV
-		// of parent IDs, not variation IDs), and the binner uses the
-		// capped expected-set to drop the over-cap tail.
+		// the parent's ID in `parent` (a CSV of parent IDs, not
+		// variation IDs), and the binner uses the capped expected-set
+		// to drop the over-cap tail.
 		// `skipped` = declared(60) - returned(50) = 10 — cap-truncated
 		// entries DO contribute to skipped so agents see a
 		// `partial_variants` warning when their product overflows the
@@ -616,11 +623,12 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 			$declared_ids[] = 1000 + $i;
 		}
 
-		// Production WC will return ALL 60 variations because
-		// `parent_includes` filters by parent_id, not by the capped
-		// expected-set. The binning step's `in_array($variation_id,
-		// $expected_ids)` guard is the only thing dropping the
-		// over-cap tail. Returning all 60 here exercises that guard.
+		// Production WC will return ALL 60 variations because the
+		// `parent` query param filters by post_parent__in, not by the
+		// capped expected-set. The binning step's
+		// `in_array($variation_id, $expected_ids)` guard is the only
+		// thing dropping the over-cap tail. Returning all 60 here
+		// exercises that guard.
 		$page_1 = array();
 		for ( $i = 1; $i <= 60; $i++ ) {
 			$page_1[] = $this->variation( 1000 + $i, 35 );
@@ -776,7 +784,7 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		// Pagination keys were restored — filter MUST NOT override them.
 		$this->assertSame( 100, $this->captured_dispatches[0]['per_page'] );
 		$this->assertSame( 1, $this->captured_dispatches[0]['page'] );
-		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent'] );
 	}
 
 	public function test_filter_returning_non_array_falls_back_safely(): void {
@@ -795,6 +803,6 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertCount( 1, $this->captured_dispatches );
-		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent'] );
 	}
 }

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -375,18 +375,18 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 	// MAX_VARIATIONS_PER_PRODUCT cap
 	// ------------------------------------------------------------------
 
-	public function test_max_cap_truncates_expected_set_per_parent(): void {
-		// Parent declares 60 variations; cap is 50. The CSV must NOT
-		// expect IDs 51-60, and skipped count is 0 if all 50 capped
-		// IDs return — cap-truncated entries don't contribute to skipped
-		// (matches fetch_variations_for() semantics).
+	public function test_max_cap_truncates_expected_set_and_reports_overage_as_skipped(): void {
+		// Parent declares 60 variations; cap is 50. Expected-set is
+		// the first 50; only those go in the parent_includes CSV.
+		// `skipped` = declared(60) - returned(50) = 10 — cap-truncated
+		// entries DO contribute to skipped so agents see a
+		// `partial_variants` warning when their product overflows the
+		// cap. Matches fetch_variations_for() semantics.
 		$declared_ids = array();
 		for ( $i = 1; $i <= 60; $i++ ) {
 			$declared_ids[] = 1000 + $i;
 		}
 
-		// Only return the first 50 — any "expected" 51-60 would be
-		// silently included and skipped is the only way to detect it.
 		$page_1 = array();
 		for ( $i = 1; $i <= 50; $i++ ) {
 			$page_1[] = $this->variation( 1000 + $i, 35 );
@@ -398,8 +398,8 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 
 		$this->assertCount( 50, $result[35]['variations'] );
-		// No skipped — cap-truncated entries weren't expected.
-		$this->assertSame( 0, $result[35]['skipped'] );
+		// 10 over the cap → 10 skipped (the cap-truncated tail).
+		$this->assertSame( 10, $result[35]['skipped'] );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -612,8 +612,11 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 	public function test_max_cap_truncates_expected_set_and_reports_overage_as_skipped(): void {
 		// Parent declares 60 variations; cap is 50. The dispatch sends
 		// the parent's ID in `parent` (a CSV of parent IDs, not
-		// variation IDs), and the binner uses the capped expected-set
-		// to drop the over-cap tail.
+		// variation IDs), and the accumulation loop uses an O(1)
+		// per-parent expected-ID lookup (`$expected_per_parent_set`)
+		// to drop the over-cap tail at append time — non-expected
+		// variations never enter `$all_variations`, saving memory + CPU
+		// for parents with many over-cap variations.
 		// `skipped` = declared(60) - returned(50) = 10 — cap-truncated
 		// entries DO contribute to skipped so agents see a
 		// `partial_variants` warning when their product overflows the
@@ -625,10 +628,9 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 
 		// Production WC will return ALL 60 variations because the
 		// `parent` query param filters by post_parent__in, not by the
-		// capped expected-set. The binning step's
-		// `in_array($variation_id, $expected_ids)` guard is the only
-		// thing dropping the over-cap tail. Returning all 60 here
-		// exercises that guard.
+		// capped expected-set. The accumulation-time `isset()` lookup
+		// against the per-parent expected-set is what drops the
+		// over-cap tail. Returning all 60 here exercises that filter.
 		$page_1 = array();
 		for ( $i = 1; $i <= 60; $i++ ) {
 			$page_1[] = $this->variation( 1000 + $i, 35 );

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -40,10 +40,19 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 	private array $canned_pages = [];
 
 	/**
-	 * If true, the `rest_do_request` stub returns WP_Error to exercise
-	 * the batch-fail degradation policy.
+	 * If true, the `rest_do_request` stub returns WP_Error on every
+	 * page. Exercises the page-1 (degenerate) failure path.
 	 */
 	private bool $force_wp_error = false;
+
+	/**
+	 * Set of page numbers (1-indexed) where the stub should return
+	 * WP_Error. Used to exercise partial-failure paths where earlier
+	 * pages succeed and a later page errors.
+	 *
+	 * @var array<int, bool>
+	 */
+	private array $wp_error_pages = [];
 
 	protected function setUp(): void {
 		parent::setUp();
@@ -52,20 +61,22 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		$this->captured_dispatches = [];
 		$this->canned_pages        = [];
 		$this->force_wp_error      = false;
+		$this->wp_error_pages      = [];
 
 		// Wire rest_do_request to capture + return canned pages.
 		$captured     = &$this->captured_dispatches;
 		$pages        = &$this->canned_pages;
 		$wp_error_ref = &$this->force_wp_error;
+		$error_pages  = &$this->wp_error_pages;
 		Functions\when( 'rest_do_request' )->alias(
-			static function ( WP_REST_Request $request ) use ( &$captured, &$pages, &$wp_error_ref ) {
+			static function ( WP_REST_Request $request ) use ( &$captured, &$pages, &$wp_error_ref, &$error_pages ) {
 				$captured[] = $request->get_params();
 
-				if ( $wp_error_ref ) {
+				$page = (int) $request->get_param( 'page' );
+				if ( $wp_error_ref || ! empty( $error_pages[ $page ] ) ) {
 					return new WP_Error( 'forced_error', 'Test forced WP_Error.' );
 				}
 
-				$page = (int) $request->get_param( 'page' );
 				$body = $pages[ $page ] ?? array();
 				return new WP_REST_Response( $body, 200 );
 			}
@@ -354,7 +365,10 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 	// Batch-call failure (WP_Error / 5xx)
 	// ------------------------------------------------------------------
 
-	public function test_wp_error_degrades_all_parents_to_empty_with_skipped(): void {
+	public function test_first_page_wp_error_degrades_all_parents_to_empty_with_skipped(): void {
+		// Degenerate case: page 1 itself fails. No data was captured;
+		// every variable parent must degrade to `variations: [],
+		// skipped: declared` so the partial-variants warning fires.
 		$this->force_wp_error = true;
 
 		$result = $this->call_batched(
@@ -364,11 +378,63 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 			)
 		);
 
-		$this->assertCount( 1, $this->captured_dispatches ); // tried once, WP_Error broke the loop
+		$this->assertCount( 1, $this->captured_dispatches );
 		$this->assertSame( array(), $result[35]['variations'] );
 		$this->assertSame( 3, $result[35]['skipped'] );
 		$this->assertSame( array(), $result[36]['variations'] );
 		$this->assertSame( 2, $result[36]['skipped'] );
+	}
+
+	public function test_page_n_wp_error_keeps_prior_page_data(): void {
+		// Partial-failure case: page 1 captures 100 variations
+		// successfully, page 2 errors out. Pre-fix, the entire batch
+		// degraded — punishing parents whose variations were fully
+		// returned on page 1. After the fix, prior-page data is kept
+		// and the per-parent `declared - returned` math computes
+		// skipped naturally.
+		//
+		// Setup: parents 35 and 36 each declare 50 variations (100
+		// combined), parent 37 declares 30. Page 1 returns the 100
+		// from parents 35 + 36. Page 2 should return parent 37's 30,
+		// but errors. Result: parents 35 + 36 fully captured (skipped
+		// = 0); parent 37 fully missing (skipped = 30).
+		$page_1 = array();
+		foreach ( array( 35, 36 ) as $parent_id ) {
+			for ( $i = 1; $i <= 50; $i++ ) {
+				$page_1[] = $this->variation( ( $parent_id * 1000 ) + $i, $parent_id );
+			}
+		}
+		$this->canned_pages         = array( 1 => $page_1 );
+		$this->wp_error_pages[ 2 ]  = true;
+
+		$result = $this->call_batched(
+			array(
+				$this->variable_product(
+					35,
+					array_map( static fn( int $i ): int => 35000 + $i, range( 1, 50 ) )
+				),
+				$this->variable_product(
+					36,
+					array_map( static fn( int $i ): int => 36000 + $i, range( 1, 50 ) )
+				),
+				$this->variable_product(
+					37,
+					array_map( static fn( int $i ): int => 37000 + $i, range( 1, 30 ) )
+				),
+			)
+		);
+
+		// Page 1 succeeded for 35 + 36; page 2 errored before parent 37
+		// could be returned.
+		$this->assertCount( 50, $result[35]['variations'] );
+		$this->assertSame( 0, $result[35]['skipped'] );
+		$this->assertCount( 50, $result[36]['variations'] );
+		$this->assertSame( 0, $result[36]['skipped'] );
+		// Parent 37 has no returned variations; declared 30 → skipped 30.
+		// Parents whose data was fully returned aren't punished for the
+		// later page failure — that was the regression this test guards.
+		$this->assertCount( 0, $result[37]['variations'] );
+		$this->assertSame( 30, $result[37]['skipped'] );
 	}
 
 	// ------------------------------------------------------------------
@@ -387,8 +453,13 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 			$declared_ids[] = 1000 + $i;
 		}
 
+		// Production WC will return ALL 60 variations because
+		// `parent_includes` filters by parent_id, not by the capped
+		// expected-set. The binning step's `in_array($variation_id,
+		// $expected_ids)` guard is the only thing dropping the
+		// over-cap tail. Returning all 60 here exercises that guard.
 		$page_1 = array();
-		for ( $i = 1; $i <= 50; $i++ ) {
+		for ( $i = 1; $i <= 60; $i++ ) {
 			$page_1[] = $this->variation( 1000 + $i, 35 );
 		}
 		$this->canned_pages = array( 1 => $page_1 );
@@ -397,7 +468,15 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 			array( $this->variable_product( 35, $declared_ids ) )
 		);
 
+		// Only the first 50 should appear; the IDs 1051–1060 must NOT
+		// be in the returned variations (the binner dropped them).
 		$this->assertCount( 50, $result[35]['variations'] );
+		$returned_ids = array_column( $result[35]['variations'], 'id' );
+		$this->assertSame(
+			range( 1001, 1050 ),
+			$returned_ids,
+			'Cap-truncated tail (1051..1060) must be filtered out by the binner.'
+		);
 		// 10 over the cap → 10 skipped (the cap-truncated tail).
 		$this->assertSame( 10, $result[35]['skipped'] );
 	}

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -172,6 +172,111 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		$this->assertCount( 0, $this->captured_dispatches );
 	}
 
+	public function test_all_malformed_pointers_emits_partial_variants_warning(): void {
+		// Variable parent declares 3 variations but every pointer ID
+		// is malformed (zero/negative). Pre-fix: the parent silently
+		// dropped from the result map, no warning. Post-fix: the
+		// parent gets `variations: [], skipped: 3` so the partial-
+		// variants warning fires — matches fetch_variations_for()
+		// semantics where any unsurfaced declared variation triggers
+		// the warning.
+		$result = $this->call_batched(
+			array(
+				array(
+					'id'         => 35,
+					'type'       => 'variable',
+					'variations' => array(
+						array( 'id' => 0 ),
+						array( 'id' => -1 ),
+						array( 'id' => 0 ),
+					),
+				),
+			)
+		);
+
+		$this->assertArrayHasKey( 35, $result );
+		$this->assertSame( array(), $result[35]['variations'] );
+		$this->assertSame( 3, $result[35]['skipped'] );
+		// No dispatch — all-malformed parents have nothing to fetch.
+		$this->assertCount( 0, $this->captured_dispatches );
+	}
+
+	public function test_mixed_malformed_and_valid_parents_dispatches_only_valid(): void {
+		// Mixed worklist: parent 35 has a valid pointer, parent 36 is
+		// all-malformed. Verify the dispatch only includes parent 35
+		// AND parent 36 still gets a result entry with skipped: 2.
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation( 101, 35 ),
+			),
+		);
+
+		$result = $this->call_batched(
+			array(
+				array(
+					'id'         => 35,
+					'type'       => 'variable',
+					'variations' => array( array( 'id' => 101 ) ),
+				),
+				array(
+					'id'         => 36,
+					'type'       => 'variable',
+					'variations' => array( array( 'id' => 0 ), array( 'id' => -5 ) ),
+				),
+			)
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+
+		$this->assertArrayHasKey( 35, $result );
+		$this->assertCount( 1, $result[35]['variations'] );
+		$this->assertSame( 0, $result[35]['skipped'] );
+
+		$this->assertArrayHasKey( 36, $result );
+		$this->assertSame( array(), $result[36]['variations'] );
+		$this->assertSame( 2, $result[36]['skipped'] );
+	}
+
+	public function test_returned_variations_match_declared_source_order(): void {
+		// Store API may return variations in any order (typically by
+		// menu_order or modification time). The result MUST honor the
+		// parent's declared `variations[]` sequence so downstream
+		// emission matches what the agent expects from the parent's
+		// pointer list. Mirrors the per-variation predecessor that
+		// iterated declared IDs in order.
+		$this->canned_pages = array(
+			// API returns them shuffled vs. declared order [101,102,103,104].
+			1 => array(
+				$this->variation( 103, 35 ),
+				$this->variation( 101, 35 ),
+				$this->variation( 104, 35 ),
+				$this->variation( 102, 35 ),
+			),
+		);
+
+		$result = $this->call_batched(
+			array(
+				array(
+					'id'         => 35,
+					'type'       => 'variable',
+					'variations' => array(
+						array( 'id' => 101 ),
+						array( 'id' => 102 ),
+						array( 'id' => 103 ),
+						array( 'id' => 104 ),
+					),
+				),
+			)
+		);
+
+		$ids = array_map(
+			static fn( array $v ): int => (int) $v['id'],
+			$result[35]['variations']
+		);
+		$this->assertSame( array( 101, 102, 103, 104 ), $ids );
+	}
+
 	// ------------------------------------------------------------------
 	// Happy path — single + multi parent
 	// ------------------------------------------------------------------
@@ -442,8 +547,10 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 	// ------------------------------------------------------------------
 
 	public function test_max_cap_truncates_expected_set_and_reports_overage_as_skipped(): void {
-		// Parent declares 60 variations; cap is 50. Expected-set is
-		// the first 50; only those go in the parent_includes CSV.
+		// Parent declares 60 variations; cap is 50. The dispatch sends
+		// the parent's ID in parent_includes (parent_includes is a CSV
+		// of parent IDs, not variation IDs), and the binner uses the
+		// capped expected-set to drop the over-cap tail.
 		// `skipped` = declared(60) - returned(50) = 10 — cap-truncated
 		// entries DO contribute to skipped so agents see a
 		// `partial_variants` warning when their product overflows the

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -1,0 +1,460 @@
+<?php
+/**
+ * Tests for WC_AI_Storefront_UCP_REST_Controller::fetch_variations_batched().
+ *
+ * The batched helper replaces per-variation N+1 fan-out with a single
+ * (or few) `?parent_includes=<csv>&per_page=100` collection dispatch.
+ * These tests cover the dispatch shape, pagination at the 100-cap,
+ * partial-failure detection, the WP_Error degradation policy, the
+ * MAX_VARIATIONS_PER_PRODUCT cap, the empty-input guard, and filter
+ * compatibility — without exercising the search/lookup wiring (those
+ * tests live in UcpCatalogSearchTest / UcpCatalogLookupTest).
+ *
+ * @package WooCommerce_AI_Storefront
+ */
+
+use Brain\Monkey;
+use Brain\Monkey\Functions;
+use Mockery\Adapter\Phpunit\MockeryPHPUnitIntegration;
+
+class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
+	use MockeryPHPUnitIntegration;
+
+	/**
+	 * Captured `rest_do_request` calls. Each entry is the params
+	 * snapshot of one dispatched WP_REST_Request, in order. Tests
+	 * assert against this to verify the batched-dispatch contract
+	 * (one request per page, correct query params).
+	 *
+	 * @var array<int, array<string, mixed>>
+	 */
+	private array $captured_dispatches = [];
+
+	/**
+	 * Canned variation responses indexed by their order in the
+	 * collection response. Tests can either return the full set in
+	 * one response or split across multiple pages.
+	 *
+	 * @var array<int, array<int, array<string, mixed>>>
+	 */
+	private array $canned_pages = [];
+
+	/**
+	 * If true, the `rest_do_request` stub returns WP_Error to exercise
+	 * the batch-fail degradation policy.
+	 */
+	private bool $force_wp_error = false;
+
+	protected function setUp(): void {
+		parent::setUp();
+		Monkey\setUp();
+
+		$this->captured_dispatches = [];
+		$this->canned_pages        = [];
+		$this->force_wp_error      = false;
+
+		// Wire rest_do_request to capture + return canned pages.
+		$captured     = &$this->captured_dispatches;
+		$pages        = &$this->canned_pages;
+		$wp_error_ref = &$this->force_wp_error;
+		Functions\when( 'rest_do_request' )->alias(
+			static function ( WP_REST_Request $request ) use ( &$captured, &$pages, &$wp_error_ref ) {
+				$captured[] = $request->get_params();
+
+				if ( $wp_error_ref ) {
+					return new WP_Error( 'forced_error', 'Test forced WP_Error.' );
+				}
+
+				$page = (int) $request->get_param( 'page' );
+				$body = $pages[ $page ] ?? array();
+				return new WP_REST_Response( $body, 200 );
+			}
+		);
+
+		// Reset settings between tests so any disabled-state behavior
+		// doesn't leak. Stub defaults to enabled.
+		WC_AI_Storefront::$test_settings = [];
+	}
+
+	protected function tearDown(): void {
+		Monkey\tearDown();
+		parent::tearDown();
+	}
+
+	/**
+	 * Invoke fetch_variations_batched() via reflection (private method).
+	 *
+	 * @param array<int, array<string, mixed>> $wc_products
+	 * @return array<int, array{variations: array<int, array<string, mixed>>, skipped: int}>
+	 */
+	private function call_batched( array $wc_products ): array {
+		$controller = new WC_AI_Storefront_UCP_REST_Controller();
+		$method     = ( new \ReflectionClass( $controller ) )->getMethod( 'fetch_variations_batched' );
+		$method->setAccessible( true );
+		return $method->invoke( $controller, $wc_products );
+	}
+
+	/**
+	 * Build a parent-product fixture pointing at the given variation IDs.
+	 *
+	 * @param array<int, int> $variation_ids
+	 * @return array<string, mixed>
+	 */
+	private function variable_product( int $parent_id, array $variation_ids ): array {
+		return array(
+			'id'         => $parent_id,
+			'type'       => 'variable',
+			'variations' => array_map(
+				static fn( int $id ): array => array( 'id' => $id ),
+				$variation_ids
+			),
+		);
+	}
+
+	/**
+	 * Build a canned variation response carrying the parent linkage
+	 * the binning step uses.
+	 *
+	 * @return array<string, mixed>
+	 */
+	private function variation( int $id, int $parent_id ): array {
+		return array(
+			'id'     => $id,
+			'parent' => $parent_id,
+			'name'   => "Variation $id",
+		);
+	}
+
+	// ------------------------------------------------------------------
+	// Edge cases — input shape
+	// ------------------------------------------------------------------
+
+	public function test_empty_input_skips_dispatch(): void {
+		$result = $this->call_batched( array() );
+
+		$this->assertSame( array(), $result );
+		$this->assertCount( 0, $this->captured_dispatches );
+	}
+
+	public function test_all_simple_input_skips_dispatch(): void {
+		$result = $this->call_batched(
+			array(
+				array( 'id' => 1, 'type' => 'simple' ),
+				array( 'id' => 2, 'type' => 'simple' ),
+			)
+		);
+
+		$this->assertSame( array(), $result );
+		$this->assertCount( 0, $this->captured_dispatches );
+	}
+
+	public function test_variable_with_empty_variations_array_skips_parent(): void {
+		// A variable product whose `variations[]` pointer list is
+		// empty (data anomaly) contributes nothing to the work list.
+		$result = $this->call_batched(
+			array(
+				array( 'id' => 1, 'type' => 'variable', 'variations' => array() ),
+			)
+		);
+
+		$this->assertSame( array(), $result );
+		$this->assertCount( 0, $this->captured_dispatches );
+	}
+
+	// ------------------------------------------------------------------
+	// Happy path — single + multi parent
+	// ------------------------------------------------------------------
+
+	public function test_single_parent_dispatches_once_with_correct_params(): void {
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation( 101, 35 ),
+				$this->variation( 102, 35 ),
+				$this->variation( 103, 35 ),
+			),
+		);
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, array( 101, 102, 103 ) ) )
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertSame( 100, $this->captured_dispatches[0]['per_page'] );
+		$this->assertSame( 1, $this->captured_dispatches[0]['page'] );
+
+		$this->assertCount( 3, $result[35]['variations'] );
+		$this->assertSame( 0, $result[35]['skipped'] );
+	}
+
+	public function test_multi_parent_dispatches_once_with_csv_of_parents(): void {
+		// Three variable parents in one search result page → one
+		// batched dispatch with comma-separated parent_includes.
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation( 101, 35 ),
+				$this->variation( 102, 35 ),
+				$this->variation( 201, 36 ),
+				$this->variation( 301, 37 ),
+				$this->variation( 302, 37 ),
+			),
+		);
+
+		$result = $this->call_batched(
+			array(
+				$this->variable_product( 35, array( 101, 102 ) ),
+				$this->variable_product( 36, array( 201 ) ),
+				$this->variable_product( 37, array( 301, 302 ) ),
+			)
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+		$this->assertSame( '35,36,37', $this->captured_dispatches[0]['parent_includes'] );
+
+		$this->assertCount( 2, $result[35]['variations'] );
+		$this->assertCount( 1, $result[36]['variations'] );
+		$this->assertCount( 2, $result[37]['variations'] );
+		$this->assertSame( 0, $result[35]['skipped'] );
+		$this->assertSame( 0, $result[36]['skipped'] );
+		$this->assertSame( 0, $result[37]['skipped'] );
+	}
+
+	public function test_mixed_simple_and_variable_only_batches_variable_parents(): void {
+		$this->canned_pages = array(
+			1 => array( $this->variation( 101, 35 ) ),
+		);
+
+		$result = $this->call_batched(
+			array(
+				array( 'id' => 22, 'type' => 'simple' ),
+				$this->variable_product( 35, array( 101 ) ),
+				array( 'id' => 23, 'type' => 'simple' ),
+			)
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+		$this->assertArrayHasKey( 35, $result );
+		$this->assertArrayNotHasKey( 22, $result );
+		$this->assertArrayNotHasKey( 23, $result );
+	}
+
+	// ------------------------------------------------------------------
+	// Pagination at the 100-item cap
+	// ------------------------------------------------------------------
+
+	public function test_combined_count_above_100_paginates_correctly(): void {
+		// Three parents × 50 variations = 150 total. Page 1 returns
+		// 100 (full), page 2 returns 50 (short — terminates the walk).
+		$page_1 = array();
+		$page_2 = array();
+		$expected_per_parent = array();
+		foreach ( array( 35, 36, 37 ) as $parent ) {
+			$expected_per_parent[ $parent ] = array();
+			for ( $i = 1; $i <= 50; $i++ ) {
+				$variation_id = ( $parent * 1000 ) + $i;
+				$expected_per_parent[ $parent ][] = $variation_id;
+			}
+		}
+		// Spread the 150 variations across two pages: 100 then 50.
+		$flat = array();
+		foreach ( $expected_per_parent as $parent => $ids ) {
+			foreach ( $ids as $id ) {
+				$flat[] = $this->variation( $id, $parent );
+			}
+		}
+		$page_1 = array_slice( $flat, 0, 100 );
+		$page_2 = array_slice( $flat, 100, 50 );
+		$this->canned_pages = array( 1 => $page_1, 2 => $page_2 );
+
+		$result = $this->call_batched(
+			array(
+				$this->variable_product( 35, $expected_per_parent[35] ),
+				$this->variable_product( 36, $expected_per_parent[36] ),
+				$this->variable_product( 37, $expected_per_parent[37] ),
+			)
+		);
+
+		$this->assertCount( 2, $this->captured_dispatches );
+		$this->assertSame( 1, $this->captured_dispatches[0]['page'] );
+		$this->assertSame( 2, $this->captured_dispatches[1]['page'] );
+
+		$this->assertCount( 50, $result[35]['variations'] );
+		$this->assertCount( 50, $result[36]['variations'] );
+		$this->assertCount( 50, $result[37]['variations'] );
+	}
+
+	public function test_short_first_page_terminates_walk(): void {
+		// Only 5 variations across all parents — first page returns
+		// 5 (short), no second dispatch.
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation( 101, 35 ),
+				$this->variation( 102, 35 ),
+				$this->variation( 103, 35 ),
+				$this->variation( 201, 36 ),
+				$this->variation( 202, 36 ),
+			),
+		);
+
+		$this->call_batched(
+			array(
+				$this->variable_product( 35, array( 101, 102, 103 ) ),
+				$this->variable_product( 36, array( 201, 202 ) ),
+			)
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+	}
+
+	// ------------------------------------------------------------------
+	// Partial failure (some variations missing from response)
+	// ------------------------------------------------------------------
+
+	public function test_partial_response_emits_skipped_count(): void {
+		// Parent 35 declares 3 variations; only 2 come back.
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation( 101, 35 ),
+				$this->variation( 102, 35 ),
+				// 103 is missing — fetch failed or scope-filtered
+			),
+		);
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, array( 101, 102, 103 ) ) )
+		);
+
+		$this->assertCount( 2, $result[35]['variations'] );
+		$this->assertSame( 1, $result[35]['skipped'] );
+	}
+
+	public function test_orphan_variation_with_unknown_parent_is_dropped(): void {
+		// An orphaned variation whose parent isn't in the request
+		// shouldn't appear under any bin. Defensive — should never
+		// happen with `parent_includes=<csv>` but the binning code
+		// has the guard so we test it.
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation( 101, 35 ),
+				$this->variation( 999, 9999 ), // orphan
+			),
+		);
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, array( 101 ) ) )
+		);
+
+		$this->assertCount( 1, $result[35]['variations'] );
+		$this->assertSame( 101, $result[35]['variations'][0]['id'] );
+		$this->assertArrayNotHasKey( 9999, $result );
+	}
+
+	// ------------------------------------------------------------------
+	// Batch-call failure (WP_Error / 5xx)
+	// ------------------------------------------------------------------
+
+	public function test_wp_error_degrades_all_parents_to_empty_with_skipped(): void {
+		$this->force_wp_error = true;
+
+		$result = $this->call_batched(
+			array(
+				$this->variable_product( 35, array( 101, 102, 103 ) ),
+				$this->variable_product( 36, array( 201, 202 ) ),
+			)
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches ); // tried once, WP_Error broke the loop
+		$this->assertSame( array(), $result[35]['variations'] );
+		$this->assertSame( 3, $result[35]['skipped'] );
+		$this->assertSame( array(), $result[36]['variations'] );
+		$this->assertSame( 2, $result[36]['skipped'] );
+	}
+
+	// ------------------------------------------------------------------
+	// MAX_VARIATIONS_PER_PRODUCT cap
+	// ------------------------------------------------------------------
+
+	public function test_max_cap_truncates_expected_set_per_parent(): void {
+		// Parent declares 60 variations; cap is 50. The CSV must NOT
+		// expect IDs 51-60, and skipped count is 0 if all 50 capped
+		// IDs return — cap-truncated entries don't contribute to skipped
+		// (matches fetch_variations_for() semantics).
+		$declared_ids = array();
+		for ( $i = 1; $i <= 60; $i++ ) {
+			$declared_ids[] = 1000 + $i;
+		}
+
+		// Only return the first 50 — any "expected" 51-60 would be
+		// silently included and skipped is the only way to detect it.
+		$page_1 = array();
+		for ( $i = 1; $i <= 50; $i++ ) {
+			$page_1[] = $this->variation( 1000 + $i, 35 );
+		}
+		$this->canned_pages = array( 1 => $page_1 );
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, $declared_ids ) )
+		);
+
+		$this->assertCount( 50, $result[35]['variations'] );
+		// No skipped — cap-truncated entries weren't expected.
+		$this->assertSame( 0, $result[35]['skipped'] );
+	}
+
+	// ------------------------------------------------------------------
+	// Filter compatibility
+	// ------------------------------------------------------------------
+
+	public function test_wc_ai_storefront_ucp_store_api_args_filter_applied(): void {
+		// A merchant filter that adds a `category` constraint must
+		// flow into the batched dispatch params just as it does for
+		// the search collection dispatch.
+		$this->canned_pages = array(
+			1 => array( $this->variation( 101, 35 ) ),
+		);
+
+		Monkey\Filters\expectApplied( 'wc_ai_storefront_ucp_store_api_args' )
+			->once()
+			->with(
+				\Mockery::on( static fn( $params ): bool => is_array( $params ) ),
+				'/wc/store/v1/products'
+			)
+			->andReturnUsing(
+				static function ( array $params ): array {
+					$params['category'] = 'invisible-scope';
+					return $params;
+				}
+			);
+
+		$this->call_batched(
+			array( $this->variable_product( 35, array( 101 ) ) )
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+		$this->assertSame( 'invisible-scope', $this->captured_dispatches[0]['category'] );
+		// Pagination keys were restored — filter MUST NOT override them.
+		$this->assertSame( 100, $this->captured_dispatches[0]['per_page'] );
+		$this->assertSame( 1, $this->captured_dispatches[0]['page'] );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+	}
+
+	public function test_filter_returning_non_array_falls_back_safely(): void {
+		// Misbehaving filter callbacks return non-arrays; guard
+		// preserves original params so dispatch isn't broken.
+		$this->canned_pages = array(
+			1 => array( $this->variation( 101, 35 ) ),
+		);
+
+		Monkey\Filters\expectApplied( 'wc_ai_storefront_ucp_store_api_args' )
+			->once()
+			->andReturn( 'not-an-array' );
+
+		$this->call_batched(
+			array( $this->variable_product( 35, array( 101 ) ) )
+		);
+
+		$this->assertCount( 1, $this->captured_dispatches );
+		$this->assertSame( '35', $this->captured_dispatches[0]['parent_includes'] );
+	}
+}

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -136,6 +136,29 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		);
 	}
 
+	/**
+	 * Build a variation as stdClass with stdClass-nested fields. Mimics
+	 * what the WC Store API REST controller returns over an internal
+	 * dispatch — prepared `\WP_REST_Response` objects whose nested
+	 * fields don't get array-cast unless serialized through HTTP.
+	 *
+	 * @return \stdClass
+	 */
+	private function variation_object( int $id, int $parent_id ): \stdClass {
+		$o         = new \stdClass();
+		$o->id     = $id;
+		$o->parent = $parent_id;
+		$o->name   = "Variation $id";
+		// Nested stdClass field — common in real Store API responses
+		// for `prices`, `attributes`, etc. The translator path expects
+		// arrays here, so the normalize step must reach into nested
+		// objects, not just the top-level list.
+		$o->prices               = new \stdClass();
+		$o->prices->price        = '1000';
+		$o->prices->currency     = 'USD';
+		return $o;
+	}
+
 	// ------------------------------------------------------------------
 	// Edge cases — input shape
 	// ------------------------------------------------------------------
@@ -443,6 +466,39 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 
 		$this->assertCount( 2, $result[35]['variations'] );
 		$this->assertSame( 1, $result[35]['skipped'] );
+	}
+
+	public function test_stdclass_variations_are_normalized_before_binning(): void {
+		// Internal `rest_do_request` returns prepared WP_REST_Response
+		// objects whose nested data is stdClass, not arrays. Pre-fix,
+		// the loop's `is_array($variation)` guard silently dropped each
+		// stdClass entry — leaving callers with `variations: []` even
+		// though the dispatch succeeded. Post-fix, normalize_store_api_data()
+		// recursively casts the response to arrays so binning + the
+		// downstream translators see uniform array shapes.
+		$this->canned_pages = array(
+			1 => array(
+				$this->variation_object( 101, 35 ),
+				$this->variation_object( 102, 35 ),
+			),
+		);
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, array( 101, 102 ) ) )
+		);
+
+		$this->assertCount( 2, $result[35]['variations'] );
+		$this->assertSame( 0, $result[35]['skipped'] );
+		// Each variation is now a plain array (not stdClass) so the
+		// translator can read it without "Cannot use object of type
+		// stdClass as array" fatals.
+		$this->assertIsArray( $result[35]['variations'][0] );
+		$this->assertSame( 101, $result[35]['variations'][0]['id'] );
+		$this->assertSame( 35, $result[35]['variations'][0]['parent'] );
+		// Nested stdClass fields are also normalized — important for
+		// downstream translators that read `prices`, `attributes`, etc.
+		$this->assertIsArray( $result[35]['variations'][0]['prices'] );
+		$this->assertSame( '1000', $result[35]['variations'][0]['prices']['price'] );
 	}
 
 	public function test_orphan_variation_with_unknown_parent_is_dropped(): void {

--- a/tests/php/unit/UcpVariationBatchTest.php
+++ b/tests/php/unit/UcpVariationBatchTest.php
@@ -644,6 +644,104 @@ class UcpVariationBatchTest extends \PHPUnit\Framework\TestCase {
 		$this->assertSame( 10, $result[35]['skipped'] );
 	}
 
+	public function test_pagination_stops_early_once_all_expected_ids_collected(): void {
+		// Parent declares 200 variations; the cap (50) leaves the
+		// expected set as 1001..1050. Production WC would return all
+		// 200 across multiple pages (per_page caps at 100). Pre-
+		// optimization the loop walked all 200; post-optimization it
+		// stops as soon as every expected ID has been seen on the
+		// wire — the over-cap tail (1051..1200) is never fetched.
+		//
+		// In this canned scenario page 1 returns 1001..1100 (100 vars),
+		// which contains all 50 expected IDs. Page 2 (1101..1200)
+		// MUST NOT be fetched.
+		$declared_ids = array();
+		for ( $i = 1; $i <= 200; $i++ ) {
+			$declared_ids[] = 1000 + $i;
+		}
+
+		$page_1 = array();
+		for ( $i = 1; $i <= 100; $i++ ) {
+			$page_1[] = $this->variation( 1000 + $i, 35 );
+		}
+		$page_2 = array();
+		for ( $i = 101; $i <= 200; $i++ ) {
+			$page_2[] = $this->variation( 1000 + $i, 35 );
+		}
+		$this->canned_pages = array(
+			1 => $page_1,
+			2 => $page_2,
+		);
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, $declared_ids ) )
+		);
+
+		// Single dispatch — page 2 was elided by the early-stop check.
+		$this->assertCount(
+			1,
+			$this->captured_dispatches,
+			'Early-stop should prevent fetching page 2 once all expected IDs are collected on page 1.'
+		);
+		$this->assertSame( '1', (string) $this->captured_dispatches[0]['page'] );
+
+		// Output assertions match the cap-overage behavior: 50 emitted,
+		// 150 skipped (200 declared − 50 returned).
+		$this->assertCount( 50, $result[35]['variations'] );
+		$returned_ids = array_column( $result[35]['variations'], 'id' );
+		$this->assertSame( range( 1001, 1050 ), $returned_ids );
+		$this->assertSame( 150, $result[35]['skipped'] );
+	}
+
+	public function test_no_early_stop_when_expected_ids_split_across_pages(): void {
+		// Worst-case sanity: if the API returns expected IDs late in
+		// pagination, the early-stop check shouldn't fire prematurely
+		// — we must keep walking until every expected ID is seen.
+		// Cap=50, declared=50 (no cap overage). Page 1 returns 100
+		// variations BUT only 30 of the 50 expected IDs. Page 2 must
+		// be fetched to collect the remaining 20.
+		$declared_ids = range( 1001, 1050 );
+
+		// Page 1: variations 1001..1030 (expected, 30 of 50) +
+		// 9001..9070 (unexpected, 70). Total 100 = per_page.
+		// Worst-case interleaving: the API surfaces unexpected IDs
+		// alongside expected ones, so we don't get to early-stop.
+		$page_1 = array();
+		for ( $i = 1; $i <= 30; $i++ ) {
+			$page_1[] = $this->variation( 1000 + $i, 35 );
+		}
+		for ( $i = 1; $i <= 70; $i++ ) {
+			$page_1[] = $this->variation( 9000 + $i, 35 );
+		}
+
+		// Page 2: variations 1031..1050 (expected, remaining 20).
+		$page_2 = array();
+		for ( $i = 31; $i <= 50; $i++ ) {
+			$page_2[] = $this->variation( 1000 + $i, 35 );
+		}
+
+		$this->canned_pages = array(
+			1 => $page_1,
+			2 => $page_2,
+		);
+
+		$result = $this->call_batched(
+			array( $this->variable_product( 35, $declared_ids ) )
+		);
+
+		// Two dispatches expected — page 1's count was per_page (100),
+		// not all expected IDs collected → keep walking. Page 2
+		// returns the remaining expected IDs AND is short-of-per_page
+		// (20 < 100), so the loop terminates after page 2.
+		$this->assertCount(
+			2,
+			$this->captured_dispatches,
+			'Loop must keep walking when not all expected IDs are seen by end of a page.'
+		);
+		$this->assertCount( 50, $result[35]['variations'] );
+		$this->assertSame( 0, $result[35]['skipped'] );
+	}
+
 	// ------------------------------------------------------------------
 	// Filter compatibility
 	// ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes #351. Builds on PR #352 (closes #349) — targets the compliance branch as base; will rebase onto `main` after #352 merges. Ships as part of 0.12.0.

Replace per-variation `rest_do_request` N+1 fan-out with a single (or few) batched dispatch via `GET /wc/store/v1/products?type=variation&parent=<csv>&per_page=100`. Two params combine to surface variations through the collection endpoint:

- `type=variation` flips the underlying WP_Query's `post_type` from `'product'` (the default) to `'product_variation'` (per WC `StoreApi/Utilities/ProductQuery.php::prepare_objects_query()`). Without it, the route's default post_type filter excludes every variation regardless of the parent filter.
- `parent=<csv>` populates `post_parent__in` via WC's `wp_parse_id_list` sanitizer (per the same file + `StoreApi/Routes/V1/Products.php` parameter schema).

**Note (history):** an earlier revision of this PR mistakenly used `parent_includes=<csv>` — a parameter name that doesn't exist in WC's Store API. That dispatch was silently ignored by WP_Query and would have returned random catalog products in production. Tests passed because the `rest_do_request` stub recognized our fictional param. Caught + fixed before merge ([2d8397f](https://github.com/Automattic/woocommerce-ai-storefront/commit/2d8397f)) — verified live against a wp-env install: `?parent_includes=35` returned 18 random products with `parent: 0`; the corrected `?type=variation&parent=35` returns 9 actual variations of product 35.

## Performance gains

| Scenario | Before | After (warm) | Saved (warm) | Saved (cold) |
|---|---:|---:|---:|---:|
| 20 products, 30% variable, avg 5 vars (~30 var fetches) | 30 dispatches | 1 dispatch | ~700ms | ~2s+ |
| 20 products, 60% variable, avg 8 vars (~96 var fetches) | 96 dispatches | 1 dispatch | ~2.4s | ~7s |
| 5-ID lookup, all variable, avg 5 vars (~25 var fetches) | 30 dispatches | 6 dispatches | ~600ms | ~1.8s+ |
| 1-ID lookup, 22 variations (Leather Shoes) | 23 dispatches | 2 dispatches | ~525ms | ~1.5s+ |

(Estimates based on `rest_do_request` cost ~25ms warm / ~75ms cold-cache. Real numbers in the PR comment after benchmarking.)

## Five commits

| Commit | Subject |
|---|---|
| 1 | `perf(ucp): add fetch_variations_batched() helper (no callers yet)` |
| 2 | `perf(ucp): wire fetch_variations_batched into catalog/search` |
| 3 | `perf(ucp): wire fetch_variations_batched into catalog/lookup` |
| 4 | `refactor(ucp): remove fetch_variations_for() (was N+1 per-variation dispatch)` |
| 5 | `docs(changelog): add #351 perf entry under [0.12.0]` |

## Design

- **Single batched call vs per-parent batching:** chose single call. `rest_do_request` is in-process — no network failure mode that justifies per-parent isolation. The single-call approach reduces 15 dispatches (typical 30%-variable page) to 1.
- **Failure policy:** WP_Error or HTTP >= 400 on page 1 degrades every variable parent to `variations: [], skipped: total_declared` (degenerate fallback); page-N failures (N > 1) keep prior data and let per-parent `skipped = declared - returned` math compute residue. Each parent missing variations emits one `partial_variants` warning.
- **`per_page=100` cap:** paginates via short-page sentinel. For the rare page where combined-variation count > 100 we walk pages until short-page; bounded at `ceil(total_vars / 100)`.
- **Early-stop optimization:** the page loop tracks expected variation IDs in a flat set and breaks once every expected ID has been collected — for a parent with 200 variations capped at 50, walks 1 page instead of 2.
- **`MAX_VARIATIONS_PER_PRODUCT` cap:** preserved per-parent. Cap-overage contributes to `skipped` count so agents see `partial_variants` warning when their product overflows.
- **Scope gate:** variations inherit visibility from parent. Per-variation `is_product_syndicated()` was redundant and is now omitted (parent gate runs upstream).
- **`wc_ai_storefront_ucp_store_api_args` filter:** applies to the batched dispatch with the same `/wc/store/v1/products` endpoint string. The four dispatch-shape keys (`type`, `parent`, `page`, `per_page`) are restored after the filter so callbacks can't break the post_type targeting or the page-walk invariant.

## Tests

- New `UcpVariationBatchTest` (21 tests) covering the helper directly via `ReflectionClass` invocation: empty/all-simple guards, single-/multi-parent dispatch (asserts both `type=variation` AND `parent=<csv>`), >100-variation pagination, partial response, WP_Error / HTTP >= 400 degradation, MAX cap overage, early-stop pagination, source-order preservation, all-malformed-pointer regression, stdClass normalization, filter compatibility, non-array filter return.
- `UcpCatalogSearchTest` and `UcpCatalogLookupTest` stubs extended to recognize `?type=variation&parent=<csv>` on the collection endpoint and bin variations by `parent` field. Both params load-bearing — without `type=variation`, real WC defaults to `post_type='product'` and returns zero variations, so the stubs reject the call too.
- Three lookup tests rewritten to match the new dispatch contract (assert observable shape rather than per-ID dispatch counts).
- 1300 PHP tests passing.

## Test plan

- [x] `composer test` (full suite) — 1300/1300 passing
- [x] `vendor/bin/phpcs` clean
- [x] `vendor/bin/phpstan analyse` clean
- [x] Live verified: `?type=variation&parent=35&per_page=100` returns 9 actual variations of product 35 (vs old `?parent_includes=35` returning 18 random products)
- [ ] CI green on push (PHP 8.1/8.2/8.3/8.4, JS, lint, build, schema)