### PR TITLE
chore(dev): bump wp-env memory limit to 512M

### DIFF
--- a/.wp-env.json
+++ b/.wp-env.json
@@ -11,7 +11,9 @@
 		"WP_DEBUG_LOG": true,
 		"WP_DEBUG_DISPLAY": false,
 		"SCRIPT_DEBUG": true,
-		"WP_ENVIRONMENT_TYPE": "local"
+		"WP_ENVIRONMENT_TYPE": "local",
+		"WP_MEMORY_LIMIT": "512M",
+		"WP_MAX_MEMORY_LIMIT": "512M"
 	},
 	"port": 8030,
 	"testsEnvironment": false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   - **Disabled / rejected feedback**: when the capability is off, inbound `discounts.codes[]` are dropped AND the response carries an `info` message `discount_codes_unsupported` so agents know their input was acknowledged but not honored. When the capability is on but all supplied codes fail validation, agents get `discount_codes_rejected` instead. Distinct codes route remediation correctly (fix the input vs. ask the merchant). No 4xx for either case — tolerant of stale agent caches.
 
 ### Refactors
+
+- **Dev tooling: bump wp-env memory limit to 512M.** Local `wp-env` stack was hitting PHP `Allowed memory size of 134217728 bytes exhausted` fatals during plugin activation (WC core + WC Subscriptions + WC Payments + Jetpack + this plugin overran 128M) and on `action-scheduler run` catch-up commands. Added `WP_MEMORY_LIMIT` + `WP_MAX_MEMORY_LIMIT` set to `512M` in `.wp-env.json`'s `config` block. Dev-env-only — production / staging WP hosts configure `memory_limit` through their own php.ini or wp-config.php directly.
+
 ### Tests
 ### Docs
 


### PR DESCRIPTION
## Summary

Local dev `wp-env` stack was hitting PHP `Allowed memory size of 134217728 bytes exhausted` fatals in two recurring places:

1. **Bootstrap container** during plugin activation — WC core + WC Subscriptions + WC Payments + Jetpack + this plugin overran the default 128M ceiling. Resulted in `Exited (1)` bootstrap and a half-filled "container starting" state in Docker Desktop.
2. **CLI container** running `action-scheduler run` after wp-env downtime — same ceiling, every invocation. Required ad-hoc `--skip-plugins=...` + memory-bump `--require` workarounds.

## Fix

Set `WP_MEMORY_LIMIT` + `WP_MAX_MEMORY_LIMIT` to `512M` in `.wp-env.json`'s `config` block. wp-env writes these to `wp-config.php` on `env:start`, so they apply to both web requests AND WP-CLI runs.

## Why 512M (not 256M / 1G)

| Value | Verdict |
|---|---|
| 256M | Conservative bump but still <2x headroom over the 128M-line failure. Risk of another OOM on the next plugin addition. |
| **512M** ✓ | What the AS catch-up `--require` override already proved works under load. |
| 1G | More headroom than needed and could mask a real memory regression in future plugin work. |

## Scope

Dev-env-only. Production / staging WP hosts configure `memory_limit` through their own php.ini or wp-config.php directly.

## Test plan

- [x] `npm run env:stop && npm run env:start` — all 3 containers up, no `Exited` bootstrap
- [x] `curl http://localhost:8030/` returns 200
- [x] `npm run env:cli -- plugin list --status=active` runs without OOM
- [x] Diff is 2 lines — purely additive, no behavior change for production

🤖 Generated with [Claude Code](https://claude.com/claude-code)