### PR TITLE
fix(#373): guard unpurchasable variations on UCP + JSON-LD surfaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ### Features
 ### Fixes
+
+- **UCP / JSON-LD: unpurchasable variations no longer leak to agents.** Closes #373. A misconfigured variation (e.g. missing a price) was emitted with a usable-looking variant ID and a checkout URL that WC then refused at cart-add. Three coordinated guards:
+  - **UCP catalog/search/lookup:** `fetch_variations_for()` now drops variations where `is_purchasable: false` before they reach the product translator. If every variation of a variable parent is unpurchasable, falls through to the existing `synthesize_default()` placeholder so the schema's `variants: minItems: 1` constraint still holds.
+  - **UCP /checkout-sessions:** a stale or guessed unpurchasable variant ID is rejected with the new `item_unpurchasable` error code (distinct from `out_of_stock`) so agents can tell "no inventory" apart from "merchant misconfiguration / not for sale". Mixed carts retain purchasable line items while excluding unpurchasable ones from `continue_url`, `line_items[]`, and `totals`.
+  - **JSON-LD:** unpurchasable variant entries under `hasVariant[]` emit descriptive fields (`@id`, `name`, `sku`, `image`, `offers[].price`) but suppress `BuyAction` and `Offer.checkoutPageURLTemplate`. Same treatment for the parent shape on an unpurchasable simple/variable parent.
+
 ### Refactors
 ### Tests
 ### Docs

--- a/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
+++ b/includes/ai-storefront/class-wc-ai-storefront-jsonld.php
@@ -136,9 +136,19 @@ class WC_AI_Storefront_JsonLd {
 			return $markup;
 		}
 
-		$this->add_buy_action( $markup, $product );
-
-		$this->add_checkout_page_url_template( $markup, $product );
+		// Skip checkout action URLs when the product itself is not
+		// purchasable (no price, draft, catalog-hidden). The descriptive
+		// product entity still emits — crawlers see the product exists,
+		// just without a monetary action that would 4xx at checkout. For
+		// variable parents, `maybe_convert_to_product_group()` later
+		// overrides this by converting to ProductGroup and emitting
+		// per-variant entries under `hasVariant`, each gated
+		// independently (see `build_variant_entry`). (#373)
+		$parent_purchasable = ! method_exists( $product, 'is_purchasable' ) || $product->is_purchasable();
+		if ( $parent_purchasable ) {
+			$this->add_buy_action( $markup, $product );
+			$this->add_checkout_page_url_template( $markup, $product );
+		}
 
 		$this->add_inventory_level( $markup, $product );
 
@@ -1132,8 +1142,18 @@ class WC_AI_Storefront_JsonLd {
 		// BuyAction + checkoutPageURLTemplate both use the VARIATION ID
 		// (not the parent product ID) so the URL drops the buyer on
 		// checkout with the specific SKU.
-		$this->add_buy_action( $entry, $variation );
-		$this->add_checkout_page_url_template( $entry, $variation );
+		//
+		// Skip BOTH when the variation is not purchasable (e.g. no
+		// price set, draft, catalog-hidden). Emitting a Shareable
+		// Checkout URL for an unpurchasable SKU hands SEO crawlers and
+		// non-UCP agents a URL that WC will refuse at checkout. The
+		// descriptive variant entry (@id, name, sku, image) still
+		// emits — agents see the variant exists, just without a
+		// monetary action attached. (#373)
+		if ( ! method_exists( $variation, 'is_purchasable' ) || $variation->is_purchasable() ) {
+			$this->add_buy_action( $entry, $variation );
+			$this->add_checkout_page_url_template( $entry, $variation );
+		}
 
 		return $entry;
 	}

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-error-codes.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-error-codes.php
@@ -79,6 +79,14 @@ final class WC_AI_Storefront_UCP_Error_Codes {
 	const OUT_OF_STOCK = 'out_of_stock';
 
 	/**
+	 * A requested product is not purchasable (e.g. missing price,
+	 * misconfigured variation, hidden from catalog). Distinct from
+	 * `OUT_OF_STOCK`: the product may have inventory but WC refuses
+	 * to add it to a cart. (#373)
+	 */
+	const ITEM_UNPURCHASABLE = 'item_unpurchasable';
+
+	/**
 	 * Duplicate line items targeting the same product were merged.
 	 */
 	const MERGED_DUPLICATE_ITEMS = 'merged_duplicate_items';

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3697,6 +3697,20 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			}
 		}
 
+		// Compute `$skipped` BEFORE the purchasability filter (#373
+		// review). `$skipped` flows downstream into the
+		// `partial_variants` warning, which means "variants weren't
+		// fully retrievable — distrust price_range". That signal is
+		// for cap-truncation, scope-filtering, fetch failures, and
+		// malformed refs — situations where the agent should reason
+		// about an incomplete view of the variants set. Unpurchasable
+		// variations are an INTENTIONAL exclusion (merchant
+		// misconfiguration → safe to hide), not a retrieval gap, so
+		// they must not contribute to `partial_variants`. Tracked
+		// separately in `$unpurchasable_dropped` for the debug log
+		// only.
+		$skipped = $total_declared - count( $variations );
+
 		// Drop variations that WC reports as not purchasable. A no-price
 		// or misconfigured variation still has `is_in_stock = true` in
 		// WC but `is_purchasable = false` — handing its ID to an agent
@@ -3709,7 +3723,8 @@ class WC_AI_Storefront_UCP_REST_Controller {
 		// synthesize_default fallback, surfacing the parent shape
 		// (typically also unpurchasable) which downstream code already
 		// handles as a degraded entry. (#373)
-		$variations = array_values(
+		$pre_filter_count      = count( $variations );
+		$variations            = array_values(
 			array_filter(
 				$variations,
 				static function ( $v ): bool {
@@ -3717,19 +3732,16 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				}
 			)
 		);
+		$unpurchasable_dropped = $pre_filter_count - count( $variations );
 
-		// Skipped = everything the product declared that didn't make it
-		// into $variations. Includes cap-truncated + scope-filtered +
-		// fetch-failed + malformed-ref + unpurchasable entries.
-		$skipped = $total_declared - count( $variations );
-
-		if ( $skipped > 0 ) {
+		if ( $skipped > 0 || $unpurchasable_dropped > 0 ) {
 			WC_AI_Storefront_Logger::debug(
 				sprintf(
-					'UCP fetch_variations_for(%d): skipped %d of %d declared variations',
+					'UCP fetch_variations_for(%d): skipped %d of %d declared variations (fetch/cap/scope) + filtered %d unpurchasable',
 					(int) ( $wc_product['id'] ?? 0 ),
 					$skipped,
-					$total_declared
+					$total_declared,
+					$unpurchasable_dropped
 				)
 			);
 		}

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php
@@ -3697,9 +3697,30 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			}
 		}
 
+		// Drop variations that WC reports as not purchasable. A no-price
+		// or misconfigured variation still has `is_in_stock = true` in
+		// WC but `is_purchasable = false` — handing its ID to an agent
+		// would lead to a `/checkout-link/?products=<id>:1` URL that WC
+		// refuses to add to cart. Filter upstream of `extract_variants()`
+		// so all three downstream surfaces (catalog response, JSON-LD
+		// `hasVariant`, checkout-sessions `continue_url`) see the same
+		// purchasable-only set. When every variation is unpurchasable,
+		// the resulting empty array trips `extract_variants()`'s
+		// synthesize_default fallback, surfacing the parent shape
+		// (typically also unpurchasable) which downstream code already
+		// handles as a degraded entry. (#373)
+		$variations = array_values(
+			array_filter(
+				$variations,
+				static function ( $v ): bool {
+					return ! isset( $v['is_purchasable'] ) || true === $v['is_purchasable'];
+				}
+			)
+		);
+
 		// Skipped = everything the product declared that didn't make it
 		// into $variations. Includes cap-truncated + scope-filtered +
-		// fetch-failed + malformed-ref entries.
+		// fetch-failed + malformed-ref + unpurchasable entries.
 		$skipped = $total_declared - count( $variations );
 
 		if ( $skipped > 0 ) {
@@ -5194,6 +5215,22 @@ class WC_AI_Storefront_UCP_REST_Controller {
 			);
 		}
 
+		// Unpurchasable rejected outright (#373). `is_purchasable` is
+		// independent from `is_in_stock`: a variation with stock but
+		// no price reads `is_in_stock=true, is_purchasable=false`. The
+		// translator filter at `fetch_variations_for()` already drops
+		// these from catalog/JSON-LD responses, but a stale or guessed
+		// variant ID could still arrive here. Reject early with a
+		// distinct code so the agent can distinguish "no inventory"
+		// from "merchant misconfiguration / not for sale".
+		$purchasable = ! isset( $wc_product['is_purchasable'] ) || true === $wc_product['is_purchasable'];
+		if ( ! $purchasable ) {
+			return array(
+				'processed' => null,
+				'messages'  => array( self::checkout_error_message( WC_AI_Storefront_UCP_Error_Codes::ITEM_UNPURCHASABLE, $path . '.item.id' ) ),
+			);
+		}
+
 		$unit_price_minor = (int) ( $wc_product['prices']['price'] ?? 0 );
 
 		// --- Price-drift warning (agent opt-in) ---
@@ -5990,6 +6027,8 @@ class WC_AI_Storefront_UCP_REST_Controller {
 				return __( 'Product type cannot be added via the Shareable Checkout URL; link to the product page directly.', 'woocommerce-ai-storefront' );
 			case WC_AI_Storefront_UCP_Error_Codes::OUT_OF_STOCK:
 				return __( 'Product is out of stock.', 'woocommerce-ai-storefront' );
+			case WC_AI_Storefront_UCP_Error_Codes::ITEM_UNPURCHASABLE:
+				return __( 'Product is not available for purchase.', 'woocommerce-ai-storefront' );
 			case WC_AI_Storefront_UCP_Error_Codes::VARIATION_REQUIRED:
 				// Caller overrides with the more specific message; default
 				// here matches in case the override is ever dropped.

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-11T03:19:32+00:00\n"
+"POT-Creation-Date: 2026-05-11T04:40:59+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,11 +82,11 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:465
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:475
 msgid "Sign-up fee"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1874
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1894
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"
@@ -233,136 +233,140 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %s: the input ID the agent submitted that didn't resolve.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3765
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3786
 #, php-format
 msgid "Input \"%s\" did not resolve to a known product or variant."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3768
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3789
 msgid "An input did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3936
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3957
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4006
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4027
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4036
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4057
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4055
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4076
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4079
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4100
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4111
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4132
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4146
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4167
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4176
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4197
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4247
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4268
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4297
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4318
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4326
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4347
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4415
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4436
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4653
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4674
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4687
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4708
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5496
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5533
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5916
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5953
 msgid "Merchant has no privacy policy configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5932
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5969
 msgid "Merchant has no terms of service configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5980
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6017
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5984
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6021
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5988
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6025
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5990
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6027
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5992
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6029
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5996
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6031
+msgid "Product is not available for purchase."
+msgstr ""
+
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6035
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5998
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6037
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-11T04:40:59+00:00\n"
+"POT-Creation-Date: 2026-05-11T05:12:55+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -233,140 +233,140 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %s: the input ID the agent submitted that didn't resolve.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3786
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3798
 #, php-format
 msgid "Input \"%s\" did not resolve to a known product or variant."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3789
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3801
 msgid "An input did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3957
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3969
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4027
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4039
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4057
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4069
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4076
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4088
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4100
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4112
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4132
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4144
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4167
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4179
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4197
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4209
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4268
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4280
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4318
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4330
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4347
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4359
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4436
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4448
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4674
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4686
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4708
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4720
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5533
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5545
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5953
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5965
 msgid "Merchant has no privacy policy configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5969
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5981
 msgid "Merchant has no terms of service configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6017
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6029
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6021
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6033
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6025
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6037
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6027
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6039
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6029
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6041
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6031
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6043
 msgid "Product is not available for purchase."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6035
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6047
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6037
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6049
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/JsonLdNormalizationTest.php
+++ b/tests/php/unit/JsonLdNormalizationTest.php
@@ -99,6 +99,9 @@ class JsonLdNormalizationTest extends \PHPUnit\Framework\TestCase {
 		$product->shouldReceive( 'get_cross_sell_ids' )->andReturn( [] );
 		$product->shouldReceive( 'get_upsell_ids' )->andReturn( [] );
 		$product->shouldReceive( 'get_sku' )->andReturn( '' );
+		// Default to purchasable for the JSON-LD URL gate (#373).
+		$product->shouldReceive( 'is_purchasable' )
+			->andReturn( $overrides['is_purchasable'] ?? true );
 
 		// Argument-aware `is_type()` mock matching WC core: returns true
 		// only when the queried type matches the configured product type

--- a/tests/php/unit/JsonLdReturnPolicyTest.php
+++ b/tests/php/unit/JsonLdReturnPolicyTest.php
@@ -110,6 +110,10 @@ class JsonLdReturnPolicyTest extends \PHPUnit\Framework\TestCase {
 		$product->shouldReceive( 'get_sku' )->andReturn( '' );
 		$product->shouldReceive( 'get_cross_sell_ids' )->andReturn( [] );
 		$product->shouldReceive( 'get_upsell_ids' )->andReturn( [] );
+		// Default to purchasable; the JSON-LD URL gate (#373) calls
+		// `is_purchasable()` before emitting `BuyAction` /
+		// `checkoutPageURLTemplate`.
+		$product->shouldReceive( 'is_purchasable' )->andReturn( true );
 
 		// Argument-aware `is_type()` mock matching WC core: returns true
 		// only when the queried type matches 'simple' (the type return-

--- a/tests/php/unit/JsonLdTest.php
+++ b/tests/php/unit/JsonLdTest.php
@@ -228,6 +228,11 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 			->andReturn( $overrides['cross_sell_ids'] ?? [] );
 		$product->shouldReceive( 'get_upsell_ids' )
 			->andReturn( $overrides['upsell_ids'] ?? [] );
+		// Default to purchasable so existing tests don't need to set
+		// it; the unpurchasable-guard tests (#373) override this to
+		// `false` to exercise the gate.
+		$product->shouldReceive( 'is_purchasable' )
+			->andReturn( $overrides['is_purchasable'] ?? true );
 
 		// `is_type()` accepts a string or array per WC core. Default the
 		// product's type to 'simple' so existing tests keep working
@@ -875,6 +880,66 @@ class JsonLdTest extends \PHPUnit\Framework\TestCase {
 			$entry['offers'][0]['checkoutPageURLTemplate'],
 			'Per-variant BuyAction URL and checkoutPageURLTemplate must match'
 		);
+	}
+
+	public function test_variant_entry_omits_buy_action_and_url_template_when_unpurchasable(): void {
+		// #373: an unpurchasable variation (e.g. no price set) emits its
+		// descriptive fields (@id, name, sku, image, offers[].price) but
+		// MUST NOT emit `potentialAction` (BuyAction) nor
+		// `offers[0].checkoutPageURLTemplate`. SEO crawlers and non-UCP
+		// agents that only read JSON-LD must not be handed a URL that
+		// WC would refuse at checkout. The price/availability remain so
+		// the variant entry isn't a black hole — just no monetary action
+		// is attached.
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$parent    = $this->make_product( [ 'id' => 100 ] );
+		$variation = $this->make_variation( [ 'id' => 999, 'is_purchasable' => false ] );
+
+		$entry = $this->invoke_build_variant_entry( $variation, $parent );
+
+		// Descriptive fields still emit.
+		$this->assertArrayHasKey( 'sku', $entry );
+		$this->assertArrayHasKey( 'name', $entry );
+		$this->assertArrayHasKey( 'offers', $entry );
+		$this->assertArrayHasKey( 'price', $entry['offers'][0] );
+
+		// Action URLs are suppressed.
+		$this->assertArrayNotHasKey( 'potentialAction', $entry );
+		$this->assertArrayNotHasKey( 'checkoutPageURLTemplate', $entry['offers'][0] );
+	}
+
+	public function test_enhance_product_omits_buy_action_when_parent_unpurchasable(): void {
+		// #373: an unpurchasable simple/parent product emits its
+		// descriptive markup but no BuyAction or checkoutPageURLTemplate.
+		// Variable parents that convert to ProductGroup later have their
+		// own per-variant gating; this covers the simple-product path
+		// and the variable-parent-that-doesn't-convert edge case.
+		WC_AI_Storefront::$test_settings = [ 'enabled' => 'yes' ];
+		Functions\when( 'get_woocommerce_currency' )->justReturn( 'USD' );
+
+		$product = $this->make_product( [ 'is_purchasable' => false ] );
+		$markup  = [
+			'@type'  => 'Product',
+			'name'   => 'Broken Product',
+			'offers' => [
+				[
+					'@type'         => 'Offer',
+					'price'         => '0',
+					'priceCurrency' => 'USD',
+				],
+			],
+		];
+
+		$result = $this->jsonld->enhance_product_data( $markup, $product );
+
+		// Descriptive shape preserved.
+		$this->assertSame( 'Product', $result['@type'] );
+		$this->assertArrayHasKey( 'offers', $result );
+
+		// Action URLs suppressed.
+		$this->assertArrayNotHasKey( 'potentialAction', $result );
+		$this->assertArrayNotHasKey( 'checkoutPageURLTemplate', $result['offers'][0] );
 	}
 
 	// ------------------------------------------------------------------

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -1032,6 +1032,19 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		$this->assertContains( 'var_101', $emitted_ids );
 		$this->assertContains( 'var_103', $emitted_ids );
 		$this->assertNotContains( 'var_102', $emitted_ids );
+
+		// Unpurchasable filtering must NOT emit `partial_variants` —
+		// that signal is reserved for genuine retrieval gaps (cap-
+		// truncation, fetch failures, scope-filtering). Filtering an
+		// unpurchasable variation is an intentional exclusion and the
+		// emitted variants[] set is the complete-and-correct
+		// purchasable set. (#373 review)
+		$messages = $body['messages'] ?? [];
+		$partial  = array_filter(
+			$messages,
+			static fn( array $m ): bool => 'partial_variants' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 0, $partial, 'partial_variants must not fire for purchasability-only filtering.' );
 	}
 
 	public function test_all_unpurchasable_variations_falls_through_to_synthesized_default(): void {
@@ -1059,6 +1072,17 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// `synthesize_default()`'s convention — distinct from a real
 		// `var_<id>` shape so downstream consumers can tell it apart.
 		$this->assertStringEndsWith( '_default', $variants[0]['id'] );
+
+		// Even when EVERY variation is dropped, the synthesized-default
+		// fallback fires WITHOUT triggering `partial_variants` — the
+		// degraded shape is itself the signal, and a warning would be
+		// redundant noise. (#373 review)
+		$messages = $body['messages'] ?? [];
+		$partial  = array_filter(
+			$messages,
+			static fn( array $m ): bool => 'partial_variants' === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 0, $partial );
 	}
 
 	/**

--- a/tests/php/unit/UcpCatalogLookupTest.php
+++ b/tests/php/unit/UcpCatalogLookupTest.php
@@ -148,7 +148,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 	/**
 	 * Seed a variable product + its variations at the given IDs.
 	 *
-	 * @param array<int, array{id: int, price: string, size: string}> $variation_specs
+	 * @param array<int, array{id: int, price: string, size: string, is_purchasable?: bool}> $variation_specs
 	 */
 	private function seed_variable_product(
 		int $parent_id,
@@ -168,6 +168,7 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 				'name'              => $name,
 				'short_description' => '',
 				'is_in_stock'       => true,
+				'is_purchasable'    => $spec['is_purchasable'] ?? true,
 				'prices'            => [
 					'price'               => $spec['price'],
 					'currency_code'       => 'USD',
@@ -1002,6 +1003,62 @@ class UcpCatalogLookupTest extends \PHPUnit\Framework\TestCase {
 		// it keeps strict validators happy.
 		$this->assertArrayNotHasKey( 'severity', $msg );
 		$this->assertArrayHasKey( 'content', $msg );
+	}
+
+	public function test_unpurchasable_variations_are_filtered_from_variants_list(): void {
+		// #373: a variation with `is_purchasable: false` (e.g. no price
+		// set by the merchant) MUST NOT appear in the catalog response.
+		// Handing its ID to an agent would lead to a checkout URL WC
+		// refuses to add to cart. Filter happens in
+		// `fetch_variations_for()` upstream of the product translator
+		// so all three surfaces (catalog response, JSON-LD, checkout-
+		// sessions) see the same purchasable-only set.
+		$this->seed_variable_product(
+			789,
+			'T-Shirt',
+			[
+				[ 'id' => 101, 'price' => '1000', 'size' => 'Small' ],
+				[ 'id' => 102, 'price' => '0', 'size' => 'Medium', 'is_purchasable' => false ],
+				[ 'id' => 103, 'price' => '2000', 'size' => 'Large' ],
+			]
+		);
+
+		$body = $this->successful_lookup( [ 'ids' => [ 'prod_789' ] ] );
+
+		$variants = $body['products'][0]['variants'];
+		$this->assertCount( 2, $variants, 'Unpurchasable variant 102 should be dropped.' );
+
+		$emitted_ids = array_map( static fn( array $v ): string => $v['id'], $variants );
+		$this->assertContains( 'var_101', $emitted_ids );
+		$this->assertContains( 'var_103', $emitted_ids );
+		$this->assertNotContains( 'var_102', $emitted_ids );
+	}
+
+	public function test_all_unpurchasable_variations_falls_through_to_synthesized_default(): void {
+		// #373: when every variation is unpurchasable, the filter
+		// produces an empty variations[] array, which trips
+		// `extract_variants()`'s synthesize_default fallback. Agents
+		// still see a single (degraded) variant rather than a
+		// schema-invalid empty list — they can read the entry but
+		// won't be handed a workable checkout URL via downstream
+		// surfaces.
+		$this->seed_variable_product(
+			791,
+			'Broken Tee',
+			[
+				[ 'id' => 201, 'price' => '0', 'size' => 'Small',  'is_purchasable' => false ],
+				[ 'id' => 202, 'price' => '0', 'size' => 'Medium', 'is_purchasable' => false ],
+			]
+		);
+
+		$body = $this->successful_lookup( [ 'ids' => [ 'prod_791' ] ] );
+
+		$variants = $body['products'][0]['variants'];
+		$this->assertCount( 1, $variants, 'Synthesized default emitted as the sole variant.' );
+		// The synthesized default carries the `_default` suffix per
+		// `synthesize_default()`'s convention — distinct from a real
+		// `var_<id>` shape so downstream consumers can tell it apart.
+		$this->assertStringEndsWith( '_default', $variants[0]['id'] );
 	}
 
 	/**

--- a/tests/php/unit/UcpCheckoutSessionsTest.php
+++ b/tests/php/unit/UcpCheckoutSessionsTest.php
@@ -149,26 +149,33 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 	// Test helpers
 	// ------------------------------------------------------------------
 
-	private function seed_simple_product( int $id, int $price_minor = 1000, bool $in_stock = true ): void {
+	private function seed_simple_product(
+		int $id,
+		int $price_minor = 1000,
+		bool $in_stock = true,
+		bool $is_purchasable = true
+	): void {
 		$this->fake_store_api[ $id ] = [
-			'id'          => $id,
-			'name'        => 'Simple #' . $id,
-			'type'        => 'simple',
-			'is_in_stock' => $in_stock,
-			'prices'      => [
+			'id'             => $id,
+			'name'           => 'Simple #' . $id,
+			'type'           => 'simple',
+			'is_in_stock'    => $in_stock,
+			'is_purchasable' => $is_purchasable,
+			'prices'         => [
 				'price'         => (string) $price_minor,
 				'currency_code' => 'USD',
 			],
 		];
 	}
 
-	private function seed_variation( int $id, int $price_minor = 1500 ): void {
+	private function seed_variation( int $id, int $price_minor = 1500, bool $is_purchasable = true ): void {
 		$this->fake_store_api[ $id ] = [
-			'id'          => $id,
-			'name'        => 'T-Shirt',
-			'type'        => 'variation',
-			'is_in_stock' => true,
-			'prices'      => [
+			'id'             => $id,
+			'name'           => 'T-Shirt',
+			'type'           => 'variation',
+			'is_in_stock'    => true,
+			'is_purchasable' => $is_purchasable,
+			'prices'         => [
 				'price'         => (string) $price_minor,
 				'currency_code' => 'USD',
 			],
@@ -1471,6 +1478,84 @@ class UcpCheckoutSessionsTest extends \PHPUnit\Framework\TestCase {
 		);
 		$this->assertCount( 1, $oos_messages );
 		$msg = array_values( $oos_messages )[0];
+		$this->assertEquals( '$.line_items[1].item.id', $msg['path'] );
+	}
+
+	public function test_unpurchasable_item_rejected_with_distinct_code(): void {
+		// #373: an item that is `is_in_stock: true` but
+		// `is_purchasable: false` (e.g. no price set, draft, hidden
+		// from catalog) must be rejected separately from OUT_OF_STOCK
+		// so agents can distinguish "no inventory" from "merchant
+		// misconfiguration". The translator filter at
+		// `fetch_variations_for()` drops these from catalog responses,
+		// but defense-in-depth here catches stale/guessed IDs.
+		$this->seed_simple_product( 222, 1000, true, false );
+
+		$result = $this->call_handler(
+			[ 'line_items' => [ [ 'item' => [ 'id' => 'prod_222' ], 'quantity' => 1 ] ] ]
+		);
+
+		$this->assertEquals( 200, $result['status'] );
+		$this->assertEquals( 'incomplete', $result['data']['status'] );
+		$this->assertArrayNotHasKey( 'continue_url', $result['data'] );
+		$this->assertCount( 0, $result['data']['line_items'] );
+
+		$errors = array_filter(
+			$result['data']['messages'],
+			static fn( array $m ): bool => WC_AI_Storefront_UCP_Error_Codes::ITEM_UNPURCHASABLE === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $errors );
+		$msg = array_values( $errors )[0];
+		$this->assertEquals( 'error', $msg['type'] );
+		$this->assertEquals( 'unrecoverable', $msg['severity'] );
+
+		// And NO out_of_stock error — these codes are mutually exclusive
+		// at the routing point (in-stock items don't fall through to the
+		// out-of-stock branch).
+		$oos = array_filter(
+			$result['data']['messages'],
+			static fn( array $m ): bool => WC_AI_Storefront_UCP_Error_Codes::OUT_OF_STOCK === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 0, $oos );
+	}
+
+	public function test_mixed_cart_excludes_unpurchasable_from_totals_and_line_items(): void {
+		// #373: mixed cart with one purchasable and one unpurchasable
+		// item — the purchasable item must flow through cleanly while
+		// the unpurchasable item surfaces as a message and is excluded
+		// from every output field that carries chargeable items.
+		// Mirrors the OOS test pattern.
+		$this->seed_simple_product( 300, 1500, true, true );    // $15, purchasable
+		$this->seed_simple_product( 400, 2500, true, false );   // $25, NOT purchasable
+
+		$result = $this->call_handler(
+			[
+				'line_items' => [
+					[ 'item' => [ 'id' => 'prod_300' ], 'quantity' => 2 ],   // $30
+					[ 'item' => [ 'id' => 'prod_400' ], 'quantity' => 1 ],   // unpurchasable — excluded
+				],
+			]
+		);
+
+		$this->assertEquals( 201, $result['status'] );
+		$this->assertEquals( 'requires_escalation', $result['data']['status'] );
+
+		// continue_url contains only the purchasable item.
+		$this->assertStringContainsString( '300:2', $result['data']['continue_url'] );
+		$this->assertStringNotContainsString( '400', $result['data']['continue_url'] );
+
+		$this->assertCount( 1, $result['data']['line_items'] );
+		$this->assertEquals( 'prod_300', $result['data']['line_items'][0]['item']['id'] );
+
+		// Subtotal reflects ONLY the purchasable item (2 × $15 = 3000).
+		$this->assertSame( 3000, $result['data']['totals'][0]['amount'] );
+
+		$unpurchasable = array_filter(
+			$result['data']['messages'],
+			static fn( array $m ): bool => WC_AI_Storefront_UCP_Error_Codes::ITEM_UNPURCHASABLE === ( $m['code'] ?? '' )
+		);
+		$this->assertCount( 1, $unpurchasable );
+		$msg = array_values( $unpurchasable )[0];
 		$this->assertEquals( '$.line_items[1].item.id', $msg['path'] );
 	}
 


### PR DESCRIPTION
Closes #373.

## Summary

A misconfigured variation (e.g. no price set) was reading `is_in_stock: true` but `is_purchasable: false` in WC, and the plugin was gating on `is_in_stock` alone. Three surfaces leaked broken variant IDs to agents — catalog/lookup, JSON-LD `hasVariant`, and `/checkout-sessions` — producing `/checkout-link/?products=<id>:1` URLs that WC then refused at cart-add.

## Three coordinated guards

| Surface | Behavior |
|---|---|
| UCP `fetch_variations_for()` | Filter out `is_purchasable: false` before reaching the product translator. All unpurchasable → empty `variations[]` → existing `synthesize_default()` fallback fires, preserving the `variants: minItems: 1` schema constraint. |
| UCP `/checkout-sessions` | New `ITEM_UNPURCHASABLE` error code (distinct from `OUT_OF_STOCK`) so agents can tell "no inventory" apart from "merchant misconfiguration / not for sale". Mixed carts keep purchasable items in `continue_url`, `line_items[]`, and `totals`; unpurchasable lines surface as `messages[]` entries with exact `$.line_items[N].item.id` paths. |
| JSON-LD URL suppression | Unpurchasable variants under `hasVariant[]` emit descriptive fields (sku, name, image, offers[].price) but **drop** `BuyAction` and `Offer.checkoutPageURLTemplate`. Same treatment for parent shape on unpurchasable simple/variable parents. SEO crawlers and non-UCP agents no longer get URLs WC would 4xx. |

## Test plan

- [x] PHPUnit: 1416 tests pass (6 new behavioral tests added covering all three surfaces)
- [x] PHPCS clean (incl. `phpcbf` pre-push)
- [x] PHPStan clean (`--memory-limit=512M`)
- [ ] Live verify on pierorocca.com after merge by hitting `/catalog/lookup` for the misconfigured no-price variation and confirming it's filtered out

## Files touched

```
includes/ai-storefront/class-wc-ai-storefront-jsonld.php                +30 -1
includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-error-codes.php  +8
includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php  +41 -7
tests/php/unit/JsonLdNormalizationTest.php       +3
tests/php/unit/JsonLdReturnPolicyTest.php        +4
tests/php/unit/JsonLdTest.php                    +65
tests/php/unit/UcpCatalogLookupTest.php          +59
tests/php/unit/UcpCheckoutSessionsTest.php       +109
CHANGELOG.md                                     +6
```

## Notes

- The translator filter happens **after** the fetch loop (not inline), because `fetch_store_api_product()` is memoized and pluggable via filter — a future filter could hydrate `is_purchasable: true` even on a misconfigured variation. Filtering post-fetch sees the final value.
- The `is_purchasable` check uses `! isset() || true === ...` so missing field defaults to "purchasable" — back-compat with any legacy fixture lacking the field. Only an explicit `false` triggers the filter.
- `method_exists()` guard in JSON-LD before `is_purchasable()` is defensive against test stubs that don't implement the full `WC_Product` interface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)