### PR TITLE
docs(user-guide): add 'What this plugin does not do' section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 ### Tests
 ### Docs
 
+- **User guide: new "What this plugin does not do" section.** Heads off four common merchant misconceptions before they land as disappointment: this isn't a product feed for Google Shopping / Bing / Copilot / Meta Catalog (those need merchant-center uploads, this is crawler-discovered); it isn't for in-chat agentic checkout (UCP is shopper-present handoff, not ACP-style delegated payments); it isn't an AI chatbot widget for the merchant's own site; and it doesn't write or improve product copy. Placed directly after "What this plugin does" so the boundary reads next to the positive scope — merchants forming wrong expectations don't have to scroll to §1.1 to discover the limit.
+
 ---
 
 ## [0.15.0] – 2026-05-13

--- a/docs/user-guide/USER-GUIDE.html
+++ b/docs/user-guide/USER-GUIDE.html
@@ -73,6 +73,18 @@
 </ol>
 <p>You can think of these as three doors into the same store: agents that close the sale walk through door 1, search engines that cite you walk through door 2, conversational tools that talk about you walk through door 3. You don&#39;t need to choose; the plugin opens all three.</p>
 <p>You do not need an AI account, an API key, or a developer.</p>
+<h2>What this plugin does not do</h2>
+<p>A few things this plugin is intentionally not, so you can decide if it fits your goal:</p>
+<ul>
+<li><p><strong>It is not a product feed for Google Shopping, Bing Shopping, Microsoft/Copilot Commerce, or Meta Catalog.</strong> Those platforms ingest catalogs you submit through their merchant centers (Google Merchant Center, Bing Webmaster, Meta Commerce Manager). This plugin works the opposite way: it publishes open discovery surfaces on your own site that AI agents read directly. The two are complementary, not substitutes; if you already use Google Merchant Center for Google Shopping, keep it. See §1.2 below.</p>
+</li>
+<li><p><strong>It is not for in-chat agentic checkout</strong> (sometimes called &quot;delegated payments&quot; or ACP-style flows). Protocols like Stripe ACP or Google&#39;s emerging Agentic Commerce APIs hand the agent a payment token and have it complete the transaction inside the chat surface, sometimes without the shopper present. UCP, what this plugin speaks, explicitly does the opposite: the agent hands the shopper off to your checkout, where the shopper (or, in the on-behalf-of case, the agent acting under their authorization) completes the purchase using your existing payment provider. If your business model requires headless agent purchasing without a shopper-checkout step, this plugin alone won&#39;t deliver that.</p>
+</li>
+<li><p><strong>It is not an AI chatbot for your store.</strong> There&#39;s no chat widget, no conversational UI, no &quot;ask our store assistant&quot; surface added to your site. The plugin makes your catalog legible to external AI tools (ChatGPT, Gemini, Claude, etc.); it doesn&#39;t bring an AI tool into your store.</p>
+</li>
+<li><p><strong>It does not write or improve product copy.</strong> No descriptions are generated, rewritten, or summarized. The plugin reads what you&#39;ve already authored in WooCommerce and republishes it in machine-readable formats. Better-authored products yield better AI responses, but that&#39;s an upstream merchandising task, not something the plugin does for you.</p>
+</li>
+</ul>
 <h2>Contents</h2>
 <ol>
 <li><a href="#1-before-you-start">Before you start</a></li>

--- a/docs/user-guide/USER-GUIDE.md
+++ b/docs/user-guide/USER-GUIDE.md
@@ -22,6 +22,18 @@ You can think of these as three doors into the same store: agents that close the
 
 You do not need an AI account, an API key, or a developer.
 
+## What this plugin does not do
+
+A few things this plugin is intentionally not, so you can decide if it fits your goal:
+
+- **It is not a product feed for Google Shopping, Bing Shopping, Microsoft/Copilot Commerce, or Meta Catalog.** Those platforms ingest catalogs you submit through their merchant centers (Google Merchant Center, Bing Webmaster, Meta Commerce Manager). This plugin works the opposite way: it publishes open discovery surfaces on your own site that AI agents read directly. The two are complementary, not substitutes; if you already use Google Merchant Center for Google Shopping, keep it. See §1.2 below.
+
+- **It is not for in-chat agentic checkout** (sometimes called "delegated payments" or ACP-style flows). Protocols like Stripe ACP or Google's emerging Agentic Commerce APIs hand the agent a payment token and have it complete the transaction inside the chat surface, sometimes without the shopper present. UCP, what this plugin speaks, explicitly does the opposite: the agent hands the shopper off to your checkout, where the shopper (or, in the on-behalf-of case, the agent acting under their authorization) completes the purchase using your existing payment provider. If your business model requires headless agent purchasing without a shopper-checkout step, this plugin alone won't deliver that.
+
+- **It is not an AI chatbot for your store.** There's no chat widget, no conversational UI, no "ask our store assistant" surface added to your site. The plugin makes your catalog legible to external AI tools (ChatGPT, Gemini, Claude, etc.); it doesn't bring an AI tool into your store.
+
+- **It does not write or improve product copy.** No descriptions are generated, rewritten, or summarized. The plugin reads what you've already authored in WooCommerce and republishes it in machine-readable formats. Better-authored products yield better AI responses, but that's an upstream merchandising task, not something the plugin does for you.
+
 ## Contents
 
 1. [Before you start](#1-before-you-start)


### PR DESCRIPTION
## Summary

Adds a new \"What this plugin does not do\" section to USER-GUIDE.md, placed directly after the existing \"What this plugin does\" intro. Four bullets, each heading off a common false expectation merchants form when they first install:

1. **Not a product feed for Google Shopping, Bing, Copilot, Meta Catalog.** Those need merchant-center uploads (GMC, Bing Webmaster, Meta Commerce Manager). This plugin works in the opposite direction: it publishes discovery surfaces on the merchant's own site for AI agents to read. Complementary, not a substitute. Cross-references §1.2 for the existing GMC compatibility note.

2. **Not for in-chat agentic checkout** (ACP-style delegated payments). UCP, which the plugin speaks, is explicitly shopper-present handoff: the agent hands the buyer off to the merchant's checkout, not the other way around. Reinforces the framing rewrite that shipped in 0.15.0.

3. **Not an AI chatbot widget for the merchant's own site.** No conversational UI gets added to the merchant's storefront. The plugin makes the catalog legible to external AI tools (ChatGPT, Gemini, Claude, etc.); it doesn't bring an AI tool into the store.

4. **Does not write or improve product copy.** Reads existing WooCommerce product fields verbatim. Merchandising stays an upstream authoring task.

## Why placement matters

Currently the user guide jumps from \"What this plugin does\" (positive scope) straight to the Contents and §1 (\"Before you start\"). A merchant skimming the intro doesn't encounter the scope boundary until §1.1's \"Is this plugin a fit for your store?\" check, which is store-type oriented (B2B, headless, marketplaces). The four bullets here are AI-integration-shape oriented — a different axis, and one merchants are more likely to misread first.

## Test plan

- [x] Rebuilt `USER-GUIDE.html` via `npm run build:user-guide`; output is 38,344 bytes (+2.1KB).
- [x] Em-dash free per AGENTS.md convention (verified locally; uses parens / commas / colons throughout).
- [x] Cross-reference \"§1.2 below\" still resolves: the existing GMC note lives at \"### Known compatibility notes\" under §1.
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)