### PR TITLE
feat(#374): relocate Product.{status, published_at, updated_at} under metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 ## [Unreleased]
 
 ### Features
+
+- **UCP catalog: relocate `status` + timestamps under `metadata` per spec.** Closes #374. Post-repo-access audit found that `product.json` does not define `status`, `published_at`, or `updated_at` as first-class properties — they're business-defined extension fields, and the spec's `metadata` block is the official escape hatch. New shape:
+  - `metadata.lifecycle.status` — always `"published"` (catalog handlers only translate Store-API-returned products, which already filters out drafts/private).
+  - `metadata.timestamps.published_at` / `metadata.timestamps.updated_at` — ISO 8601 strings; the whole `timestamps` sub-block is omitted when no timestamps are available rather than emitted as empty scaffolding.
+  - Top-level `status`, `published_at`, `updated_at` are dropped. Hard cutover — prerelease, no merchant adoption to migrate.
+
 ### Fixes
 
 - **UCP / JSON-LD: unpurchasable variations no longer leak to agents.** Closes #373. A misconfigured variation (e.g. missing a price) was emitted with a usable-looking variant ID and a checkout URL that WC then refused at cart-add. Three coordinated guards:

--- a/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
+++ b/includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php
@@ -140,26 +140,19 @@ class WC_AI_Storefront_UCP_Product_Translator {
 			$product['list_price_range'] = $list_price_range;
 		}
 
-		// Spec metadata fields — additive, non-breaking.
-		//
-		// `status` is a fixed literal "published": our catalog handlers
-		// only emit products returned by the Store API, which already
-		// filters to published (we don't syndicate drafts/private).
-		// Emitting the key anyway communicates the posture to agents
-		// so "why didn't I find product X?" is traceable back to
-		// "its status isn't in your result set".
-		$product['status'] = 'published';
-
-		// `published_at` / `updated_at` — ISO 8601 timestamps from the
-		// Store API. Older WC versions emit a `{raw, format_to_edit}`
-		// object; 9.5+ emits the ISO string directly. Coerce both.
+		// `status` and timestamps are emitted under `metadata` rather
+		// than at the top level of the product. UCP `product.json` does
+		// not define `status`, `published_at`, or `updated_at` as
+		// first-class properties — they're business-defined extension
+		// fields, and the spec's `metadata` block is the official
+		// escape hatch for that shape of data. Strict validators that
+		// tighten `additionalProperties` in a future spec revision
+		// would silently reject the old top-level emission; the
+		// metadata path is forward-compatible. The actual block
+		// assembly happens later (alongside `metadata.attributes`,
+		// `metadata.bundle`, `metadata.grouped`) — see the
+		// `$metadata` construction below. (#374)
 		$timestamps = self::extract_timestamps( $wc_product );
-		if ( isset( $timestamps['published_at'] ) ) {
-			$product['published_at'] = $timestamps['published_at'];
-		}
-		if ( isset( $timestamps['updated_at'] ) ) {
-			$product['updated_at'] = $timestamps['updated_at'];
-		}
 
 		// Seller is no longer attached at the product level. UCP
 		// `variant.json` defines `seller` inline only on variants
@@ -238,6 +231,29 @@ class WC_AI_Storefront_UCP_Product_Translator {
 		// attributes on non-variable products (simple/bundle/grouped),
 		// since those have no buyer-selectable axes by definition.
 		$metadata = [];
+
+		// Lifecycle + timestamps under metadata (#374). `lifecycle.status`
+		// is always "published" — catalog handlers upstream only translate
+		// products the Store API returns, which already filters out
+		// drafts/private. The key is emitted unconditionally so agents
+		// can distinguish "didn't find product X" from "product X is in
+		// our index but not published". Timestamps are conditional: the
+		// Store API extension is the primary source (`extract_timestamps`
+		// above), and downgrading gracefully to omission when the source
+		// lacks them is correct — never synthesize fake dates.
+		$lifecycle = [ 'status' => 'published' ];
+		$ts_subset = [];
+		if ( isset( $timestamps['published_at'] ) ) {
+			$ts_subset['published_at'] = $timestamps['published_at'];
+		}
+		if ( isset( $timestamps['updated_at'] ) ) {
+			$ts_subset['updated_at'] = $timestamps['updated_at'];
+		}
+		$metadata['lifecycle'] = $lifecycle;
+		if ( ! empty( $ts_subset ) ) {
+			$metadata['timestamps'] = $ts_subset;
+		}
+
 		if ( ! empty( $classified['metadata_attributes'] ) ) {
 			$metadata['attributes'] = $classified['metadata_attributes'];
 		}
@@ -263,9 +279,10 @@ class WC_AI_Storefront_UCP_Product_Translator {
 				$metadata['grouped'] = $grouped_metadata;
 			}
 		}
-		if ( ! empty( $metadata ) ) {
-			$product['metadata'] = $metadata;
-		}
+		// `metadata.lifecycle.status` is always present (#374), so the
+		// block is unconditionally non-empty — direct assignment instead
+		// of a `! empty()` guard.
+		$product['metadata'] = $metadata;
 
 		// Rating + review count — emitted under core `product.rating`
 		// (2.0.0+). Previously (1.x) under the vendor extension

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-11T05:06:52+00:00\n"
+"POT-Creation-Date: 2026-05-11T05:17:01+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,11 +82,11 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:465
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:475
 msgid "Sign-up fee"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1874
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1894
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"
@@ -233,136 +233,140 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %s: the input ID the agent submitted that didn't resolve.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3765
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3798
 #, php-format
 msgid "Input \"%s\" did not resolve to a known product or variant."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3768
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3801
 msgid "An input did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3936
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3969
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4006
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4039
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4036
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4069
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4055
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4088
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4079
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4112
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4111
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4144
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4146
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4179
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4176
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4209
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4247
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4280
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4297
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4330
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4326
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4359
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4415
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4448
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4653
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4686
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4687
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4720
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5496
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5545
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5916
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5965
 msgid "Merchant has no privacy policy configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5932
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5981
 msgid "Merchant has no terms of service configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5980
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6029
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5984
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6033
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5988
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6037
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5990
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6039
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5992
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6041
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5996
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6043
+msgid "Product is not available for purchase."
+msgstr ""
+
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6047
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5998
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6049
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/languages/woocommerce-ai-storefront.pot
+++ b/languages/woocommerce-ai-storefront.pot
@@ -9,7 +9,7 @@ msgstr ""
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
-"POT-Creation-Date: 2026-05-11T05:12:55+00:00\n"
+"POT-Creation-Date: 2026-05-11T05:06:52+00:00\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "X-Generator: WP-CLI 2.12.0\n"
 "X-Domain: woocommerce-ai-storefront\n"
@@ -82,11 +82,11 @@ msgstr ""
 msgid "Session ID:"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:475
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:465
 msgid "Sign-up fee"
 msgstr ""
 
-#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1894
+#: includes/ai-storefront/class-wc-ai-storefront-jsonld.php:1874
 #: client/settings/ai-storefront/product-selection.js:914
 #: client/settings/ai-storefront/product-selection.js:1128
 msgid "Products"
@@ -233,140 +233,136 @@ msgid "This /checkout-sessions/{id} URL is stateless and supports no operations:
 msgstr ""
 
 #. translators: %s: the input ID the agent submitted that didn't resolve.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3798
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3765
 #, php-format
 msgid "Input \"%s\" did not resolve to a known product or variant."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3801
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3768
 msgid "An input did not resolve to a known product or variant."
 msgstr ""
 
 #. translators: 1: number of variations missing, 2: WC product ID.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3969
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:3936
 #, php-format
 msgid "%1$d variation of product %2$d is not included in the variants list; the list is incomplete."
 msgid_plural "%1$d variations of product %2$d are not included in the variants list; the list is incomplete."
 msgstr[0] ""
 msgstr[1] ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4039
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4006
 msgid "pagination must be an object; using defaults."
 msgstr ""
 
 #. translators: 1: requested limit, 2: applied limit, 3: max allowed.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4069
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4036
 #, php-format
 msgid "Requested pagination.limit %1$d was clamped to %2$d (allowed range: 1–%3$d)."
 msgstr ""
 
 #. translators: %d is the applied default limit.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4088
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4055
 #, php-format
 msgid "pagination.limit must be a non-negative integer; using default %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4112
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4079
 msgid "Pagination cursor could not be decoded; returning first page. If you copied this cursor from a prior response the catalog may have changed, but a malformed cursor most often indicates a client bug."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4144
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4111
 msgid "sort.field and sort.direction must be strings; using default ordering."
 msgstr ""
 
 #. translators: %s is the unsupported sort field the agent sent.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4179
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4146
 #, php-format
 msgid "Sort field \"%s\" is not supported; using default ordering."
 msgstr ""
 
 #. translators: %s is the category slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4209
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4176
 #, php-format
 msgid "Category \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: 1: agent-supplied currency, 2: store currency.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4280
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4247
 #, php-format
 msgid "context.currency \"%1$s\" does not match store currency \"%2$s\" and conversion is not supported; price filter ignored."
 msgstr ""
 
 #. translators: %s is the tag slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4330
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4297
 #, php-format
 msgid "Tag \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the brand slug/name the agent sent that couldn't be resolved.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4359
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4326
 #, php-format
 msgid "Brand \"%s\" was not found; filter ignored for this value."
 msgstr ""
 
 #. translators: %s is the attribute taxonomy name the agent sent that doesn't exist on the store.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4448
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4415
 #, php-format
 msgid "Attribute taxonomy \"%s\" was not found on the store; filter ignored for this axis."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4686
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4653
 #, php-format
 msgid "%1$s received %2$d values; truncated to the first %3$d. Further values were ignored."
 msgstr ""
 
 #. translators: 1: filter path, 2: original count, 3: applied cap.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4720
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:4687
 #, php-format
 msgid "%1$s received %2$d keys; truncated to the first %3$d. Further keys were ignored."
 msgstr ""
 
 #. translators: 1: expected amount (minor units), 2: current amount (minor units).
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5545
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5496
 #, php-format
 msgid "Unit price changed from %1$d to %2$d (minor units) since the catalog was fetched."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5965
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5916
 msgid "Merchant has no privacy policy configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5981
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5932
 msgid "Merchant has no terms of service configured; agents may want to surface this caveat to buyers before proceeding."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6029
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5980
 msgid "Line item must be an object with \"item.id\" and \"quantity\"."
 msgstr ""
 
 #. translators: %d is the maximum quantity per line item.
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6033
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5984
 #, php-format
 msgid "Quantity must be a positive integer up to %d."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6037
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5988
 msgid "Product not found."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6039
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5990
 msgid "Product type cannot be added via the Shareable Checkout URL; link to the product page directly."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6041
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5992
 msgid "Product is out of stock."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6043
-msgid "Product is not available for purchase."
-msgstr ""
-
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6047
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5996
 msgid "Product is variable — specify a variation ID instead of the parent product ID."
 msgstr ""
 
-#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:6049
+#: includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-rest-controller.php:5998
 msgid "Line item could not be processed."
 msgstr ""
 

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -1151,12 +1151,12 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		$this->assertArrayNotHasKey( 'attributes', $result );
 	}
 
-	public function test_translate_omits_options_and_metadata_when_source_has_no_attributes(): void {
+	public function test_translate_omits_options_and_metadata_attributes_when_source_has_no_attributes(): void {
 		// No WC attributes at all → no `options` key, and no
 		// `metadata.attributes` sub-block (no empty scaffolding emitted).
 		// `metadata` itself IS present post-#374 because
-		// `metadata.lifecycle.status` always emits; the assertion is
-		// scoped to the attributes sub-block.
+		// `metadata.lifecycle.status` always emits; the assertions are
+		// scoped to the attributes-related sub-blocks only.
 		$fixture = $this->simple_product_fixture();
 		unset( $fixture['attributes'] );
 

--- a/tests/php/unit/UcpProductTranslatorTest.php
+++ b/tests/php/unit/UcpProductTranslatorTest.php
@@ -1152,16 +1152,18 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 	}
 
 	public function test_translate_omits_options_and_metadata_when_source_has_no_attributes(): void {
-		// No WC attributes at all → both `options` and `metadata` keys
-		// should be absent (no empty scaffolding emitted).
+		// No WC attributes at all → no `options` key, and no
+		// `metadata.attributes` sub-block (no empty scaffolding emitted).
+		// `metadata` itself IS present post-#374 because
+		// `metadata.lifecycle.status` always emits; the assertion is
+		// scoped to the attributes sub-block.
 		$fixture = $this->simple_product_fixture();
 		unset( $fixture['attributes'] );
 
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate( $fixture, [] );
 
-		$this->assertArrayNotHasKey( 'attributes', $result );
 		$this->assertArrayNotHasKey( 'options', $result );
-		$this->assertArrayNotHasKey( 'metadata', $result );
+		$this->assertArrayNotHasKey( 'attributes', $result['metadata'] ?? [] );
 	}
 
 	public function test_simple_product_reserved_attribute_demoted_to_metadata(): void {
@@ -1496,19 +1498,22 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 	// Spec metadata fields (PR G)
 	// ------------------------------------------------------------------
 
-	public function test_translate_always_emits_status_published(): void {
+	public function test_translate_always_emits_status_published_under_metadata(): void {
 		// The handler upstream filters out draft/private products at
 		// the Store API layer, so anything we translate is by
 		// definition published. Emitting the `status` key explicitly
 		// communicates that posture to agents — otherwise they'd
 		// have no way to know whether missing products are drafts
-		// vs. out-of-stock vs. excluded-by-permission.
+		// vs. out-of-stock vs. excluded-by-permission. Lives under
+		// `metadata.lifecycle.status` per UCP spec (#374): top-level
+		// `status` is not in `product.json`.
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
 			$this->simple_product_fixture(),
 			[]
 		);
 
-		$this->assertSame( 'published', $result['status'] );
+		$this->assertSame( 'published', $result['metadata']['lifecycle']['status'] );
+		$this->assertArrayNotHasKey( 'status', $result, 'Top-level status must not be emitted post-#374.' );
 	}
 
 	public function test_translate_reads_timestamps_from_store_api_extension_namespace(): void {
@@ -1516,7 +1521,8 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		// under `extensions[com-woocommerce-ai-storefront]` as RFC
 		// 3339 / ISO 8601 UTC strings. WC 9.5+ Store API strips the
 		// top-level date fields; the extension is the only reliable
-		// path to these values.
+		// path to these values. Emitted under `metadata.timestamps`
+		// post-#374.
 		$fixture                 = $this->simple_product_fixture();
 		$fixture['extensions']   = [
 			'com-woocommerce-ai-storefront' => [
@@ -1527,8 +1533,10 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate( $fixture, [] );
 
-		$this->assertSame( '2026-01-15T10:30:00Z', $result['published_at'] );
-		$this->assertSame( '2026-04-20T14:22:31Z', $result['updated_at'] );
+		$this->assertSame( '2026-01-15T10:30:00Z', $result['metadata']['timestamps']['published_at'] );
+		$this->assertSame( '2026-04-20T14:22:31Z', $result['metadata']['timestamps']['updated_at'] );
+		$this->assertArrayNotHasKey( 'published_at', $result, 'Top-level published_at must not be emitted post-#374.' );
+		$this->assertArrayNotHasKey( 'updated_at', $result, 'Top-level updated_at must not be emitted post-#374.' );
 	}
 
 	public function test_translate_falls_back_to_top_level_date_fields_when_extension_absent(): void {
@@ -1543,8 +1551,8 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate( $fixture, [] );
 
-		$this->assertSame( '2026-01-15T10:30:00', $result['published_at'] );
-		$this->assertSame( '2026-04-20T14:22:31', $result['updated_at'] );
+		$this->assertSame( '2026-01-15T10:30:00', $result['metadata']['timestamps']['published_at'] );
+		$this->assertSame( '2026-04-20T14:22:31', $result['metadata']['timestamps']['updated_at'] );
 	}
 
 	public function test_translate_prefers_extension_over_top_level_when_both_present(): void {
@@ -1563,7 +1571,7 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate( $fixture, [] );
 
-		$this->assertSame( '2026-01-15T10:30:00Z', $result['published_at'] );
+		$this->assertSame( '2026-01-15T10:30:00Z', $result['metadata']['timestamps']['published_at'] );
 	}
 
 	public function test_translate_tolerates_non_array_extensions_without_fatal(): void {
@@ -1572,6 +1580,8 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		// entry. Without an `is_array` guard we'd fatal on array
 		// indexing. Verify the translator degrades to the top-level
 		// fallback path (and ultimately to omission) without error.
+		// Post-#374: `metadata.timestamps` is omitted entirely when no
+		// timestamps survive (rather than emitted as an empty sub-block).
 		foreach ( [
 			'extensions-is-string' => [ 'extensions' => 'surprise string' ],
 			'extensions-is-int'    => [ 'extensions' => 42 ],
@@ -1584,8 +1594,11 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 			// (no top-level date_* either in this fixture).
 			$result = WC_AI_Storefront_UCP_Product_Translator::translate( $fixture, [] );
 
-			$this->assertArrayNotHasKey( 'published_at', $result, "Fatal-averted path failed: {$label}" );
-			$this->assertArrayNotHasKey( 'updated_at', $result, "Fatal-averted path failed: {$label}" );
+			$this->assertArrayNotHasKey(
+				'timestamps',
+				$result['metadata'] ?? [],
+				"Fatal-averted path failed: {$label}"
+			);
 		}
 	}
 
@@ -1594,13 +1607,16 @@ class UcpProductTranslatorTest extends \PHPUnit\Framework\TestCase {
 		// translator is pure — don't synthesize fake timestamps if
 		// the input happens to lack them (e.g. a mocked response in
 		// a caller's integration test). Omission is valid per spec.
+		// Post-#374: `metadata.lifecycle.status` still emits (it's a
+		// fixed literal not sourced from input); only `timestamps` is
+		// conditional on input.
 		$result = WC_AI_Storefront_UCP_Product_Translator::translate(
 			$this->simple_product_fixture(),
 			[]
 		);
 
-		$this->assertArrayNotHasKey( 'published_at', $result );
-		$this->assertArrayNotHasKey( 'updated_at', $result );
+		$this->assertArrayHasKey( 'lifecycle', $result['metadata'] );
+		$this->assertArrayNotHasKey( 'timestamps', $result['metadata'] );
 	}
 
 	public function test_translate_stamps_seller_on_synthesized_default_variant(): void {


### PR DESCRIPTION
Closes #374.

## Summary

Post-repo-access spec audit found that UCP `product.json` does not define `status`, `published_at`, or `updated_at` as first-class properties — they're business-defined extension fields, and the spec's `metadata` block is the official escape hatch for that shape of data. We were emitting them at the top level since v0.14.0; this PR relocates them.

## Shape change

**Before (v0.14.0–0.14.1):**

```json
{
  "id": "prod_42",
  "status": "published",
  "published_at": "2026-05-10T12:34:56Z",
  "updated_at": "2026-05-10T18:00:00Z",
  ...
}
```

**After:**

```json
{
  "id": "prod_42",
  ...,
  "metadata": {
    "lifecycle":  { "status": "published" },
    "timestamps": {
      "published_at": "2026-05-10T12:34:56Z",
      "updated_at":   "2026-05-10T18:00:00Z"
    }
  }
}
```

## Behavioral notes

- `metadata.lifecycle.status` always emits — fixed literal `"published"` (upstream catalog handlers only translate Store-API-returned products, which already filters out drafts/private).
- `metadata.timestamps` is conditional on source availability — the whole sub-block is omitted when no timestamps are extracted, not emitted as empty scaffolding.
- Top-level `status` / `published_at` / `updated_at` are dropped entirely. **Hard cutover** (no dual-emit). Prerelease, no merchant adoption to migrate.
- `metadata` is now unconditionally non-empty (lifecycle always present), so the `! empty( $metadata )` guard before assignment is removed.

## Test plan

- [x] PHPUnit: 1410 tests pass
  - 6 translator tests migrated to `metadata.lifecycle.status` / `metadata.timestamps.{published_at,updated_at}` + top-level-absence assertions
  - 1 collateral test fixed: "no metadata key when no attributes" → "no `metadata.attributes` sub-block" (metadata is now always present)
- [x] PHPCS clean (`phpcbf` pre-push)
- [x] PHPStan clean
- [ ] Live verify on pierorocca.com after merge: `POST /catalog/lookup` for any product and confirm `metadata.lifecycle.status` + `metadata.timestamps.*` shape

## Files touched

```
CHANGELOG.md                                                            +6
includes/ai-storefront/ucp-rest/class-wc-ai-storefront-ucp-product-translator.php  +37 -22
tests/php/unit/UcpProductTranslatorTest.php                             +35 -17
languages/woocommerce-ai-storefront.pot                                 (auto-regen)
```

## Breaking change disclaimer

This is a **breaking change** for any consumer reading `product.status` / `product.published_at` / `product.updated_at` at the top level. Audit of known consumers:

- UCPPlayground: doesn't display these fields in their UI today.
- Local Gemini test agent: doesn't reference these fields in its prompts.

Risk is low because the fields are 3 days old (shipped in v0.14.0 on 2026-05-08) and the plugin is still prerelease.

🤖 Generated with [Claude Code](https://claude.com/claude-code)