### PR TITLE
ci: add release-drafter + CHANGELOG-check workflows

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,6 +1,15 @@
 name-template: 'v$RESOLVED_VERSION'
 tag-template: 'v$RESOLVED_VERSION'
 
+# Mark every drafted Release as a pre-release. We're pre-1.0 — every
+# 0.x release ships under the pre-release convention, and the GitHub
+# Release's UI badge ("Pre-release") signals that to consumers browsing
+# the releases page. Previously this flag lived in `release.yml` (when
+# release.yml owned Release creation); when ownership moved to
+# release-drafter in the workflow split, the flag came with it. Drop
+# once we ship 1.0.0.
+prerelease: true
+
 # How release-drafter computes the next version number.
 #
 # The resolver bumps from the **most recent published Release**:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -40,15 +40,31 @@ version-resolver:
   default: patch
 
 # Categories aligned with CHANGELOG.md section headings used in this
-# repo: Features / Fixes / Refactors / Docs / Chores (see existing
-# entries under [0.11.x] for the canonical heading set). One refinement:
-# we split out a `Performance` category in the draft because the
-# release notes can be more granular than the CHANGELOG, where perf
-# work usually rolls up into Features or Refactors. Each merged PR
-# lands under whichever category matches its labels. Every label that
-# triggers a version bump (above) MUST have a corresponding category
-# here — otherwise a PR could bump the version without appearing in
-# the draft notes.
+# repo: Features / Fixes / Refactors / Tests / Docs / Chores
+# (`grep -E '^### ' CHANGELOG.md | sort -u` for the canonical set).
+#
+# Two intentional differences between this draft taxonomy and the
+# CHANGELOG sections:
+#
+#   1. We split out a `Performance` category in the draft because
+#      release notes can be more granular than the CHANGELOG, where
+#      perf work usually rolls up into Features or Refactors.
+#
+#   2. We do NOT have a `Tests` category here even though
+#      CHANGELOG.md has `### Tests`. The repo's label palette
+#      (`gh label list`) doesn't include a `tests` label, so
+#      release-drafter has no signal to auto-categorize PRs as
+#      Tests. The `### Tests` section in CHANGELOG.md gets
+#      populated manually in the same release-prep commit that
+#      bumps the version, listing test additions made alongside
+#      the feature/fix work in the release window. If we ever add
+#      a `tests` label, add a `Tests` category here and align the
+#      version-resolver patch list above.
+#
+# Each merged PR lands under whichever category matches its labels.
+# Every label that triggers a version bump (above) MUST have a
+# corresponding category here — otherwise a PR could bump the version
+# without appearing in the draft notes.
 categories:
   - title: 'Features'
     labels:

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -30,12 +30,16 @@ version-resolver:
       - 'task'
   default: patch
 
-# Categories grouped to match the CHANGELOG.md convention used in
-# this repo (Features / Fixes / Performance / Refactors / Documentation /
-# Chores). Each merged PR lands under whichever category matches its
-# labels. Every label that triggers a version bump (above) MUST have
-# a corresponding category here — otherwise a PR could bump the
-# version without appearing in the draft notes.
+# Categories aligned with CHANGELOG.md section headings used in this
+# repo: Features / Fixes / Refactors / Docs / Chores (see existing
+# entries under [0.11.x] for the canonical heading set). One refinement:
+# we split out a `Performance` category in the draft because the
+# release notes can be more granular than the CHANGELOG, where perf
+# work usually rolls up into Features or Refactors. Each merged PR
+# lands under whichever category matches its labels. Every label that
+# triggers a version bump (above) MUST have a corresponding category
+# here — otherwise a PR could bump the version without appearing in
+# the draft notes.
 categories:
   - title: 'Features'
     labels:
@@ -52,7 +56,7 @@ categories:
       - 'refactor'
       - 'tech-debt'
       - 'architecture'
-  - title: 'Documentation'
+  - title: 'Docs'
     labels:
       - 'documentation'
   - title: 'Chores'

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -4,18 +4,17 @@ tag-template: 'v$RESOLVED_VERSION'
 # How release-drafter computes the next version number.
 #
 # The resolver bumps from the **most recent published Release**:
-#   - any PR with a `breaking` label  → MAJOR bump
 #   - any PR with `enhancement` / `feature` / `performance` → MINOR bump
 #   - everything else (`bug`, `documentation`, `refactor`, ...) → PATCH bump
 #
-# This is purely advisory — the draft Release shows the suggested
-# version, but the human cutting the release can override before
-# publishing. We're nowhere near 1.0 so MAJOR auto-bump is unlikely
-# to fire; even if it does, you can edit it to a minor on the way out.
+# We omit the `major` resolver entirely because the `breaking` label
+# doesn't exist in this repo's label palette today and GitHub does NOT
+# auto-create labels on demand. If a future PR really represents a
+# breaking change, the human cutting the release can override the
+# suggested version on the draft Release page before publishing.
+# (We're pre-1.0 anyway, so even breaking changes ship as minor bumps
+# under the pre-1.0 grace convention.)
 version-resolver:
-  major:
-    labels:
-      - 'breaking'
   minor:
     labels:
       - 'enhancement'
@@ -27,12 +26,16 @@ version-resolver:
       - 'documentation'
       - 'refactor'
       - 'tech-debt'
+      - 'architecture'
       - 'task'
   default: patch
 
 # Categories grouped to match the CHANGELOG.md convention used in
-# this repo (Features / Fixes / Performance / Refactors / Tests / Docs).
-# Each merged PR lands under whichever category matches its labels.
+# this repo (Features / Fixes / Performance / Refactors / Documentation /
+# Chores). Each merged PR lands under whichever category matches its
+# labels. Every label that triggers a version bump (above) MUST have
+# a corresponding category here — otherwise a PR could bump the
+# version without appearing in the draft notes.
 categories:
   - title: 'Features'
     labels:
@@ -52,6 +55,9 @@ categories:
   - title: 'Documentation'
     labels:
       - 'documentation'
+  - title: 'Chores'
+    labels:
+      - 'task'
 
 # Hide PRs labelled `automated` from the draft (e.g. dependabot bumps,
 # bot-opened release PRs). Same for `duplicate`/`invalid`/`wontfix`.

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -1,0 +1,75 @@
+name-template: 'v$RESOLVED_VERSION'
+tag-template: 'v$RESOLVED_VERSION'
+
+# How release-drafter computes the next version number.
+#
+# The resolver bumps from the **most recent published Release**:
+#   - any PR with a `breaking` label  → MAJOR bump
+#   - any PR with `enhancement` / `feature` / `performance` → MINOR bump
+#   - everything else (`bug`, `documentation`, `refactor`, ...) → PATCH bump
+#
+# This is purely advisory — the draft Release shows the suggested
+# version, but the human cutting the release can override before
+# publishing. We're nowhere near 1.0 so MAJOR auto-bump is unlikely
+# to fire; even if it does, you can edit it to a minor on the way out.
+version-resolver:
+  major:
+    labels:
+      - 'breaking'
+  minor:
+    labels:
+      - 'enhancement'
+      - 'feature'
+      - 'performance'
+  patch:
+    labels:
+      - 'bug'
+      - 'documentation'
+      - 'refactor'
+      - 'tech-debt'
+      - 'task'
+  default: patch
+
+# Categories grouped to match the CHANGELOG.md convention used in
+# this repo (Features / Fixes / Performance / Refactors / Tests / Docs).
+# Each merged PR lands under whichever category matches its labels.
+categories:
+  - title: 'Features'
+    labels:
+      - 'enhancement'
+      - 'feature'
+  - title: 'Fixes'
+    labels:
+      - 'bug'
+  - title: 'Performance'
+    labels:
+      - 'performance'
+  - title: 'Refactors'
+    labels:
+      - 'refactor'
+      - 'tech-debt'
+      - 'architecture'
+  - title: 'Documentation'
+    labels:
+      - 'documentation'
+
+# Hide PRs labelled `automated` from the draft (e.g. dependabot bumps,
+# bot-opened release PRs). Same for `duplicate`/`invalid`/`wontfix`.
+exclude-labels:
+  - 'automated'
+  - 'duplicate'
+  - 'invalid'
+  - 'wontfix'
+
+# Per-PR template line. `$AUTHOR` is auto-substituted; we omit the
+# author for first-party PRs by post-filtering with autolabeler if
+# we ever want to. Keep it simple for now.
+change-template: '- $TITLE (#$NUMBER)'
+change-title-escapes: '\<*_&'
+
+template: |
+  ## What's changed
+
+  $CHANGES
+
+  **Full diff**: https://github.com/$OWNER/$REPOSITORY/compare/$PREVIOUS_TAG...v$RESOLVED_VERSION

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -64,13 +64,16 @@ jobs:
         id: path_exempt
         if: steps.skip_label.outputs.skip == 'false'
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # `BASE_REF` and `HEAD_SHA` flow through env vars into git
-          # commands as quoted args — git rejects malformed refs, so
-          # injection isn't possible here.
-          changed=$(git diff --name-only "origin/$BASE_REF...$HEAD_SHA")
+          # Diff by SHAs (not branch refs). `actions/checkout` on
+          # `pull_request` events doesn't guarantee `origin/<base>` is
+          # populated locally, but `base.sha` and `head.sha` always
+          # are. Both are server-issued git OIDs; they flow through
+          # env vars and quoted shell expansions, so injection isn't
+          # possible.
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
           # If every changed file is in an exempt directory, skip the
           # check entirely. Exempt prefixes (narrow): `.github/`,
           # `docs/`, `.planning/`. `tests/` and `bin/` deliberately
@@ -86,7 +89,7 @@ jobs:
       - name: Verify CHANGELOG entry under [Unreleased]
         if: steps.skip_label.outputs.skip == 'false' && steps.path_exempt.outputs.exempt == 'false'
         env:
-          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           # Walk the CHANGELOG.md diff and count `+- ` lines that fall
@@ -94,25 +97,24 @@ jobs:
           # added to a published `## [0.x.y]` section does NOT satisfy
           # this check.
           #
+          # `-U9999` provides effectively-unlimited context lines so
+          # the diff hunks always include the surrounding `## [...]`
+          # section headers. Without this, a PR adding a bullet under
+          # `### Fixes` deep in the Unreleased section might emit a
+          # hunk whose nearest visible header is `### Fixes` — the
+          # awk state machine would never see the `## [Unreleased]`
+          # header, miss-classify the hunk, and reject the bullet.
+          # CHANGELOG.md is small enough (a few hundred lines) that
+          # full-file context is cheap.
+          #
           # State machine:
           #   - We're inside a hunk when a line starts with `@@`.
           #   - Within a hunk, lines starting with `+` (added) or ` `
           #     (context) belong to the head version; lines starting
           #     with `-` belong to the base version.
-          #   - The "current section" is whichever was last seen as a
-          #     `## [...]` header in either the added or context lines.
-          #     Diff hunks always include enough context that the
-          #     section header is visible above the change OR the
-          #     change itself includes the header.
-          #   - When the current section is `## [Unreleased]`, an
-          #     added bullet (`+- `) counts. Anywhere else, it doesn't.
-          #
-          # Edge case: a PR that ADDS the `## [Unreleased]` header
-          # itself (somehow missing it) plus bullets under it — the
-          # awk script handles this (the header line `+## [Unreleased]`
-          # flips state to in_unreleased before the subsequent bullet
-          # lines are evaluated).
-          diff_output=$(git diff "origin/$BASE_REF...$HEAD_SHA" -- CHANGELOG.md)
+          #   - When the most recent `## [...]` header is `Unreleased`,
+          #     an added bullet (`+- `) counts. Anywhere else, it doesn't.
+          diff_output=$(git diff -U9999 "$BASE_SHA...$HEAD_SHA" -- CHANGELOG.md)
           if [ -z "$diff_output" ]; then
             echo "::error::This PR touches non-exempt code paths but does not modify CHANGELOG.md."
             echo "::error::Add a bullet under '## [Unreleased]' describing the change, or apply the 'skip-changelog' label."

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -121,12 +121,18 @@ jobs:
             exit 1
           fi
 
+          # Bullet matcher: `[[:space:]]*-[[:space:]]` accepts both
+          # unindented (`+- foo`) and indented (`+  - foo`) bullets,
+          # AND any whitespace character (space OR tab) after the dash.
+          # The earlier `[[:space:]]*- ` form required a literal space
+          # after the dash; tab-indented bullets that opted for tab
+          # after the dash too would have escaped detection.
           unreleased_bullet=$(printf '%s\n' "$diff_output" | awk '
             /^@@/                    { in_hunk = 1; next }
             in_hunk == 0             { next }
             /^[+ ]## \[Unreleased\]/ { in_unreleased = 1; next }
             /^[+ ]## \[/             { in_unreleased = 0; next }
-            in_unreleased && /^\+[[:space:]]*- / { print; found = 1 }
+            in_unreleased && /^\+[[:space:]]*-[[:space:]]/ { print; found = 1 }
             END                      { exit (found ? 0 : 1) }
           ' || true)
 

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -14,6 +14,15 @@ name: CHANGELOG check
 #     the "Tests" CHANGELOG category, and bin/ scripts have shipped
 #     in past CHANGELOGs (e.g. bin/cleanup-test-fixtures.sh).
 #
+# Release-prep PRs MUST use `skip-changelog`. The version-bump PR
+# moves bullets out of `## [Unreleased]` into a new `## [X.Y.Z]`
+# section — there's no NET-NEW bullet under `[Unreleased]` to count,
+# so this check would otherwise fail and block release. The smarter
+# alternative (detect "Unreleased → versioned" moves and accept them)
+# would add awk complexity that's hard to keep correct under multi-
+# bullet rearrangements; using the existing label is simpler and
+# only costs maintainers one extra step at release-cut time.
+#
 # Security note: all user-controllable values (PR labels, file paths)
 # flow through `env:` into shell-quoted variable expansions; no
 # direct interpolation into `run:` script bodies. Workflow-injection

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,0 +1,108 @@
+name: CHANGELOG check
+
+# Fails any PR that touches code without adding a line under the
+# `## [Unreleased]` section of CHANGELOG.md. Forces every substantive
+# PR to declare what it's contributing to the next release, which
+# pairs with release-drafter (auto-generated draft from PR labels)
+# to keep release notes accurate.
+#
+# Bypass options:
+#   - Apply the `skip-changelog` label to the PR.
+#   - PRs that touch only `.github/`, `docs/`, `tests/`, or `bin/`
+#     are exempt automatically.
+#
+# Security note: all user-controllable values (PR labels, file paths)
+# flow through `env:` into shell-quoted variable expansions; no
+# direct interpolation into `run:` script bodies. Workflow-injection
+# guidance applies to `${{ ... }}` inside `run:` text — none here.
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - labeled
+      - unlabeled
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  changelog-required:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check skip-changelog label
+        id: skip_label
+        env:
+          PR_LABELS: ${{ toJSON(github.event.pull_request.labels.*.name) }}
+        run: |
+          # Treat the JSON array as untrusted input — pass through
+          # an env var, parse with jq, never expand label content
+          # into the shell.
+          if printf '%s' "$PR_LABELS" | jq -e 'any(. == "skip-changelog")' > /dev/null; then
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Skip — label set
+        if: steps.skip_label.outputs.skip == 'true'
+        run: echo "::notice::skip-changelog label set; bypassing CHANGELOG check."
+
+      - name: Checkout
+        if: steps.skip_label.outputs.skip == 'false'
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine if PR is exempt by path
+        id: path_exempt
+        if: steps.skip_label.outputs.skip == 'false'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # `BASE_REF` and `HEAD_SHA` are user-influenceable but flow
+          # through env vars into git commands as quoted args — git
+          # rejects malformed refs, so injection isn't possible here.
+          changed=$(git diff --name-only "origin/$BASE_REF...$HEAD_SHA")
+          # If every changed file is in an exempt directory, skip the check.
+          # Exempt prefixes: .github/, docs/, tests/, bin/, .planning/
+          non_exempt=$(printf '%s\n' "$changed" | grep -Ev '^(\.github/|docs/|tests/|bin/|\.planning/)' || true)
+          if [ -z "$non_exempt" ]; then
+            echo "exempt=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::All changed files are in exempt paths; skipping CHANGELOG check."
+          else
+            echo "exempt=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify CHANGELOG entry under [Unreleased]
+        if: steps.skip_label.outputs.skip == 'false' && steps.path_exempt.outputs.exempt == 'false'
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.ref }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          # Diff CHANGELOG.md and require at least one added line that
+          # falls within the [Unreleased] section. We check for an
+          # added bullet (line starting with `- `) anywhere in the
+          # CHANGELOG diff, then verify the [Unreleased] header is
+          # present in the head version (it should always be).
+          diff_output=$(git diff "origin/$BASE_REF...$HEAD_SHA" -- CHANGELOG.md)
+          if [ -z "$diff_output" ]; then
+            echo "::error::This PR touches non-exempt code paths but does not modify CHANGELOG.md."
+            echo "::error::Add a bullet under '## [Unreleased]' describing the change, or apply the 'skip-changelog' label."
+            exit 1
+          fi
+          # Count new bullet lines in the diff. release-drafter will
+          # auto-populate from PR labels, but the human-curated
+          # CHANGELOG line is what ships in the Stable Tag readme.txt
+          # release notes — it must be present.
+          added_bullets=$(printf '%s\n' "$diff_output" | grep -E '^\+\s*- ' || true)
+          if [ -z "$added_bullets" ]; then
+            echo "::error::CHANGELOG.md changed but no new bullet (line starting with '- ') was added."
+            echo "::error::Add a bullet under '## [Unreleased]' describing the change."
+            exit 1
+          fi
+          echo "::notice::CHANGELOG entry found."

--- a/.github/workflows/changelog-check.yml
+++ b/.github/workflows/changelog-check.yml
@@ -1,6 +1,6 @@
 name: CHANGELOG check
 
-# Fails any PR that touches code without adding a line under the
+# Fails any PR that touches code without adding a bullet UNDER the
 # `## [Unreleased]` section of CHANGELOG.md. Forces every substantive
 # PR to declare what it's contributing to the next release, which
 # pairs with release-drafter (auto-generated draft from PR labels)
@@ -8,8 +8,11 @@ name: CHANGELOG check
 #
 # Bypass options:
 #   - Apply the `skip-changelog` label to the PR.
-#   - PRs that touch only `.github/`, `docs/`, `tests/`, or `bin/`
-#     are exempt automatically.
+#   - PRs that touch only `.github/` or `docs/` (or `.planning/`,
+#     which is gitignored — defensive) are exempt automatically.
+#     `tests/` and `bin/` are NOT exempt: tests-only PRs ship under
+#     the "Tests" CHANGELOG category, and bin/ scripts have shipped
+#     in past CHANGELOGs (e.g. bin/cleanup-test-fixtures.sh).
 #
 # Security note: all user-controllable values (PR labels, file paths)
 # flow through `env:` into shell-quoted variable expansions; no
@@ -64,13 +67,15 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # `BASE_REF` and `HEAD_SHA` are user-influenceable but flow
-          # through env vars into git commands as quoted args — git
-          # rejects malformed refs, so injection isn't possible here.
+          # `BASE_REF` and `HEAD_SHA` flow through env vars into git
+          # commands as quoted args — git rejects malformed refs, so
+          # injection isn't possible here.
           changed=$(git diff --name-only "origin/$BASE_REF...$HEAD_SHA")
-          # If every changed file is in an exempt directory, skip the check.
-          # Exempt prefixes: .github/, docs/, tests/, bin/, .planning/
-          non_exempt=$(printf '%s\n' "$changed" | grep -Ev '^(\.github/|docs/|tests/|bin/|\.planning/)' || true)
+          # If every changed file is in an exempt directory, skip the
+          # check entirely. Exempt prefixes (narrow): `.github/`,
+          # `docs/`, `.planning/`. `tests/` and `bin/` deliberately
+          # NOT exempt — both can affect release notes.
+          non_exempt=$(printf '%s\n' "$changed" | grep -Ev '^(\.github/|docs/|\.planning/)' || true)
           if [ -z "$non_exempt" ]; then
             echo "exempt=true" >> "$GITHUB_OUTPUT"
             echo "::notice::All changed files are in exempt paths; skipping CHANGELOG check."
@@ -84,25 +89,49 @@ jobs:
           BASE_REF: ${{ github.event.pull_request.base.ref }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          # Diff CHANGELOG.md and require at least one added line that
-          # falls within the [Unreleased] section. We check for an
-          # added bullet (line starting with `- `) anywhere in the
-          # CHANGELOG diff, then verify the [Unreleased] header is
-          # present in the head version (it should always be).
+          # Walk the CHANGELOG.md diff and count `+- ` lines that fall
+          # WITHIN the `## [Unreleased]` section. A bullet retroactively
+          # added to a published `## [0.x.y]` section does NOT satisfy
+          # this check.
+          #
+          # State machine:
+          #   - We're inside a hunk when a line starts with `@@`.
+          #   - Within a hunk, lines starting with `+` (added) or ` `
+          #     (context) belong to the head version; lines starting
+          #     with `-` belong to the base version.
+          #   - The "current section" is whichever was last seen as a
+          #     `## [...]` header in either the added or context lines.
+          #     Diff hunks always include enough context that the
+          #     section header is visible above the change OR the
+          #     change itself includes the header.
+          #   - When the current section is `## [Unreleased]`, an
+          #     added bullet (`+- `) counts. Anywhere else, it doesn't.
+          #
+          # Edge case: a PR that ADDS the `## [Unreleased]` header
+          # itself (somehow missing it) plus bullets under it — the
+          # awk script handles this (the header line `+## [Unreleased]`
+          # flips state to in_unreleased before the subsequent bullet
+          # lines are evaluated).
           diff_output=$(git diff "origin/$BASE_REF...$HEAD_SHA" -- CHANGELOG.md)
           if [ -z "$diff_output" ]; then
             echo "::error::This PR touches non-exempt code paths but does not modify CHANGELOG.md."
             echo "::error::Add a bullet under '## [Unreleased]' describing the change, or apply the 'skip-changelog' label."
             exit 1
           fi
-          # Count new bullet lines in the diff. release-drafter will
-          # auto-populate from PR labels, but the human-curated
-          # CHANGELOG line is what ships in the Stable Tag readme.txt
-          # release notes — it must be present.
-          added_bullets=$(printf '%s\n' "$diff_output" | grep -E '^\+\s*- ' || true)
-          if [ -z "$added_bullets" ]; then
-            echo "::error::CHANGELOG.md changed but no new bullet (line starting with '- ') was added."
-            echo "::error::Add a bullet under '## [Unreleased]' describing the change."
+
+          unreleased_bullet=$(printf '%s\n' "$diff_output" | awk '
+            /^@@/                    { in_hunk = 1; next }
+            in_hunk == 0             { next }
+            /^[+ ]## \[Unreleased\]/ { in_unreleased = 1; next }
+            /^[+ ]## \[/             { in_unreleased = 0; next }
+            in_unreleased && /^\+[[:space:]]*- / { print; found = 1 }
+            END                      { exit (found ? 0 : 1) }
+          ' || true)
+
+          if [ -z "$unreleased_bullet" ]; then
+            echo "::error::CHANGELOG.md was modified, but no new bullet was added under '## [Unreleased]'."
+            echo "::error::Bullets retroactively added to published versioned sections do not satisfy this check."
+            echo "::error::Add a bullet under '## [Unreleased]' describing the change, or apply the 'skip-changelog' label."
             exit 1
           fi
-          echo "::notice::CHANGELOG entry found."
+          echo "::notice::CHANGELOG entry under [Unreleased] found."

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,0 +1,42 @@
+name: Release drafter
+
+# Maintains a single draft GitHub Release that auto-updates as PRs
+# merge to main. Each merged PR is categorized into the draft based
+# on its labels (see `.github/release-drafter.yml`).
+#
+# When you're ready to ship, go to the repo Releases page, review
+# the draft, edit if needed, and click "Publish release." That step
+# also creates the git tag — no separate `git tag` push required.
+#
+# This workflow does NOT bump version constants, update CHANGELOG.md,
+# or publish on its own. Those remain manual steps in the same release
+# commit that bumps `WC_AI_STOREFRONT_VERSION` etc.
+#
+# Security note: this workflow contains no `run:` steps and no use of
+# untrusted user-controlled inputs (PR titles, issue bodies, commit
+# messages). The only token reference is the server-issued
+# `secrets.GITHUB_TOKEN`. Workflow-injection guidance at
+# https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
+# applies to `run:` blocks; nothing here is at risk.
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  update_release_draft:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: release-drafter/release-drafter@v6
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,13 +4,25 @@ name: Release drafter
 # merge to main. Each merged PR is categorized into the draft based
 # on its labels (see `.github/release-drafter.yml`).
 #
-# When you're ready to ship, go to the repo Releases page, review
-# the draft, edit if needed, and click "Publish release." That step
-# also creates the git tag — no separate `git tag` push required.
+# Release responsibility split (one source of truth per field):
 #
-# This workflow does NOT bump version constants, update CHANGELOG.md,
-# or publish on its own. Those remain manual steps in the same release
-# commit that bumps `WC_AI_STOREFRONT_VERSION` etc.
+#   release-drafter (this workflow):
+#     - owns the Release's draft/published state
+#     - owns the body (categorized changelog from PR labels)
+#     - owns the version number and prerelease flag
+#     - never publishes on its own — a human clicks Publish on the
+#       Releases page, which also creates the git tag
+#
+#   release.yml (tag-push):
+#     - owns the zip artifact (built + version-verified + uploaded)
+#     - explicitly does NOT pass `draft`, `body`, `prerelease`, or
+#       `generate_release_notes` to softprops/action-gh-release, so it
+#       attaches the asset to the existing Release without flipping it
+#       back to draft or overwriting notes.
+#
+# This workflow does NOT bump version constants or update CHANGELOG.md
+# on its own. Those remain manual steps in the same release commit
+# that bumps `WC_AI_STOREFRONT_VERSION` etc.
 #
 # Trigger: `push: main` only. The official action README warns that
 # also triggering on `pull_request` events re-renders the draft for

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,10 +12,14 @@ name: Release drafter
 # or publish on its own. Those remain manual steps in the same release
 # commit that bumps `WC_AI_STOREFRONT_VERSION` etc.
 #
+# Trigger: `push: main` only. The official action README warns that
+# also triggering on `pull_request` events re-renders the draft for
+# unmerged PRs — wasted Actions minutes for no gain (the draft updates
+# when merges land, not when PRs change).
+#
 # Security note: this workflow contains no `run:` steps and no use of
-# untrusted user-controlled inputs (PR titles, issue bodies, commit
-# messages). The only token reference is the server-issued
-# `secrets.GITHUB_TOKEN`. Workflow-injection guidance at
+# untrusted user-controlled inputs. The only token reference is the
+# server-issued `secrets.GITHUB_TOKEN`. Workflow-injection guidance at
 # https://github.blog/security/vulnerability-research/how-to-catch-github-actions-workflow-injections-before-attackers-do/
 # applies to `run:` blocks; nothing here is at risk.
 
@@ -23,15 +27,10 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
 
 permissions:
-  contents: write
-  pull-requests: write
+  contents: write       # create/update the draft Release
+  pull-requests: read   # read merged PR metadata to assemble the draft
 
 jobs:
   update_release_draft:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,10 +144,20 @@ jobs:
           unzip -l "${ZIP_NAME}" | head -30
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
 
-      - name: Create GitHub Release
+      # Attach the built zip to the Release that release-drafter has
+      # already prepared and the human just published on the Releases
+      # page (which is what created this tag).
+      #
+      # We deliberately omit `generate_release_notes`, `body`, `draft`,
+      # and `prerelease` here. release-drafter (release-drafter.yml)
+      # owns those fields; passing them again would either overwrite
+      # the categorized notes already in the Release body or flip the
+      # just-published Release back to draft — both have happened in
+      # other repos that ran the two flows in series.
+      #
+      # softprops/action-gh-release@v2 finds the existing Release by
+      # tag and uploads `files:` to it without touching unset fields.
+      - name: Upload release artifact
         uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.ZIP_NAME }}
-          generate_release_notes: true
-          draft: true  # Start as draft so human can review before publishing.
-          prerelease: true  # 0.x line ships as pre-release until 1.0.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -144,6 +144,32 @@ jobs:
           unzip -l "${ZIP_NAME}" | head -30
           echo "ZIP_NAME=${ZIP_NAME}" >> "$GITHUB_ENV"
 
+      # Preflight: a GitHub Release must already exist for this tag
+      # before we run the upload step.
+      #
+      # Why: softprops/action-gh-release@v2 will silently CREATE a
+      # fresh Release if none exists at the tag — and because we
+      # intentionally omit `body`/`draft`/`prerelease` (release-drafter
+      # owns those), an auto-created Release would land published with
+      # an empty body and no prerelease flag. That's exactly the
+      # mismatch we just fixed in the opposite direction (release.yml
+      # was creating duplicate/conflicting Releases). Failing fast here
+      # forces the human to publish the release-drafter draft instead.
+      #
+      # The tag flows in via `$TAG` (set in env: at the job level),
+      # never expression-interpolated into shell text.
+      - name: Verify Release exists for tag
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          if ! gh release view "$TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "::error::No GitHub Release exists for tag $TAG."
+            echo "::error::Don't push tags directly — publish the release-drafter draft on the Releases page, which creates the tag with the curated notes + prerelease flag intact."
+            echo "::error::If you really need a release for a manually-pushed tag, create it through the UI first, then re-run this workflow."
+            exit 1
+          fi
+          echo "::notice::Release found for tag $TAG; proceeding to upload artifact."
+
       # Attach the built zip to the Release that release-drafter has
       # already prepared and the human just published on the Releases
       # page (which is what created this tag).
@@ -157,6 +183,8 @@ jobs:
       #
       # softprops/action-gh-release@v2 finds the existing Release by
       # tag and uploads `files:` to it without touching unset fields.
+      # The preflight step above guarantees the Release exists, so the
+      # action's "create-if-missing" path is never reached.
       - name: Upload release artifact
         uses: softprops/action-gh-release@v2
         with:


### PR DESCRIPTION
## Summary

Two CI additions to keep PR-to-release association tight without forcing a release-per-PR cadence.

**Recommended to land AFTER 0.12.0 ships** (PRs #352, #353, #354) so the first release-drafter run reflects the post-0.12.0 baseline cleanly.

## What's added

### `release-drafter`

Maintains a single draft GitHub Release on the Releases page that auto-updates as PRs merge to `main`. Each merged PR is categorized into the draft based on its labels (Features / Fixes / Performance / Refactors / Documentation), and the draft suggests a next-version bump from the same labels.

When ready to ship, **the workflow does NOT auto-publish** — a human opens the draft, reviews/edits, and clicks "Publish release." That step also creates the git tag (matches the existing `release.yml` trigger on `v*`). Cadence stays manual: cut releases whenever there's enough merged to warrant one.

### CHANGELOG check

Fails any PR that touches non-exempt code paths (anything outside `.github/`, `docs/`, or `.planning/`) without adding a bullet under `## [Unreleased]` in `CHANGELOG.md`. `tests/` and `bin/` are intentionally NOT exempt — tests-only PRs ship under the "Tests" CHANGELOG category, and `bin/` scripts have shipped in past CHANGELOGs. Bypass via the `skip-changelog` label.

Pairs with release-drafter: drafter assembles auto-generated release notes from PR titles/labels; the human-curated CHANGELOG bullet is what ships in `readme.txt` Stable Tag release notes (project convention).

## Workflow behavior at release time

1. Land PRs against `main` with `[Unreleased]` CHANGELOG bullets (CI-enforced).
2. Drafter accumulates them into a draft Release as they merge.
3. When ready, in **one commit**: bump version constants + move `[Unreleased]` → dated section in CHANGELOG.md.
4. Open the draft Release, review, edit if needed, click "Publish release."
5. Tag is auto-created from the publish step → `release.yml` builds the dist zip → done.

No more cascading version bumps when 3 PRs are in flight (the situation we just navigated with #352/#353/#354).

## Security note

Both workflows handle user-influenceable inputs (PR labels, base ref, head SHA) through `env:` variables and quoted shell expansions — never direct `${{ ... }}` interpolation inside `run:` script bodies, per GitHub Actions injection guidance.

## Test plan

- [ ] CI green on this PR (note: CHANGELOG-check would fail this PR if applied — but it's not applied to its own introduction since exempt paths cover the entire diff: `.github/release-drafter.yml`, `.github/workflows/*.yml` are under `.github/` exempt prefix)
- [ ] After merge, observe a draft Release auto-appear on the Releases page
- [ ] Apply a label like `enhancement` to a future PR and confirm it categorizes correctly in the draft

🤖 Generated with [Claude Code](https://claude.com/claude-code)
