### PR TITLE
docs(user-guide): independent validation tools section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,8 @@
 
 - **Em-dash cleanup across merchant-facing copy.** AGENTS.md forbids em-dashes in user-facing copy (rendering edge cases in CSV-split tools and ASCII renderers — the convention originates from a plugin Description: header rendering issue, and extends to readme.txt + all merchant-facing UI strings). Cleaned 5 in `docs/user-guide/USER-GUIDE.md` and 28 in `readme.txt`. Each replacement context-appropriate: colons for label-style flow, periods for sentence joins, parens for parentheticals.
 
+- **User guide: independent validation tools section.** New section 4a points merchants at three widely-used community tools for verifying their UCP setup beyond what the plugin's own UI can show: UCPPlayground.com (end-to-end agent simulation), UCPChecker.com (protocol-conformance validation), and UCPRegistry.com (optional directory submission). Framed as third-party and independent of Automattic, with a fallback pointer to https://ucp.dev/ if any link goes stale. The existing 4a "What the homepage publishes" section becomes 4b; the inbound link from the URL-verification table updated accordingly.
+
 ---
 
 ## [0.14.2] – 2026-05-11

--- a/docs/user-guide/USER-GUIDE.html
+++ b/docs/user-guide/USER-GUIDE.html
@@ -181,7 +181,7 @@
 </tr>
 <tr>
 <td>Homepage → &quot;View page source&quot;</td>
-<td>Search for <code>&quot;@type&quot;:&quot;OnlineStore&quot;</code>. This is your store&#39;s brand info available to AI shopping agents. See <a href="#4a-what-the-homepage-publishes-to-ai-agents">section 4a</a>.</td>
+<td>Search for <code>&quot;@type&quot;:&quot;OnlineStore&quot;</code>. This is your store&#39;s brand info available to AI shopping agents. See <a href="#4b-what-the-homepage-publishes-to-ai-agents">section 4b</a>.</td>
 </tr>
 <tr>
 <td>Any product page → &quot;View page source&quot;</td>
@@ -197,7 +197,34 @@
 </blockquote>
 <p>A working setup returns real product names with prices and links to your store within 3–10 seconds. If the agent says it can&#39;t find anything, wait a few hours (most agents cache crawl results) and retry.</p>
 <p>Natural-language search queries match against your product categories, tags, brands, and attributes, not just product titles. So an agent asking for &quot;hoodies&quot; will find products in your &quot;Hoodies&quot; category even if the individual product titles use a different word, and &quot;watches&quot; will find products in a &quot;Watch&quot; category. Plural and singular forms are handled automatically.</p>
-<h3>4a. What the homepage publishes to AI agents</h3>
+<h3>4a. Independent validation tools</h3>
+<p>The plugin&#39;s UI shows you what the plugin THINKS it&#39;s publishing. For an independent view of what an AI agent or the UCP protocol layer actually sees, three widely-used community tools can help. They&#39;re independent of Automattic and this plugin, but maintained by people active in the UCP ecosystem (UCPPlayground&#39;s creator sits on the UCP.DEV technical council).</p>
+<table>
+<thead>
+<tr>
+<th>Tool</th>
+<th>What it answers</th>
+<th>When to use</th>
+</tr>
+</thead>
+<tbody><tr>
+<td><strong><a href="https://ucpplayground.com/">UCPPlayground.com</a></strong> (Agent + Playground modes)</td>
+<td>What does an AI shopping agent see when it walks your catalog and checkout?</td>
+<td>End-to-end testing. Catches product-data issues (missing prices, unpurchasable variants, broken images) before real agents do.</td>
+</tr>
+<tr>
+<td><strong><a href="https://ucpchecker.com/">UCPChecker</a></strong></td>
+<td>Is your UCP manifest and catalog spec-conformant?</td>
+<td>Protocol validation. Catches shape drift after a plugin upgrade or after touching extension filters.</td>
+</tr>
+<tr>
+<td><strong><a href="https://ucpregistry.com/submit">UCP Registry</a></strong> (optional)</td>
+<td>A directory of UCP-enabled stores. How widely AI agents query it varies.</td>
+<td>Submission costs nothing. Treat as opt-in rather than required.</td>
+</tr>
+</tbody></table>
+<p>These tools are not officially affiliated with Automattic. URLs and capabilities may change over time. If any link is dead, the UCP spec page at <a href="https://ucp.dev/">https://ucp.dev/</a> will usually point at the current validator or playground.</p>
+<h3>4b. What the homepage publishes to AI agents</h3>
 <p>Your homepage now publishes your store&#39;s brand details (name, logo, address, contact) in a format that AI agents understand. AI shopping assistants use this info to confirm they&#39;re recommending the right store.</p>
 <table>
 <thead>

--- a/docs/user-guide/USER-GUIDE.md
+++ b/docs/user-guide/USER-GUIDE.md
@@ -136,7 +136,7 @@ Before configuring anything else, take 30 seconds to confirm the endpoints are l
 | `https://your-store.com/llms.txt` | A plain-text Markdown document starting with `# Your Store Name`, with a category list and "How AI agents should link to products" section. |
 | `https://your-store.com/.well-known/ucp` | A pretty-printed JSON document in monospace. Top-level keys: `name`, `version`, `capabilities`, `payment_handlers`, `services`. |
 | `https://your-store.com/robots.txt` | The standard WordPress `robots.txt` plus a block of `User-agent: GPTBot` / `User-agent: ChatGPT-User` / etc. each with `Allow:` lines. |
-| Homepage → "View page source" | Search for `"@type":"OnlineStore"`. This is your store's brand info available to AI shopping agents. See [section 4a](#4a-what-the-homepage-publishes-to-ai-agents). |
+| Homepage → "View page source" | Search for `"@type":"OnlineStore"`. This is your store's brand info available to AI shopping agents. See [section 4b](#4b-what-the-homepage-publishes-to-ai-agents). |
 | Any product page → "View page source" | Search for `"@type":"Product"`. You should see product details like prices and (once you set one in [section 7](#7-set-your-store-policies)) return policy information. |
 
 The Discovery tab shows the same URLs as clickable links with reachability dots. URLs render in monospace font:
@@ -153,7 +153,19 @@ A working setup returns real product names with prices and links to your store w
 
 Natural-language search queries match against your product categories, tags, brands, and attributes, not just product titles. So an agent asking for "hoodies" will find products in your "Hoodies" category even if the individual product titles use a different word, and "watches" will find products in a "Watch" category. Plural and singular forms are handled automatically.
 
-### 4a. What the homepage publishes to AI agents
+### 4a. Independent validation tools
+
+The plugin's UI shows you what the plugin THINKS it's publishing. For an independent view of what an AI agent or the UCP protocol layer actually sees, three widely-used community tools can help. They're independent of Automattic and this plugin, but maintained by people active in the UCP ecosystem (UCPPlayground's creator sits on the UCP.DEV technical council).
+
+| Tool | What it answers | When to use |
+|---|---|---|
+| **[UCPPlayground.com](https://ucpplayground.com/)** (Agent + Playground modes) | What does an AI shopping agent see when it walks your catalog and checkout? | End-to-end testing. Catches product-data issues (missing prices, unpurchasable variants, broken images) before real agents do. |
+| **[UCPChecker](https://ucpchecker.com/)** | Is your UCP manifest and catalog spec-conformant? | Protocol validation. Catches shape drift after a plugin upgrade or after touching extension filters. |
+| **[UCP Registry](https://ucpregistry.com/submit)** (optional) | A directory of UCP-enabled stores. How widely AI agents query it varies. | Submission costs nothing. Treat as opt-in rather than required. |
+
+These tools are not officially affiliated with Automattic. URLs and capabilities may change over time. If any link is dead, the UCP spec page at https://ucp.dev/ will usually point at the current validator or playground.
+
+### 4b. What the homepage publishes to AI agents
 
 Your homepage now publishes your store's brand details (name, logo, address, contact) in a format that AI agents understand. AI shopping assistants use this info to confirm they're recommending the right store.
 


### PR DESCRIPTION
Adds a new subsection to USER-GUIDE.md section 4 pointing merchants at three widely-used community tools for validating their UCP setup beyond what the plugin's own UI surfaces.

## The tools

| Tool | What it answers |
|---|---|
| [UCPPlayground.com](https://ucpplayground.com/) (Agent + Playground modes) | What does an AI shopping agent see when it walks the catalog and checkout? |
| [UCPChecker.com](https://ucpchecker.com/) | Is the UCP manifest and catalog spec-conformant? |
| [UCPRegistry.com](https://ucpregistry.com/submit) (optional) | A directory of UCP-enabled stores. Submission costs nothing, but agent uptake varies. |

## Framing decision

These tools are independent of Automattic (third-party), but maintained by people active in the UCP ecosystem — UCPPlayground's creator sits on the UCP.DEV technical council. That makes them more than "random third-party validators" but stops short of "official UCP reference tools." The user-guide copy reflects that nuance:

> They're independent of Automattic and this plugin, but maintained by people active in the UCP ecosystem...

URL liability hedge included: if any link is dead, https://ucp.dev/ usually points at the current validator. Lower the cost of doc maintenance if these tools rebrand or move.

## Section renumbering

The existing section 4a ("What the homepage publishes to AI agents") becomes 4b to make room for the new "Independent validation tools" at 4a. Validation tools come first in the narrative flow because they're actionable; "what the homepage publishes" is reference/FYI material that supports the smoke-test workflow above. Inbound link from the URL-verification table at the top of section 4 updated to the new anchor.

## Test plan

- [x] `npm run build:user-guide` rebuilds the HTML
- [x] `grep -c "—" docs/user-guide/USER-GUIDE.md` → 0 (no em-dashes introduced in new content)
- [x] CHANGELOG entry under [Unreleased] / Docs ready to satisfy `changelog-required` workflow on first push
- [x] Inbound link from URL-verification table at section 4 top updated to `#4b-what-the-homepage-publishes-to-ai-agents`
- [ ] Verify the rendered HTML's `<a href="#4b-...">` anchor matches the auto-generated heading id (will check via browser-load of the rendered HTML if needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)